### PR TITLE
fix(docs): correct report-service discovery, tools error code, router 307 note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ scripts/session_pool_results.json
 # Scraped data
 scraped/
 
+# Local reference clones (third-party repos, never commit)
+reference/
+
 # Misc local files
 *.png

--- a/docs/00-Authentication.md
+++ b/docs/00-Authentication.md
@@ -764,6 +764,8 @@ Accept: application/json
 }
 ```
 
+> **307 redirect gotcha:** On some installations, `GET /api/ui/router/v1?urlType=external` (no trailing slash after `v1`) responds with a **307 redirect** to the trailing-slash form. HTTP clients that do not follow redirects by default — including `httpx` — receive the 307 and an HTML body instead of the JSON response. Either request `/api/ui/router/v1/?urlType=external` (trailing slash) directly, or enable redirect following (`httpx.get(..., follow_redirects=True)`). C# `HttpClient` follows GET redirects by default and is unaffected. Verified live on a 25.2 system (July 2026).
+
 <!-- tabs -->
 
 **Python:**
@@ -772,8 +774,9 @@ Accept: application/json
 def get_ui_server_url(base_url: str, token: str) -> str:
     """Get UI server URL for Interactive/Transaction APIs."""
     response = httpx.get(
-        f"{base_url}/api/ui/router/v1?urlType=external",
-        headers=get_auth_headers(token)
+        f"{base_url}/api/ui/router/v1/?urlType=external",  # trailing slash avoids a 307
+        headers=get_auth_headers(token),
+        follow_redirects=True,
     )
     response.raise_for_status()
     return response.json()["Url"].rstrip("/")

--- a/docs/03-Transaction-API.md
+++ b/docs/03-Transaction-API.md
@@ -37,7 +37,7 @@ Then use the returned URL as base:
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/v2/services` | GET | List available services (optional `?type=` filter) |
+| `/api/v2/services` | GET | List available services (transaction business objects only — report services are not listed; see [PDF Report Generation](#pdf-report-generation)) |
 | `/api/v2/definition/{name}` | GET | Get service schema and template |
 | `/api/v2/defaults/{name}` | GET | Get default values for a service |
 | `/api/v2/transaction/get` | POST | Retrieve existing records |
@@ -1335,7 +1335,17 @@ The Transaction API includes a dedicated endpoint for generating PDF documents -
 | `m_reprintpurchaseorders` | Purchase Order reprints |
 | `m_reprintpicktickets` | Pick Ticket reprints |
 
-> **Discovery:** Use `GET /api/v2/services?type=report` to list available report services. Use `GET /api/v2/definition/{service_name}` to inspect the DataElement structure and field names for each report.
+> **Discovery:** The `m_*` report services are **hidden from `GET /api/v2/services`** — that endpoint lists only the transaction business objects (299 on a 25.2 test system), and `?type=report` returns an empty list (verified live; `?type=window` returns the same transaction list, other `?type=` values return HTTP 400 `"Service Type is invalid."`). The report services are still fully callable: `GET /api/v2/definition/{service_name}` and `GET /api/v2/defaults/{service_name}` both work for them. To discover callable report names, probe the definition endpoint directly, or pull candidate names from the `window_x_menu` table — the callable service name is the last `/`-segment of `menu_name`:
+>
+> ```sql
+> SELECT DISTINCT RIGHT(menu_name, CHARINDEX('/', REVERSE(menu_name) + '/') - 1) AS callable_name
+> FROM window_x_menu
+> WHERE menu_name LIKE 'm[_]%';
+> ```
+>
+> Probe each candidate with `GET /api/v2/definition/{name}` — the ones that return 200 are callable. On a 25.2 test system this yields ~157 callable report services, including `m_picktickets`, `m_reprintpicktickets`, `m_productionorders`, `m_orderacknowledgements`, `m_invoices`, `m_packinglists`, and `m_customerstatements`.
+>
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) identified that report services are hidden from the services list and worked out the `window_x_menu` discovery path.
 
 ### Request Structure
 

--- a/docs/04-Interactive-API.md
+++ b/docs/04-Interactive-API.md
@@ -75,9 +75,9 @@ Then use the returned URL as base:
 > |----------|:-:|:-:|
 > | GET/DELETE `/v2/window` | **Yes** | No (422) |
 > | GET/DELETE `/v2/data` | **Yes** | No (400/422) |
-> | GET `/v2/tools` | No (500) | **Yes** |
+> | GET `/v2/tools` | No (400) | **Yes** |
 >
-> Using the wrong parameter returns an error — there is no fallback.
+> Using the wrong parameter returns an error — there is no fallback. `GET /v2/tools?id=` fails with HTTP 400 and a validation body (`"The windowId field is required."`).
 
 ### Data Operations (v1 - Legacy)
 

--- a/docs/html/00-Authentication.html
+++ b/docs/html/00-Authentication.html
@@ -1311,6 +1311,9 @@
 <span class="p">}</span>
 </code></pre></div>
 
