### PR TITLE
docs: add lessons learned from Cube Writer project

### DIFF
--- a/docs/02-OData-API.html
+++ b/docs/02-OData-API.html
@@ -334,6 +334,37 @@ $filter=notes ne null
 </code></pre></div>
 
 <hr />
+<h2 id="common-patterns">Common Patterns</h2>
+<h3 id="active-record-filter">Active Record Filter</h3>
+<p>P21 uses <code>row_status_flag</code> to track record status. Active records have <code>row_status_flag = 704</code>:</p>
+<div class="highlight"><pre><span></span><code>$filter=row_status_flag eq 704
+</code></pre></div>
+
+<p>Always include this filter when querying for active data:</p>
+<div class="highlight"><pre><span></span><code>$filter=supplier_id eq 21274 and row_status_flag eq 704
+</code></pre></div>
+
+<h3 id="non-expired-records">Non-Expired Records</h3>
+<p>To filter out expired records, compare <code>expiration_date</code> against a date value:</p>
+<div class="highlight"><pre><span></span><code>$filter=expiration_date ge 2025-01-01
+</code></pre></div>
+
+<p><strong>Warning:</strong> The <code>now()</code> function is not supported in P21 OData. Using it will return a 404 error:</p>
+<div class="highlight"><pre><span></span><code># DOES NOT WORK - returns 404
+$filter=expiration_date ge now()
+
+# CORRECT - use explicit date
+$filter=expiration_date ge 2025-12-28
+</code></pre></div>
+
+<p>For date-relative queries, calculate the date in your application code:</p>
+<div class="highlight"><pre><span></span><code><span class="kn">from</span><span class="w"> </span><span class="nn">datetime</span><span class="w"> </span><span class="kn">import</span> <span class="n">date</span><span class="p">,</span> <span class="n">timedelta</span>
+
+<span class="n">tomorrow</span> <span class="o">=</span> <span class="p">(</span><span class="n">date</span><span class="o">.</span><span class="n">today</span><span class="p">()</span> <span class="o">+</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">days</span><span class="o">=</span><span class="mi">1</span><span class="p">))</span><span class="o">.</span><span class="n">isoformat</span><span class="p">()</span>
+<span class="n">filter_expr</span> <span class="o">=</span> <span class="sa">f</span><span class="s2">&quot;expiration_date ge </span><span class="si">{</span><span class="n">tomorrow</span><span class="si">}</span><span class="s2">&quot;</span>
+</code></pre></div>
+
+<hr />
 <h2 id="data-type-formatting">Data Type Formatting</h2>
 <table>
 <thead>
@@ -592,8 +623,8 @@ $filter=notes ne null
 </tr>
 <tr>
 <td>404 Not Found</td>
-<td>Table doesn't exist</td>
-<td>Verify table name</td>
+<td>Table doesn't exist, or unsupported function</td>
+<td>Verify table name; avoid <code>now()</code></td>
 </tr>
 <tr>
 <td>500 Server Error</td>
@@ -602,6 +633,16 @@ $filter=notes ne null
 </tr>
 </tbody>
 </table>
+<h3 id="now-function-not-supported">now() Function Not Supported</h3>
+<p>The standard OData <code>now()</code> function returns 404 in P21. Use explicit date values instead:</p>
+<div class="highlight"><pre><span></span><code><span class="c1"># Calculate date in code</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">datetime</span><span class="w"> </span><span class="kn">import</span> <span class="n">date</span><span class="p">,</span> <span class="n">timedelta</span>
+<span class="n">tomorrow</span> <span class="o">=</span> <span class="p">(</span><span class="n">date</span><span class="o">.</span><span class="n">today</span><span class="p">()</span> <span class="o">+</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">days</span><span class="o">=</span><span class="mi">1</span><span class="p">))</span><span class="o">.</span><span class="n">isoformat</span><span class="p">()</span>
+
+<span class="c1"># Use in filter</span>
+<span class="n">params</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;$filter&quot;</span><span class="p">:</span> <span class="sa">f</span><span class="s2">&quot;expiration_date ge </span><span class="si">{</span><span class="n">tomorrow</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">}</span>
+</code></pre></div>
+
 <hr />
 <h2 id="performance-tips">Performance Tips</h2>
 <ul>
@@ -638,6 +679,43 @@ $filter=notes ne null
 </tr>
 </tbody>
 </table>
+<h3 id="avoiding-n1-query-patterns">Avoiding N+1 Query Patterns</h3>
+<p>When working with related entities (e.g., pages → books → libraries), avoid fetching related data in a loop:</p>
+<div class="highlight"><pre><span></span><code><span class="c1"># BAD: N+1 queries - one query per page</span>
+<span class="k">for</span> <span class="n">page</span> <span class="ow">in</span> <span class="n">pages</span><span class="p">:</span>
+    <span class="n">book</span> <span class="o">=</span> <span class="k">await</span> <span class="n">odata</span><span class="o">.</span><span class="n">get_book_for_page</span><span class="p">(</span><span class="n">page</span><span class="p">[</span><span class="s1">&#39;uid&#39;</span><span class="p">])</span>  <span class="c1"># N queries!</span>
+    <span class="n">library</span> <span class="o">=</span> <span class="k">await</span> <span class="n">odata</span><span class="o">.</span><span class="n">get_library_for_book</span><span class="p">(</span><span class="n">book</span><span class="p">[</span><span class="s1">&#39;uid&#39;</span><span class="p">])</span>  <span class="c1"># N more!</span>
+</code></pre></div>
+
+<p><strong>Solution 1: Batch queries</strong></p>
+<p>Fetch all related data upfront with IN clauses or multiple conditions:</p>
+<div class="highlight"><pre><span></span><code><span class="c1"># Get all pages first</span>
+<span class="n">pages</span> <span class="o">=</span> <span class="k">await</span> <span class="n">odata</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="s2">&quot;price_page&quot;</span><span class="p">,</span> <span class="n">filter_expr</span><span class="o">=</span><span class="s2">&quot;supplier_id eq 21274&quot;</span><span class="p">)</span>
+<span class="n">page_uids</span> <span class="o">=</span> <span class="p">[</span><span class="n">p</span><span class="p">[</span><span class="s1">&#39;price_page_uid&#39;</span><span class="p">]</span> <span class="k">for</span> <span class="n">p</span> <span class="ow">in</span> <span class="n">pages</span><span class="p">]</span>
+
+<span class="c1"># Get all links in fewer queries</span>
+<span class="k">for</span> <span class="n">page_uid</span> <span class="ow">in</span> <span class="n">page_uids</span><span class="p">:</span>
+    <span class="n">links</span> <span class="o">=</span> <span class="k">await</span> <span class="n">odata</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="s2">&quot;price_page_x_book&quot;</span><span class="p">,</span>
+                               <span class="n">filter_expr</span><span class="o">=</span><span class="sa">f</span><span class="s2">&quot;price_page_uid eq </span><span class="si">{</span><span class="n">page_uid</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+</code></pre></div>
+
+<p><strong>Solution 2: Cache lookups</strong></p>
+<p>For repeated lookups (like library-to-book mapping), cache results:</p>
+<div class="highlight"><pre><span></span><code><span class="k">class</span><span class="w"> </span><span class="nc">P21OData</span><span class="p">:</span>
+    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">_library_book_cache</span><span class="p">:</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">dict</span> <span class="o">|</span> <span class="kc">None</span><span class="p">]</span> <span class="o">=</span> <span class="p">{}</span>
+
+    <span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="nf">get_book_for_library</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">library_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">dict</span> <span class="o">|</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="c1"># Return cached result if available</span>
+        <span class="k">if</span> <span class="n">library_id</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">_library_book_cache</span><span class="p">:</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_library_book_cache</span><span class="p">[</span><span class="n">library_id</span><span class="p">]</span>
+
+        <span class="c1"># Fetch and cache</span>
+        <span class="n">result</span> <span class="o">=</span> <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">_fetch_book_for_library</span><span class="p">(</span><span class="n">library_id</span><span class="p">)</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">_library_book_cache</span><span class="p">[</span><span class="n">library_id</span><span class="p">]</span> <span class="o">=</span> <span class="n">result</span>
+        <span class="k">return</span> <span class="n">result</span>
+</code></pre></div>
+
 <hr />
 <h2 id="related">Related</h2>
 <ul>

--- a/docs/04-Interactive-API.html
+++ b/docs/04-Interactive-API.html
@@ -491,7 +491,7 @@
         <span class="p">)</span>
 </code></pre></div>
 
-<h3 id="context-manager-usage">Context Manager Usage</h3>
+<h3 id="context-manager-usage-sync">Context Manager Usage (Sync)</h3>
 <div class="highlight"><pre><span></span><code><span class="k">class</span><span class="w"> </span><span class="nc">InteractiveClient</span><span class="p">:</span>
     <span class="c1"># ... methods above ...</span>
 
@@ -516,6 +516,91 @@
     <span class="n">window</span><span class="o">.</span><span class="n">close</span><span class="p">()</span>
 </code></pre></div>
 
+<h3 id="async-context-manager-recommended">Async Context Manager (Recommended)</h3>
+<p>For production code, use async patterns with proper cleanup:</p>
+<div class="highlight"><pre><span></span><code><span class="kn">import</span><span class="w"> </span><span class="nn">httpx</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">logging</span>
+
+<span class="n">logger</span> <span class="o">=</span> <span class="n">logging</span><span class="o">.</span><span class="n">getLogger</span><span class="p">(</span><span class="vm">__name__</span><span class="p">)</span>
+
+<span class="k">class</span><span class="w"> </span><span class="nc">P21Client</span><span class="p">:</span>
+    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">base_url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">username</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">password</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">verify_ssl</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">base_url</span> <span class="o">=</span> <span class="n">base_url</span><span class="o">.</span><span class="n">rstrip</span><span class="p">(</span><span class="s1">&#39;/&#39;</span><span class="p">)</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">username</span> <span class="o">=</span> <span class="n">username</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">password</span> <span class="o">=</span> <span class="n">password</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">verify_ssl</span> <span class="o">=</span> <span class="n">verify_ssl</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">token</span><span class="p">:</span> <span class="nb">dict</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">ui_server_url</span><span class="p">:</span> <span class="nb">str</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">_client</span><span class="p">:</span> <span class="n">httpx</span><span class="o">.</span><span class="n">AsyncClient</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span>
+
+    <span class="k">def</span><span class="w"> </span><span class="nf">_get_client</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">httpx</span><span class="o">.</span><span class="n">AsyncClient</span><span class="p">:</span>
+        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_client</span> <span class="ow">is</span> <span class="kc">None</span> <span class="ow">or</span> <span class="bp">self</span><span class="o">.</span><span class="n">_client</span><span class="o">.</span><span class="n">is_closed</span><span class="p">:</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">_client</span> <span class="o">=</span> <span class="n">httpx</span><span class="o">.</span><span class="n">AsyncClient</span><span class="p">(</span>
+                <span class="n">verify</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">verify_ssl</span><span class="p">,</span>
+                <span class="n">timeout</span><span class="o">=</span><span class="mf">60.0</span><span class="p">,</span>
+                <span class="n">follow_redirects</span><span class="o">=</span><span class="kc">True</span>
+            <span class="p">)</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_client</span>
+
+    <span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="nf">authenticate</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">dict</span><span class="p">:</span>
+        <span class="n">url</span> <span class="o">=</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">base_url</span><span class="si">}</span><span class="s2">/api/security/token&quot;</span>
+        <span class="n">headers</span> <span class="o">=</span> <span class="p">{</span>
+            <span class="s2">&quot;Content-Type&quot;</span><span class="p">:</span> <span class="s2">&quot;application/json&quot;</span><span class="p">,</span>
+            <span class="s2">&quot;Accept&quot;</span><span class="p">:</span> <span class="s2">&quot;application/json&quot;</span><span class="p">,</span>
+            <span class="s2">&quot;username&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">username</span><span class="p">,</span>
+            <span class="s2">&quot;password&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">password</span>
+        <span class="p">}</span>
+        <span class="n">client</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_client</span><span class="p">()</span>
+        <span class="n">response</span> <span class="o">=</span> <span class="k">await</span> <span class="n">client</span><span class="o">.</span><span class="n">post</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span> <span class="n">content</span><span class="o">=</span><span class="s2">&quot;&quot;</span><span class="p">)</span>
+        <span class="n">response</span><span class="o">.</span><span class="n">raise_for_status</span><span class="p">()</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">token</span> <span class="o">=</span> <span class="n">response</span><span class="o">.</span><span class="n">json</span><span class="p">()</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">token</span>
+
+    <span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="nf">start_session</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">token</span><span class="p">:</span>
+            <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">authenticate</span><span class="p">()</span>
+        <span class="c1"># ... get ui_server_url and start session ...</span>
+
+    <span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="nf">end_session</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="c1"># ... end session ...</span>
+        <span class="k">pass</span>
+
+    <span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="nf">close</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_client</span> <span class="ow">and</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">_client</span><span class="o">.</span><span class="n">is_closed</span><span class="p">:</span>
+            <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">_client</span><span class="o">.</span><span class="n">aclose</span><span class="p">()</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">_client</span> <span class="o">=</span> <span class="kc">None</span>
+
+    <span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="fm">__aenter__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+<span class="w">        </span><span class="sd">&quot;&quot;&quot;Async context manager entry - authenticate and start session.&quot;&quot;&quot;</span>
+        <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">authenticate</span><span class="p">()</span>
+        <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">start_session</span><span class="p">()</span>
+        <span class="k">return</span> <span class="bp">self</span>
+
+    <span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="fm">__aexit__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">exc_type</span><span class="p">,</span> <span class="n">exc_val</span><span class="p">,</span> <span class="n">exc_tb</span><span class="p">):</span>
+<span class="w">        </span><span class="sd">&quot;&quot;&quot;Async context manager exit - end session and close client.&quot;&quot;&quot;</span>
+        <span class="k">try</span><span class="p">:</span>
+            <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">end_session</span><span class="p">()</span>
+        <span class="k">except</span> <span class="ne">Exception</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">debug</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Session cleanup error (ignored): </span><span class="si">{</span><span class="n">e</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+        <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">close</span><span class="p">()</span>
+        <span class="k">return</span> <span class="kc">False</span>
+
+<span class="c1"># Usage</span>
+<span class="k">async</span> <span class="k">with</span> <span class="n">P21Client</span><span class="p">(</span><span class="n">base_url</span><span class="p">,</span> <span class="n">username</span><span class="p">,</span> <span class="n">password</span><span class="p">)</span> <span class="k">as</span> <span class="n">client</span><span class="p">:</span>
+    <span class="n">window</span> <span class="o">=</span> <span class="k">await</span> <span class="n">client</span><span class="o">.</span><span class="n">open_window</span><span class="p">(</span><span class="n">service_name</span><span class="o">=</span><span class="s2">&quot;SalesPricePage&quot;</span><span class="p">)</span>
+    <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;description&quot;</span><span class="p">,</span> <span class="s2">&quot;New Value&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+    <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">save_data</span><span class="p">()</span>
+    <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">close</span><span class="p">()</span>
+</code></pre></div>
+
+<p><strong>Key points for async usage:</strong></p>
+<ol>
+<li>Use <code>httpx.AsyncClient</code> instead of sync <code>httpx</code></li>
+<li>Implement <code>__aenter__</code> and <code>__aexit__</code> for async context manager</li>
+<li>Always close the HTTP client in <code>__aexit__</code></li>
+<li>Ignore cleanup errors - session may have timed out</li>
+<li>Use <code>async with</code> syntax for guaranteed cleanup</li>
+</ol>
 <hr />
 <h2 id="working-example-scripts">Working Example Scripts</h2>
 <p>See the <code>scripts/interactive/</code> directory:</p>
@@ -590,6 +675,11 @@
 <td>Price pages</td>
 </tr>
 <tr>
+<td>Sales Price Book Entry</td>
+<td>SalesPriceBook</td>
+<td>Price book maintenance</td>
+</tr>
+<tr>
 <td>Purchase Order Entry</td>
 <td>PurchaseOrder</td>
 <td>Purchase orders</td>
@@ -601,6 +691,78 @@
 </tr>
 </tbody>
 </table>
+<hr />
+<h2 id="example-linking-price-page-to-price-book">Example: Linking Price Page to Price Book</h2>
+<p>This example shows how to use the SalesPriceBook window to link a price page to a price book. This is a common operation after creating a new price page.</p>
+<div class="highlight"><pre><span></span><code><span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="nf">link_page_to_book</span><span class="p">(</span>
+    <span class="n">client</span><span class="p">:</span> <span class="n">P21Client</span><span class="p">,</span>
+    <span class="n">price_page_uid</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
+    <span class="n">price_book_id</span><span class="p">:</span> <span class="nb">str</span>
+<span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+<span class="w">    </span><span class="sd">&quot;&quot;&quot;Link a price page to a price book via SalesPriceBook window.</span>
+
+<span class="sd">    Args:</span>
+<span class="sd">        client: Authenticated P21Client with active session</span>
+<span class="sd">        price_page_uid: The price page UID to link</span>
+<span class="sd">        price_book_id: The price book ID (e.g., &quot;P2 IND_OEM_HUGE&quot;)</span>
+
+<span class="sd">    Returns:</span>
+<span class="sd">        True if successful</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+    <span class="c1"># Open the SalesPriceBook window</span>
+    <span class="n">window</span> <span class="o">=</span> <span class="k">await</span> <span class="n">client</span><span class="o">.</span><span class="n">open_window</span><span class="p">(</span><span class="n">service_name</span><span class="o">=</span><span class="s1">&#39;SalesPriceBook&#39;</span><span class="p">)</span>
+
+    <span class="k">try</span><span class="p">:</span>
+        <span class="c1"># Step 1: Retrieve the book by ID on FORM tab</span>
+        <span class="n">result</span> <span class="o">=</span> <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span>
+            <span class="s1">&#39;FORM&#39;</span><span class="p">,</span> <span class="s1">&#39;price_book_id&#39;</span><span class="p">,</span> <span class="n">price_book_id</span><span class="p">,</span>
+            <span class="n">datawindow_name</span><span class="o">=</span><span class="s1">&#39;form&#39;</span>
+        <span class="p">)</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="n">result</span><span class="o">.</span><span class="n">success</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Failed to retrieve book </span><span class="si">{</span><span class="n">price_book_id</span><span class="si">}</span><span class="s2">: </span><span class="si">{</span><span class="n">result</span><span class="o">.</span><span class="n">messages</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
+        <span class="c1"># Step 2: Switch to LIST tab</span>
+        <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">select_tab</span><span class="p">(</span><span class="s1">&#39;LIST&#39;</span><span class="p">)</span>
+
+        <span class="c1"># Step 3: Add a new row to the list_detail datawindow</span>
+        <span class="n">result</span> <span class="o">=</span> <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">add_row</span><span class="p">(</span><span class="s1">&#39;list_detail&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="n">result</span><span class="o">.</span><span class="n">success</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Failed to add row: </span><span class="si">{</span><span class="n">result</span><span class="o">.</span><span class="n">messages</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
+        <span class="c1"># Step 4: Set the price_page_uid on the new row</span>
+        <span class="n">result</span> <span class="o">=</span> <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span>
+            <span class="s1">&#39;LIST&#39;</span><span class="p">,</span> <span class="s1">&#39;price_page_uid&#39;</span><span class="p">,</span> <span class="nb">str</span><span class="p">(</span><span class="n">price_page_uid</span><span class="p">),</span>
+            <span class="n">datawindow_name</span><span class="o">=</span><span class="s1">&#39;list_detail&#39;</span>
+        <span class="p">)</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="n">result</span><span class="o">.</span><span class="n">success</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Failed to set price_page_uid: </span><span class="si">{</span><span class="n">result</span><span class="o">.</span><span class="n">messages</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
+        <span class="c1"># Step 5: Save the changes</span>
+        <span class="n">result</span> <span class="o">=</span> <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">save_data</span><span class="p">()</span>
+
+        <span class="k">if</span> <span class="n">result</span><span class="o">.</span><span class="n">success</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Linked page </span><span class="si">{</span><span class="n">price_page_uid</span><span class="si">}</span><span class="s2"> to book </span><span class="si">{</span><span class="n">price_book_id</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+            <span class="k">return</span> <span class="kc">True</span>
+        <span class="k">else</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Failed to save: </span><span class="si">{</span><span class="n">result</span><span class="o">.</span><span class="n">messages</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
+    <span class="k">finally</span><span class="p">:</span>
+        <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">close</span><span class="p">()</span>
+</code></pre></div>
+
+<p><strong>Key points:</strong></p>
+<ol>
+<li>Open window by <code>ServiceName</code>, not title</li>
+<li>Retrieve the book first - this loads it into the window</li>
+<li>Switch to LIST tab before adding/modifying rows</li>
+<li>Use <code>add_row('list_detail')</code> to add a new link row</li>
+<li>Set <code>price_page_uid</code> as a string value</li>
+<li>Always close the window in a <code>finally</code> block</li>
+</ol>
 <hr />
 <h2 id="best-practices">Best Practices</h2>
 <ol>

--- a/docs/08-SalesPricePage-Codes.html
+++ b/docs/08-SalesPricePage-Codes.html
@@ -164,6 +164,70 @@
 <h2 id="overview">Overview</h2>
 <p>When working with the SalesPricePage window via the Interactive API, dropdown fields require specific <strong>display values</strong> (not codes). This document provides the mappings discovered through API testing.</p>
 <p><strong>Important:</strong> P21's code tables (<code>code_p21</code>) may not be accessible via OData in all environments. These values were discovered by testing the Interactive API directly.</p>
+<p><strong>Note:</strong> Code mappings may vary between P21 versions and configurations. Always verify codes in your specific environment.</p>
+<hr />
+<h2 id="field-order-requirements">Field Order Requirements</h2>
+<p>When creating or modifying price pages, fields must be set in a specific order. Setting fields out of order can cause validation failures or incorrect data.</p>
+<h3 id="required-field-order-for-page-creation">Required Field Order for Page Creation</h3>
+<ol>
+<li><strong><code>price_page_type_cd</code></strong> - Set page type FIRST (e.g., "Supplier / Product Group")</li>
+<li><strong><code>company_id</code></strong> - Required BEFORE product_group_id</li>
+<li><strong><code>product_group_id</code></strong> or <strong><code>discount_group_id</code></strong> - Depends on page type</li>
+<li><strong><code>supplier_id</code></strong></li>
+<li><strong><code>description</code></strong></li>
+<li><strong><code>pricing_method_cd</code></strong> - Use display value "Source"</li>
+<li><strong><code>source_price_cd</code></strong> - Use display value "Supplier List Price"</li>
+<li><strong><code>effective_date</code></strong> / <strong><code>expiration_date</code></strong></li>
+<li>Switch to <strong>VALUES</strong> tab</li>
+<li><strong><code>calculation_method_cd</code></strong> - Use display value "Multiplier"</li>
+<li><strong><code>calculation_value1</code></strong> (and additional break values if needed)</li>
+</ol>
+<h3 id="example-creating-a-price-page">Example: Creating a Price Page</h3>
+<div class="highlight"><pre><span></span><code><span class="c1"># Step 1: Set page type FIRST - this determines available fields</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;price_page_type_cd&quot;</span><span class="p">,</span>
+                         <span class="s2">&quot;Supplier / Product Group&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 2: Set company_id BEFORE product_group_id</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;company_id&quot;</span><span class="p">,</span> <span class="s2">&quot;IFPG&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 3: Set product group</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;product_group_id&quot;</span><span class="p">,</span> <span class="s2">&quot;FA5&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 4: Set supplier</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;supplier_id&quot;</span><span class="p">,</span> <span class="s2">&quot;21274&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 5: Set description</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;description&quot;</span><span class="p">,</span> <span class="s2">&quot;P2-L5-21274-FA5-IND_OEMA&quot;</span><span class="p">,</span>
+                         <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 6-7: Set pricing method and source</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;pricing_method_cd&quot;</span><span class="p">,</span> <span class="s2">&quot;Source&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;source_price_cd&quot;</span><span class="p">,</span> <span class="s2">&quot;Supplier List Price&quot;</span><span class="p">,</span>
+                         <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 8: Set dates</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;effective_date&quot;</span><span class="p">,</span> <span class="s2">&quot;2025-01-01&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span> <span class="s2">&quot;expiration_date&quot;</span><span class="p">,</span> <span class="s2">&quot;2030-12-31&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;form&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 9: Switch to VALUES tab</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">select_tab</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">)</span>
+
+<span class="c1"># Step 10-11: Set calculation method and value</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;calculation_method_cd&quot;</span><span class="p">,</span> <span class="s2">&quot;Multiplier&quot;</span><span class="p">,</span>
+                         <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;calculation_value1&quot;</span><span class="p">,</span> <span class="s2">&quot;0.85&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+
+<span class="c1"># Save</span>
+<span class="n">result</span> <span class="o">=</span> <span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">save_data</span><span class="p">()</span>
+</code></pre></div>
+
+<h3 id="why-order-matters">Why Order Matters</h3>
+<ul>
+<li>Setting <code>product_group_id</code> before <code>price_page_type_cd</code> will fail validation</li>
+<li>Setting <code>product_group_id</code> before <code>company_id</code> may cause lookup errors</li>
+<li>The VALUES tab fields are only available after FORM tab fields are set</li>
+<li>Some fields become read-only after others are set</li>
+</ul>
 <hr />
 <h2 id="calculation-method-values-tab">Calculation Method (VALUES Tab)</h2>
 <p>The <code>calculation_method_cd</code> field on the VALUES tab controls how pricing calculations are applied.</p>
@@ -253,18 +317,19 @@
 <tbody>
 <tr>
 <td>220</td>
-<td>Source</td>
+<td>Value</td>
 </tr>
 <tr>
 <td>221</td>
-<td>Margin</td>
+<td>Source</td>
 </tr>
 <tr>
 <td>222</td>
-<td>Fixed</td>
+<td>Order</td>
 </tr>
 </tbody>
 </table>
+<p><strong>Note:</strong> Some P21 environments may show different display values (e.g., "Margin", "Fixed"). The codes above were verified in a working implementation. Always test in your environment.</p>
 <hr />
 <h2 id="source-price-form-tab">Source Price (FORM Tab)</h2>
 <p>The <code>source_price_cd</code> field determines the base price source.</p>
@@ -366,6 +431,83 @@
 <span class="c1"># Extract calculation_method_cd from state[&#39;Data&#39;]</span>
 </code></pre></div>
 
+<hr />
+<h2 id="price-breaks-quantity-based-pricing">Price Breaks (Quantity-Based Pricing)</h2>
+<p>Price pages support up to 15 calculation values and 14 break quantities for quantity-based pricing.</p>
+<h3 id="fields">Fields</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>calculation_value1</code></td>
+<td>Base price (applies to quantity 1+)</td>
+</tr>
+<tr>
+<td><code>calculation_value2</code> - <code>calculation_value15</code></td>
+<td>Applied at corresponding break quantity</td>
+</tr>
+<tr>
+<td><code>break1</code> - <code>break14</code></td>
+<td>Quantity thresholds for each price level</td>
+</tr>
+</tbody>
+</table>
+<h3 id="example-setting-up-price-breaks">Example: Setting Up Price Breaks</h3>
+<div class="highlight"><pre><span></span><code><span class="c1"># Base multiplier: 0.85 for qty 1+</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;calculation_value1&quot;</span><span class="p">,</span> <span class="s2">&quot;0.85&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+
+<span class="c1"># Price break at qty 6: 0.82 multiplier</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;break1&quot;</span><span class="p">,</span> <span class="s2">&quot;6&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;calculation_value2&quot;</span><span class="p">,</span> <span class="s2">&quot;0.82&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+
+<span class="c1"># Price break at qty 25: 0.78 multiplier</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;break2&quot;</span><span class="p">,</span> <span class="s2">&quot;25&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;calculation_value3&quot;</span><span class="p">,</span> <span class="s2">&quot;0.78&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+
+<span class="c1"># Price break at qty 100: 0.75 multiplier</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;break3&quot;</span><span class="p">,</span> <span class="s2">&quot;100&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+<span class="k">await</span> <span class="n">window</span><span class="o">.</span><span class="n">change_data</span><span class="p">(</span><span class="s2">&quot;VALUES&quot;</span><span class="p">,</span> <span class="s2">&quot;calculation_value4&quot;</span><span class="p">,</span> <span class="s2">&quot;0.75&quot;</span><span class="p">,</span> <span class="n">datawindow_name</span><span class="o">=</span><span class="s2">&quot;values&quot;</span><span class="p">)</span>
+</code></pre></div>
+
+<h3 id="mapping">Mapping</h3>
+<table>
+<thead>
+<tr>
+<th>Quantity Range</th>
+<th>Calculation Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1 to (break1-1)</td>
+<td><code>calculation_value1</code></td>
+</tr>
+<tr>
+<td>break1 to (break2-1)</td>
+<td><code>calculation_value2</code></td>
+</tr>
+<tr>
+<td>break2 to (break3-1)</td>
+<td><code>calculation_value3</code></td>
+</tr>
+<tr>
+<td>...</td>
+<td>...</td>
+</tr>
+</tbody>
+</table>
+<h3 id="notes">Notes</h3>
+<ul>
+<li><code>calculation_value1</code> is always the base price (qty 1+)</li>
+<li><code>break1</code> corresponds to <code>calculation_value2</code> (not <code>calculation_value1</code>)</li>
+<li>Unused break/value fields should be 0 or null</li>
+<li>Maximum 14 break points (15 price levels including base)</li>
+</ul>
 <hr />
 <h2 id="related">Related</h2>
 <ul>


### PR DESCRIPTION
## Summary

This PR adds documentation lessons learned from the Cube Writer (P21 Price Page Manager) project. These are real-world discoveries from a production implementation using P21's OData and Interactive APIs.

### OData API Updates
- **Common Patterns section**: Added `row_status_flag eq 704` pattern for active records
- **now() function warning**: Documented that P21 OData returns 404 for `now()` - must use explicit dates
- **N+1 query patterns**: Added performance warning and caching strategies

### Interactive API Updates
- **Async context manager pattern**: Added recommended async/await example for production code
- **SalesPriceBook window**: Added to Common Windows table and included complete example for linking price pages to books

### SalesPricePage Codes Updates
- **Field Order Requirements**: Documented critical field order with complete example
- **Pricing Method codes**: Updated to match verified working implementation (220=Value, 221=Source, 222=Order)
- **Price Breaks**: Added section explaining quantity-based pricing with break1-14 and calculation_value1-15

## Issues Fixed
| Issue | Description |
|-------|-------------|
| #2 | OData now() function not supported |
| #3 | row_status_flag pattern for active records |
| #4 | SalesPriceBook window documentation |
| #5 | Interactive API field order requirements |
| #6 | Correct pricing method codes |
| #7 | N+1 query pattern warning and caching |

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify HTML files render correctly in browser
- [ ] Review code examples for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)