+<blockquote>
+<p><strong>307 redirect gotcha:</strong> On some installations, <code>GET /api/ui/router/v1?urlType=external</code> (no trailing slash after <code>v1</code>) responds with a <strong>307 redirect</strong> to the trailing-slash form. HTTP clients that do not follow redirects by default — including <code>httpx</code> — receive the 307 and an HTML body instead of the JSON response. Either request <code>/api/ui/router/v1/?urlType=external</code> (trailing slash) directly, or enable redirect following (<code>httpx.get(..., follow_redirects=True)</code>). C# <code>HttpClient</code> follows GET redirects by default and is unaffected. Verified live on a 25.2 system (July 2026).</p>
+</blockquote>
 <div class="code-tabs">
   <div class="tab-buttons">
     <button class="tab-btn active" data-lang="python">Python</button>
@@ -1320,8 +1323,9 @@
 <div class="highlight"><pre><span></span><code><span class="k">def</span><span class="w"> </span><span class="nf">get_ui_server_url</span><span class="p">(</span><span class="n">base_url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">token</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
 <span class="w">    </span><span class="sd">&quot;&quot;&quot;Get UI server URL for Interactive/Transaction APIs.&quot;&quot;&quot;</span>
     <span class="n">response</span> <span class="o">=</span> <span class="n">httpx</span><span class="o">.</span><span class="n">get</span><span class="p">(</span>
-        <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">base_url</span><span class="si">}</span><span class="s2">/api/ui/router/v1?urlType=external&quot;</span><span class="p">,</span>
-        <span class="n">headers</span><span class="o">=</span><span class="n">get_auth_headers</span><span class="p">(</span><span class="n">token</span><span class="p">)</span>
+        <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">base_url</span><span class="si">}</span><span class="s2">/api/ui/router/v1/?urlType=external&quot;</span><span class="p">,</span>  <span class="c1"># trailing slash avoids a 307</span>
+        <span class="n">headers</span><span class="o">=</span><span class="n">get_auth_headers</span><span class="p">(</span><span class="n">token</span><span class="p">),</span>
+        <span class="n">follow_redirects</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
     <span class="p">)</span>
     <span class="n">response</span><span class="o">.</span><span class="n">raise_for_status</span><span class="p">()</span>
     <span class="k">return</span> <span class="n">response</span><span class="o">.</span><span class="n">json</span><span class="p">()[</span><span class="s2">&quot;Url&quot;</span><span class="p">]</span><span class="o">.</span><span class="n">rstrip</span><span class="p">(</span><span class="s2">&quot;/&quot;</span><span class="p">)</span>

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -514,7 +514,7 @@
 <tr>
 <td><code>/api/v2/services</code></td>
 <td>GET</td>
-<td>List available services (optional <code>?type=</code> filter)</td>
+<td>List available services (transaction business objects only — report services are not listed; see <a href="#pdf-report-generation">PDF Report Generation</a>)</td>
 </tr>
 <tr>
 <td><code>/api/v2/definition/{name}</code></td>
@@ -2394,7 +2394,13 @@ The <code>target_date</code> edit must appear before <code>start_date</code> in 
 </tbody>
 </table>
 <blockquote>
-<p><strong>Discovery:</strong> Use <code>GET /api/v2/services?type=report</code> to list available report services. Use <code>GET /api/v2/definition/{service_name}</code> to inspect the DataElement structure and field names for each report.</p>
+<p><strong>Discovery:</strong> The <code>m_*</code> report services are <strong>hidden from <code>GET /api/v2/services</code></strong> — that endpoint lists only the transaction business objects (299 on a 25.2 test system), and <code>?type=report</code> returns an empty list (verified live; <code>?type=window</code> returns the same transaction list, other <code>?type=</code> values return HTTP 400 <code>"Service Type is invalid."</code>). The report services are still fully callable: <code>GET /api/v2/definition/{service_name}</code> and <code>GET /api/v2/defaults/{service_name}</code> both work for them. To discover callable report names, probe the definition endpoint directly, or pull candidate names from the <code>window_x_menu</code> table — the callable service name is the last <code>/</code>-segment of <code>menu_name</code>:</p>
+<p><code>sql
+SELECT DISTINCT RIGHT(menu_name, CHARINDEX('/', REVERSE(menu_name) + '/') - 1) AS callable_name
+FROM window_x_menu
+WHERE menu_name LIKE 'm[_]%';</code></p>
+<p>Probe each candidate with <code>GET /api/v2/definition/{name}</code> — the ones that return 200 are callable. On a 25.2 test system this yields ~157 callable report services, including <code>m_picktickets</code>, <code>m_reprintpicktickets</code>, <code>m_productionorders</code>, <code>m_orderacknowledgements</code>, <code>m_invoices</code>, <code>m_packinglists</code>, and <code>m_customerstatements</code>.</p>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> identified that report services are hidden from the services list and worked out the <code>window_x_menu</code> discovery path.</p>
 </blockquote>
 <h3 id="request-structure_1">Request Structure</h3>
 <p>The payload follows the standard TransactionSet format. Report-specific criteria go in the DataElement's <code>Edits</code> array:</p>

--- a/docs/html/04-Interactive-API.html
+++ b/docs/html/04-Interactive-API.html
@@ -668,12 +668,12 @@
 </tr>
 <tr>
 <td>GET <code>/v2/tools</code></td>
-<td style="text-align: center;">No (500)</td>
+<td style="text-align: center;">No (400)</td>
 <td style="text-align: center;"><strong>Yes</strong></td>
 </tr>
 </tbody>
 </table>
-<p>Using the wrong parameter returns an error — there is no fallback.</p>
+<p>Using the wrong parameter returns an error — there is no fallback. <code>GET /v2/tools?id=</code> fails with HTTP 400 and a validation body (<code>"The windowId field is required."</code>).</p>
 </blockquote>
 <h3 id="data-operations-v1-legacy">Data Operations (v1 - Legacy)</h3>
 <table>


### PR DESCRIPTION
## Summary
Cross-checked our docs against community findings (credit: [Alex Westemeier](https://github.com/AWestemeier)) and live-verified the disputed points against a 25.2 play environment (2026-07-10). Two of our claims were wrong; one gotcha was missing.

- **03-Transaction-API**: `GET /api/v2/services?type=report` does NOT list report services — it returns an empty list. `m_*` services are hidden from `/api/v2/services` entirely (exactly 299 transaction objects, zero `m_*`) but stay fully callable via `definition`/`defaults`/`pdfreport`. Documented the definition-probe and `window_x_menu` discovery paths instead.
- **04-Interactive-API**: `GET /v2/tools?id=` returns HTTP **400** (validation: "The windowId field is required."), not 500 as the endpoint-inconsistency table claimed.
- **00-Authentication**: the router endpoint without a trailing slash can respond **307**; clients that don't follow redirects (httpx default) break. Added a note and hardened the Python example.
- Ignore `reference/` (local third-party repo clones used for cross-checking).

## Verification
All three points verified live today with throwaway scripts (services list count/contents, `?type=` variants, tools param error codes, `m_*` definition/defaults 200s, router 307).

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE