### PR TITLE
docs: Transaction API keyed updates/upserts; JobContractPricing verified patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,8 @@ window.ChangeData("Criteria", "tp_1_dw_1", "po_criteria_id", "20");
 
 **Updates**: `Status: "Existing"` is *unused*, not a write ban. For JobContractPricing the verified update path is `Status: "New"` with FORM key fields (`company_id`, `contract_no`, `job_no`, `end_date`) in `Edits` and List `Keys` identifying the row by `item_id` — see [JobContractPricing > Updating an Existing Contract](docs/03-Transaction-API.md#updating-an-existing-contract) (Fixes #44, May 2026). Other services (Assembly, SalesPricePage, TimeEntry) are untested but likely follow the same pattern; the Interactive API remains a fallback.
 
+**Upserts (July 2026)**: keyed `Status: "New"` List rows are an upsert — update when the key matches, **insert a new row when it doesn't** (verified: 81 new JobContractPricing lines in one run, DB-confirmed; credit Alex Westemeier). Gotchas: order `pricing_method` before `price` in Edits (cascade silently zeroes the price); one transaction per POST when inserts re-save a shared FORM header (optimistic-concurrency collisions + duplicate `line_no`); header saves validate `end_date` ≥ today. `IgnoreDisabled: true` (payload top level ONLY — silently ignored inside a Transaction object) unlocks disabled columns and tabs, e.g. contract BINS quantities and JOBPRICECOST commission fields.
+
 ---
 
 *Last updated: 2026-07-06*

--- a/docs/01-API-Selection-Guide.md
+++ b/docs/01-API-Selection-Guide.md
@@ -16,7 +16,8 @@ Prophet 21 provides four different APIs for external data access and manipulatio
 | Bulk create records | **Transaction API** | Stateless, supports batching |
 | Complex business workflows | **Interactive API** | Full business logic, validation |
 | Simple CRUD (customers, vendors, contacts, addresses) | **Entity API** | Stateless, domain objects |
-| Update existing records | **Interactive API** | Reliable field-level updates |
+| Update existing records (keyed fields) | **Transaction API** | `Status: "New"` + keyed rows updates and upserts (verified) |
+| Update records behind dialogs/prompts | **Interactive API** | Only API that can answer response windows |
 | Handle response dialogs | **Interactive API** | Only API with dialog handling |
 | Record labor hours to production orders | **Transaction API** | TimeEntry service, stateless |
 | Bulk create production orders | **Transaction API** | Stateless, high-volume creation |
@@ -30,7 +31,7 @@ Prophet 21 provides four different APIs for external data access and manipulatio
 |---------|-------|-------------|-------------|--------|
 | **Read Data** | Excellent | Limited | Good | Good (4 entities) |
 | **Create Data** | No | Excellent | Good | Good (4 entities) |
-| **Update Data** | No | Limited* | Excellent | Good (4 entities) |
+| **Update Data** | No | Good* | Excellent | Good (4 entities) |
 | **Delete Data** | No | No | Via UI | Via flag |
 | **Bulk Operations** | Yes (read) | Yes | No | No |
 | **Business Logic** | No | Partial | Full | No |
@@ -38,7 +39,7 @@ Prophet 21 provides four different APIs for external data access and manipulatio
 | **Stateful** | No | No | Yes | No |
 | **Response Dialogs** | N/A | N/A | Yes | N/A |
 
-*Transaction API updates have known issues - see [Session Pool Troubleshooting](07-Session-Pool-Troubleshooting.md)
+*Transaction API updates use `Status: "New"` with keyed rows (there is no working "Existing" status — it returns HTTP 500). Keyed rows behave as an **upsert**: update if the key matches, insert if it doesn't. Verified at scale (170+ line updates, 80+ line inserts on JobContractPricing). See [Updating an Existing Contract](03-Transaction-API.md#updating-an-existing-contract). Flows that pop validation dialogs still need the Interactive API.
 
 ---
 
@@ -90,22 +91,24 @@ Prophet 21 provides four different APIs for external data access and manipulatio
 - **Bulk operations** - multiple records per request
 - **Metadata-driven** - follows P21 window schemas
 - **Fast** - 50-100x faster than Interactive API for creates
-- **Limited updates** - update operations have known issues
+- **Updates via `Status: "New"` + keys** - keyed rows upsert (update if the key matches, insert if not); the `"Existing"` status is broken (HTTP 500)
 
 ### Use When
 - Creating many records at once
+- Updating or inserting keyed fields/rows on existing records
 - Building integrations from external systems
-- Performance is critical for creation
+- Performance is critical
 - You don't need complex validation feedback
 
 ### Don't Use When
-- Updating existing records (use Interactive API)
-- You need to handle response dialogs
+- The operation pops validation dialogs / response windows (use Interactive API)
+- A sub-tab stays disabled until a parent row is selected and `IgnoreDisabled` doesn't unlock it (use Interactive API)
 - You need field-by-field validation feedback
 
 ### Known Issues
 - **Session Pool Contamination** - intermittent failures with some windows
-- **Update operations** - may fail with NullReferenceException
+- **`Status: "Existing"` is broken** - returns HTTP 500 NullReferenceException platform-wide; use `Status: "New"` for updates (see [Transaction API](03-Transaction-API.md#updating-an-existing-contract))
+- **Prompts are auto-answered with the default** - a DynaChange or validation prompt kills the affected line/record silently
 - See [Session Pool Troubleshooting](07-Session-Pool-Troubleshooting.md)
 
 ### Example Use Cases
@@ -134,9 +137,9 @@ Prophet 21 provides four different APIs for external data access and manipulatio
 - **Reliable updates** - field-level control
 
 ### Use When
-- Updating existing records
+- Operations may trigger dialogs (email, confirmations) that must be answered
+- Updating records where the Transaction API path hits disabled tabs or prompts
 - You need full P21 business validation
-- Operations may trigger dialogs (email, confirmations)
 - Complex multi-step workflows
 - You need to mimic user interaction
 
@@ -146,7 +149,7 @@ Prophet 21 provides four different APIs for external data access and manipulatio
 - You don't need business logic
 
 ### Performance Note
-The Interactive API is slower than Transaction API for creates (~5s vs 0.05s per record) but more reliable for updates.
+The Interactive API is slower than the Transaction API (~5s vs 0.05s per created record; a windowed edit typically takes ~5 round-trips). Prefer the Transaction API when a keyed update works, and fall back to the Interactive API when the flow needs real window logic or dialog answers.
 
 ### Version Note
 Some P21 servers only support v2 Interactive API endpoints. If you receive 404 errors on `/api/ui/interactive/v1/*` endpoints, use `/api/ui/interactive/v2/*` instead. The v2 endpoints have different payload formats - see [Interactive API v1 vs v2](04-Interactive-API.md#v1-vs-v2-api-differences).
@@ -208,7 +211,9 @@ Start
   │
   ├─ Need to UPDATE records?
   │   │
-  │   └─ Yes → Use Interactive API
+  │   ├─ Keyed fields/rows, no dialogs → Use Transaction API (Status "New")
+  │   │
+  │   └─ Dialogs, disabled tabs, complex flows → Use Interactive API
   │
   ├─ Need response dialog handling?
   │   │
@@ -229,8 +234,8 @@ Start
 
 The most common pattern:
 1. Use **OData** for all reads (fast, simple)
-2. Use **Transaction API** for bulk creates (fast)
-3. Use **Interactive API** for updates (reliable)
+2. Use **Transaction API** for creates and keyed updates (fast)
+3. Use **Interactive API** for flows that need window logic or dialog answers
 
 ### Example: Price Page Management
 
@@ -278,9 +283,9 @@ Measured against production P21 instance:
 | Read 160 records | 0.12s | N/A | ~2s |
 | Create 1 record | N/A | 0.05s | 2.5s |
 | Create 25 records | N/A | 1.4s | 62s |
-| Update 1 record | N/A | Unreliable* | 2.0s |
+| Update 1 record | N/A | ~0.8s* | 2.0s |
 
-*Transaction API updates may fail - see known issues
+*Transaction API keyed update via `Status: "New"` (verified on JobContractPricing; per-line latency ~0.8s). Flows that trip prompts or disabled tabs still need the Interactive API.
 
 ---
 

--- a/docs/03-Transaction-API.md
+++ b/docs/03-Transaction-API.md
@@ -110,7 +110,7 @@ The main request body for create/update operations:
 | `Name` | Yes | Service name (e.g., "Order", "SalesPricePage") |
 | `UseCodeValues` | No | If `true`, use code values; if `false` (default), use display values |
 | `Transactions` | Yes | Array of Transaction objects to process |
-| `IgnoreDisabled` | No | If `true`, skip disabled fields instead of erroring |
+| `IgnoreDisabled` | No | If `true`, allow the transaction to proceed past disabled fields (see [IgnoreDisabled](#ignoredisabled) below) |
 | `Query` | No | Optional query filter for the service |
 | `FieldMap` | No | Optional field name mappings |
 | `TransactionSplitMethod` | No | `"Standard"` (default) or `"NoSplit"` |
@@ -240,11 +240,13 @@ See [Production & Labor API](12-Production-Labor-API.md) for detailed field defi
 }
 ```
 
+> **Transactions pass/fail independently.** In a bulk POST, each Transaction in the array is processed on its own: one failing does not roll back the others (no cascade), and `Summary` tallies the outcomes (`Succeeded`/`Failed`/`Other`). Check `Results.Transactions[].Status` (`"Passed"`/`"Failed"`) to see which specific transactions landed — never the HTTP status, which is 200 either way. (Exception: transactions that each re-save the same shared header record can collide — see [Upsert Semantics](#upsert-semantics----keyed-rows-insert-when-absent).)
+
 ---
 
 ## Field Order Matters
 
-For some services, the order of fields in the request is significant. The API processes fields sequentially, and some fields trigger validation or auto-population of other fields.
+For some services, the order of fields in the request is significant. The API processes fields sequentially and mirrors the window's UI cascades — some fields trigger validation, auto-population, or **clearing** of other fields, exactly as they would when typed into the window in that order.
 
 ### Example: SalesPricePage
 
@@ -254,6 +256,41 @@ Fields must be set in this order:
 3. `product_group_id` or `discount_group_id`
 4. `supplier_id`
 5. Other fields...
+
+### Example: JobContractPricing — `pricing_method` before `price`
+
+Changing `pricing_method` **clears the typed price**, just like in the UI. If a line row's Edits send `price` before `pricing_method`, the line is created/updated with **price = $0** — and the transaction still reports `Succeeded`. Order the Edits `item_id`, `pricing_method`, `price`. Verified live: reversing the order silently zeroes the price.
+
+> **Rule of thumb:** when a write "succeeds" but a value doesn't stick, suspect a field-order cascade. Order Edits the way a user would fill in the window, and verify written values with OData or `POST /api/v2/transaction/get` after the first run.
+>
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) for the JobContractPricing ordering discovery.
+
+---
+
+## IgnoreDisabled
+
+`IgnoreDisabled: true` does more than suppress errors — it is the documented unlock for writing through **system-disabled columns** and **disabled sub-tabs** that the Transaction API otherwise cannot touch:
+
+- Forms whose defaults carry read-only/system columns (e.g. bin maintenance flags) fail with `General Exception: Column is disabled: <column>` unless the flag is set.
+- Some grids that live on a disabled sub-tab (e.g. job contract **BINS** quantities) accept keyed edits once the flag is set — see [Editing Bin Quantities](#editing-bin-quantities-on-an-existing-contract).
+
+Two placement rules:
+
+1. **`IgnoreDisabled` goes at the payload top level** — alongside `Name` and `Transactions`. Placed inside a Transaction object it is **silently ignored**, and every transaction fails with `Column is disabled: <column>`.
+2. It applies to the whole TransactionSet — there is no per-transaction form.
+
+```json
+{
+    "Name": "JobContractPricing",
+    "UseCodeValues": false,
+    "IgnoreDisabled": true,
+    "Transactions": [ ... ]
+}
+```
+
+> **Caution:** the flag lets edits through columns P21 normally protects. Only send fields you intend to change, and verify results after the first run.
+>
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) for mapping the placement failure mode and the disabled-tab unlock behavior.
 
 ---
 
@@ -657,7 +694,28 @@ DataElements:
 
 #### Commission Costs
 
-The `JOBPRICECOST` DataElement includes `commission_cost_value` and related commission fields, but these are **disabled** -- the API returns "Column is disabled: commission_cost_value". Commission costs must be set via the Interactive API (JobContractPricing window) after contract creation.
+The `JOBPRICECOST` DataElement includes `commission_cost_value` and related commission fields. These columns are **disabled by default** -- without special handling the API returns "Column is disabled: commission_cost_value".
+
+**They are writable with `IgnoreDisabled: true`** at the payload top level (see [IgnoreDisabled](#ignoredisabled)). Key the element by `item_id` and set the cost type before the value -- verified live, including in the same transaction as a line insert:
+
+```json
+{
+    "Name": "JOBPRICECOST.jobpricecost",
+    "Type": "Form",
+    "Keys": ["item_id"],
+    "Rows": [{
+        "Edits": [
+            {"Name": "item_id", "Value": "WIDGET-001"},
+            {"Name": "commission_cost_type_cd", "Value": "Value"},
+            {"Name": "commission_cost_value", "Value": "17.19"}
+        ]
+    }]
+}
+```
+
+`commission_cost_type_cd` accepts the display labels `Order`, `Source`, `Value`, `None` (with `UseCodeValues: false`). Setting only the commission cost leaves `other_cost` untouched.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) verified the `IgnoreDisabled` commission-cost write path. The Interactive API (JobContractPricing window) remains an alternative.
 
 #### Updating an Existing Contract
 
@@ -727,10 +785,81 @@ payload = {
   }
   ```
 - **Per-line latency** observed at ~0.8s. For bulk updates, single-line calls are easier to retry on failure than batches.
+- **`end_date` must be >= today.** The header is validated on every save; a past date is rejected with *"end date must be equal to or greater than today"*. This means you cannot edit lines on an **expired** contract without also moving its `end_date` forward (a real side effect) -- for expired contracts, use the Interactive API instead.
+- **Identify renewals by `job_no`.** Contract renewals can leave the same `contract_no` on two header rows; `job_no` is unique. Include it in the FORM Edits whenever it's known.
+
+#### Upsert Semantics -- Keyed Rows Insert When Absent
+
+`Status: "New"` with a keyed List row is an **upsert**: if the key matches an existing row it updates that row, and if it doesn't match, P21 **inserts a new row**. This means the Transaction API can add brand-new lines to an existing contract -- no Interactive API needed. Verified live: 81 new lines added to an existing contract in one run (price, pricing_method, and commission cost all confirmed in the database with unique `line_no` values).
+
+The payload is identical to the update example above -- the only difference is whether `item_id` already exists on the contract.
+
+**Concurrency gotcha -- one transaction per POST when inserting lines.** Every transaction re-saves the shared FORM header. If you batch several line-insert transactions into one POST:
+
+- all but one fail with an optimistic-concurrency error (*"Your changes could not be saved because changes to this information have been made outside of..."*), and
+- the transactions that do land can get **duplicate `line_no`** values, because `line_no` is not incremented across transactions within a single POST.
+
+Submit each insert as its own POST -- each one then sees the current max `line_no` and increments it correctly. (This applies to **inserts that re-save the same header**; editing existing keyed rows -- prices, bin quantities -- batches fine in one POST.)
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) verified the upsert behavior and the header-collision failure mode.
+
+#### Editing Bin Quantities on an Existing Contract
+
+Contract bin quantities (`BINS.bins` -- `min_qty`, `max_qty`, `reorder_qty`, `capacity`) live on a sub-tab that is normally disabled until a parent row is selected, which the stateless Transaction API cannot do. **`IgnoreDisabled: true` unlocks it** (see [IgnoreDisabled](#ignoredisabled)). One POST, batchable across many bins:
+
+```json
+{
+    "Name": "JobContractPricing",
+    "UseCodeValues": false,
+    "IgnoreDisabled": true,
+    "Transactions": [{
+        "Status": "New",
+        "DataElements": [
+            {
+                "Name": "FORM.d_dw_job_price_hdr", "Type": "Form", "Keys": [],
+                "Rows": [{"Edits": [
+                    {"Name": "job_no", "Value": "31"},
+                    {"Name": "customer_id", "Value": "100198"},
+                    {"Name": "ship_to_id", "Value": "200"}
+                ]}]
+            },
+            {
+                "Name": "JOBPRICELINE.jobpriceline", "Type": "List", "Keys": ["item_id"],
+                "Rows": [{"Edits": [
+                    {"Name": "item_id", "Value": "WIDGET-001"}
+                ]}]
+            },
+            {
+                "Name": "BINS.bins", "Type": "List",
+                "Keys": ["contract_bin_id", "customer_id", "ship_to_id"],
+                "Rows": [{"Edits": [
+                    {"Name": "contract_bin_id", "Value": "A01-02"},
+                    {"Name": "customer_id", "Value": "100198"},
+                    {"Name": "ship_to_id", "Value": "200"},
+                    {"Name": "min_qty", "Value": "30"},
+                    {"Name": "max_qty", "Value": "100"},
+                    {"Name": "reorder_qty", "Value": "40"},
+                    {"Name": "capacity", "Value": "100"}
+                ]}]
+            }
+        ]
+    }]
+}
+```
+
+Gotchas (all verified live):
+
+- **`IgnoreDisabled: true` is mandatory** -- without it the defaults template trips *"Column is disabled: ..."* and the BINS tab stays locked.
+- **Select the line by `item_id`** (the JOBPRICELINE key). Selecting by `line_no` alone fails with *"Sequence contains no matching element."* If the same item appears on multiple lines, add `line_no` as a second key.
+- **Batching is fine here**: repeat the `JOBPRICELINE` + `BINS.bins` pair per bin inside the same Transaction. Unlike line inserts, bin edits don't collide on the header.
+- **No `end_date` required** on this path -- it works on expired contracts too, unlike line-field updates.
+- HTTP 200 can still carry `Summary.Failed > 0` -- check `Summary` and `Messages`.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) discovered and verified the `IgnoreDisabled` bins path (single and multi-bin batches, database-confirmed). The Interactive API (select ship-to row, then line, then BINS tab) also works as a slower fallback.
 
 #### Known Limitations
 
-- **Commission fields disabled:** Cannot set commission costs via Transaction API (see above).
+- **Commission fields disabled by default:** require `IgnoreDisabled: true` (see [Commission Costs](#commission-costs) above).
 - **`corp_address_id` read-only after save:** Must be set during initial creation.
 - **Status `"Existing"` is not a valid Transaction status:** Setting `Transactions[0].Status = "Existing"` (or `"Update"`, `"Change"`) returns HTTP 500 (`NullReferenceException` at `ToInternalBeSpecification`). Use `"New"` for both create and update -- see [Updating an Existing Contract](#updating-an-existing-contract).
 

--- a/docs/html/01-API-Selection-Guide.html
+++ b/docs/html/01-API-Selection-Guide.html
@@ -474,9 +474,14 @@
 <td>Stateless, domain objects</td>
 </tr>
 <tr>
-<td>Update existing records</td>
+<td>Update existing records (keyed fields)</td>
+<td><strong>Transaction API</strong></td>
+<td><code>Status: "New"</code> + keyed rows updates and upserts (verified)</td>
+</tr>
+<tr>
+<td>Update records behind dialogs/prompts</td>
 <td><strong>Interactive API</strong></td>
-<td>Reliable field-level updates</td>
+<td>Only API that can answer response windows</td>
 </tr>
 <tr>
 <td>Handle response dialogs</td>
@@ -530,7 +535,7 @@
 <tr>
 <td><strong>Update Data</strong></td>
 <td>No</td>
-<td>Limited*</td>
+<td>Good*</td>
 <td>Excellent</td>
 <td>Good (4 entities)</td>
 </tr>
@@ -578,7 +583,7 @@
 </tr>
 </tbody>
 </table>
-<p>*Transaction API updates have known issues - see <a href="07-Session-Pool-Troubleshooting.html">Session Pool Troubleshooting</a></p>
+<p><em>Transaction API updates use <code>Status: "New"</code> with keyed rows (there is no working "Existing" status — it returns HTTP 500). Keyed rows behave as an </em><em>upsert</em>*: update if the key matches, insert if it doesn't. Verified at scale (170+ line updates, 80+ line inserts on JobContractPricing). See <a href="03-Transaction-API.html#updating-an-existing-contract">Updating an Existing Contract</a>. Flows that pop validation dialogs still need the Interactive API.</p>
 <hr />
 <h2 id="odata-api">OData API</h2>
 <h3 id="best-for">Best For</h3>
@@ -632,25 +637,27 @@
 <li><strong>Bulk operations</strong> - multiple records per request</li>
 <li><strong>Metadata-driven</strong> - follows P21 window schemas</li>
 <li><strong>Fast</strong> - 50-100x faster than Interactive API for creates</li>
-<li><strong>Limited updates</strong> - update operations have known issues</li>
+<li><strong>Updates via <code>Status: "New"</code> + keys</strong> - keyed rows upsert (update if the key matches, insert if not); the <code>"Existing"</code> status is broken (HTTP 500)</li>
 </ul>
 <h3 id="use-when_1">Use When</h3>
 <ul>
 <li>Creating many records at once</li>
+<li>Updating or inserting keyed fields/rows on existing records</li>
 <li>Building integrations from external systems</li>
-<li>Performance is critical for creation</li>
+<li>Performance is critical</li>
 <li>You don't need complex validation feedback</li>
 </ul>
 <h3 id="dont-use-when_1">Don't Use When</h3>
 <ul>
-<li>Updating existing records (use Interactive API)</li>
-<li>You need to handle response dialogs</li>
+<li>The operation pops validation dialogs / response windows (use Interactive API)</li>
+<li>A sub-tab stays disabled until a parent row is selected and <code>IgnoreDisabled</code> doesn't unlock it (use Interactive API)</li>
 <li>You need field-by-field validation feedback</li>
 </ul>
 <h3 id="known-issues">Known Issues</h3>
 <ul>
 <li><strong>Session Pool Contamination</strong> - intermittent failures with some windows</li>
-<li><strong>Update operations</strong> - may fail with NullReferenceException</li>
+<li><strong><code>Status: "Existing"</code> is broken</strong> - returns HTTP 500 NullReferenceException platform-wide; use <code>Status: "New"</code> for updates (see <a href="03-Transaction-API.html#updating-an-existing-contract">Transaction API</a>)</li>
+<li><strong>Prompts are auto-answered with the default</strong> - a DynaChange or validation prompt kills the affected line/record silently</li>
 <li>See <a href="07-Session-Pool-Troubleshooting.html">Session Pool Troubleshooting</a></li>
 </ul>
 <h3 id="example-use-cases_1">Example Use Cases</h3>
@@ -681,9 +688,9 @@
 </ul>
 <h3 id="use-when_2">Use When</h3>
 <ul>
-<li>Updating existing records</li>
+<li>Operations may trigger dialogs (email, confirmations) that must be answered</li>
+<li>Updating records where the Transaction API path hits disabled tabs or prompts</li>
 <li>You need full P21 business validation</li>
-<li>Operations may trigger dialogs (email, confirmations)</li>
 <li>Complex multi-step workflows</li>
 <li>You need to mimic user interaction</li>
 </ul>
@@ -694,7 +701,7 @@
 <li>You don't need business logic</li>
 </ul>
 <h3 id="performance-note">Performance Note</h3>
-<p>The Interactive API is slower than Transaction API for creates (~5s vs 0.05s per record) but more reliable for updates.</p>
+<p>The Interactive API is slower than the Transaction API (~5s vs 0.05s per created record; a windowed edit typically takes ~5 round-trips). Prefer the Transaction API when a keyed update works, and fall back to the Interactive API when the flow needs real window logic or dialog answers.</p>
 <h3 id="version-note">Version Note</h3>
 <p>Some P21 servers only support v2 Interactive API endpoints. If you receive 404 errors on <code>/api/ui/interactive/v1/*</code> endpoints, use <code>/api/ui/interactive/v2/*</code> instead. The v2 endpoints have different payload formats - see <a href="04-Interactive-API.html#v1-vs-v2-api-differences">Interactive API v1 vs v2</a>.</p>
 <h3 id="example-use-cases_2">Example Use Cases</h3>
@@ -755,7 +762,9 @@
   │
   ├─ Need to UPDATE records?
   │   │
-  │   └─ Yes → Use Interactive API
+  │   ├─ Keyed fields/rows, no dialogs → Use Transaction API (Status &quot;New&quot;)
+  │   │
+  │   └─ Dialogs, disabled tabs, complex flows → Use Interactive API
   │
   ├─ Need response dialog handling?
   │   │
@@ -773,8 +782,8 @@
 <h3 id="read-with-odata-write-with-transactioninteractive">Read with OData, Write with Transaction/Interactive</h3>
 <p>The most common pattern:
 1. Use <strong>OData</strong> for all reads (fast, simple)
-2. Use <strong>Transaction API</strong> for bulk creates (fast)
-3. Use <strong>Interactive API</strong> for updates (reliable)</p>
+2. Use <strong>Transaction API</strong> for creates and keyed updates (fast)
+3. Use <strong>Interactive API</strong> for flows that need window logic or dialog answers</p>
 <h3 id="example-price-page-management">Example: Price Page Management</h3>
 <div class="code-tabs">
   <div class="tab-buttons">
@@ -847,12 +856,12 @@
 <tr>
 <td>Update 1 record</td>
 <td>N/A</td>
-<td>Unreliable*</td>
+<td>~0.8s*</td>
 <td>2.0s</td>
 </tr>
 </tbody>
 </table>
-<p>*Transaction API updates may fail - see known issues</p>
+<p>*Transaction API keyed update via <code>Status: "New"</code> (verified on JobContractPricing; per-line latency ~0.8s). Flows that trip prompts or disabled tabs still need the Interactive API.</p>
 <hr />
 <h2 id="related">Related</h2>
 <ul>

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -408,8 +408,10 @@
 </li>
 <li><a href="#field-order-matters">Field Order Matters</a><ul>
 <li><a href="#example-salespricepage">Example: SalesPricePage</a></li>
+<li><a href="#example-jobcontractpricing-pricing_method-before-price">Example: JobContractPricing — pricing_method before price</a></li>
 </ul>
 </li>
+<li><a href="#ignoredisabled">IgnoreDisabled</a></li>
 <li><a href="#usecodevalues">UseCodeValues</a></li>
 <li><a href="#async-operations">Async Operations</a><ul>
 <li><a href="#submit-async-request">Submit Async Request</a></li>
@@ -636,7 +638,7 @@
 <tr>
 <td><code>IgnoreDisabled</code></td>
 <td>No</td>
-<td>If <code>true</code>, skip disabled fields instead of erroring</td>
+<td>If <code>true</code>, allow the transaction to proceed past disabled fields (see <a href="#ignoredisabled">IgnoreDisabled</a> below)</td>
 </tr>
 <tr>
 <td><code>Query</code></td>
@@ -949,9 +951,12 @@
 <span class="p">}</span>
 </code></pre></div>
 
+<blockquote>
+<p><strong>Transactions pass/fail independently.</strong> In a bulk POST, each Transaction in the array is processed on its own: one failing does not roll back the others (no cascade), and <code>Summary</code> tallies the outcomes (<code>Succeeded</code>/<code>Failed</code>/<code>Other</code>). Check <code>Results.Transactions[].Status</code> (<code>"Passed"</code>/<code>"Failed"</code>) to see which specific transactions landed — never the HTTP status, which is 200 either way. (Exception: transactions that each re-save the same shared header record can collide — see <a href="#upsert-semantics----keyed-rows-insert-when-absent">Upsert Semantics</a>.)</p>
+</blockquote>
 <hr />
 <h2 id="field-order-matters">Field Order Matters</h2>
-<p>For some services, the order of fields in the request is significant. The API processes fields sequentially, and some fields trigger validation or auto-population of other fields.</p>
+<p>For some services, the order of fields in the request is significant. The API processes fields sequentially and mirrors the window's UI cascades — some fields trigger validation, auto-population, or <strong>clearing</strong> of other fields, exactly as they would when typed into the window in that order.</p>
 <h3 id="example-salespricepage">Example: SalesPricePage</h3>
 <p>Fields must be set in this order:
 1. <code>price_page_type_cd</code> - Triggers type-specific validation
@@ -959,6 +964,36 @@
 3. <code>product_group_id</code> or <code>discount_group_id</code>
 4. <code>supplier_id</code>
 5. Other fields...</p>
+<h3 id="example-jobcontractpricing-pricing_method-before-price">Example: JobContractPricing — <code>pricing_method</code> before <code>price</code></h3>
+<p>Changing <code>pricing_method</code> <strong>clears the typed price</strong>, just like in the UI. If a line row's Edits send <code>price</code> before <code>pricing_method</code>, the line is created/updated with <strong>price = $0</strong> — and the transaction still reports <code>Succeeded</code>. Order the Edits <code>item_id</code>, <code>pricing_method</code>, <code>price</code>. Verified live: reversing the order silently zeroes the price.</p>
+<blockquote>
+<p><strong>Rule of thumb:</strong> when a write "succeeds" but a value doesn't stick, suspect a field-order cascade. Order Edits the way a user would fill in the window, and verify written values with OData or <code>POST /api/v2/transaction/get</code> after the first run.</p>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> for the JobContractPricing ordering discovery.</p>
+</blockquote>
+<hr />
+<h2 id="ignoredisabled">IgnoreDisabled</h2>
+<p><code>IgnoreDisabled: true</code> does more than suppress errors — it is the documented unlock for writing through <strong>system-disabled columns</strong> and <strong>disabled sub-tabs</strong> that the Transaction API otherwise cannot touch:</p>
+<ul>
+<li>Forms whose defaults carry read-only/system columns (e.g. bin maintenance flags) fail with <code>General Exception: Column is disabled: &lt;column&gt;</code> unless the flag is set.</li>
+<li>Some grids that live on a disabled sub-tab (e.g. job contract <strong>BINS</strong> quantities) accept keyed edits once the flag is set — see <a href="#editing-bin-quantities-on-an-existing-contract">Editing Bin Quantities</a>.</li>
+</ul>
+<p>Two placement rules:</p>
+<ol>
+<li><strong><code>IgnoreDisabled</code> goes at the payload top level</strong> — alongside <code>Name</code> and <code>Transactions</code>. Placed inside a Transaction object it is <strong>silently ignored</strong>, and every transaction fails with <code>Column is disabled: &lt;column&gt;</code>.</li>
+<li>It applies to the whole TransactionSet — there is no per-transaction form.</li>
+</ol>
+<div class="highlight"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;JobContractPricing&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;UseCodeValues&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;IgnoreDisabled&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Transactions&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w"> </span><span class="err">...</span><span class="w"> </span><span class="p">]</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<blockquote>
+<p><strong>Caution:</strong> the flag lets edits through columns P21 normally protects. Only send fields you intend to change, and verify results after the first run.</p>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> for mapping the placement failure mode and the disabled-tab unlock behavior.</p>
+</blockquote>
 <hr />
 <h2 id="usecodevalues">UseCodeValues</h2>
 <p>This setting controls how dropdown/checkbox values are interpreted:</p>
@@ -1605,7 +1640,26 @@ The <code>target_date</code> edit must appear before <code>start_date</code> in 
 </code></pre></div>
 
 <h4 id="commission-costs">Commission Costs</h4>
-<p>The <code>JOBPRICECOST</code> DataElement includes <code>commission_cost_value</code> and related commission fields, but these are <strong>disabled</strong> -- the API returns "Column is disabled: commission_cost_value". Commission costs must be set via the Interactive API (JobContractPricing window) after contract creation.</p>
+<p>The <code>JOBPRICECOST</code> DataElement includes <code>commission_cost_value</code> and related commission fields. These columns are <strong>disabled by default</strong> -- without special handling the API returns "Column is disabled: commission_cost_value".</p>
+<p><strong>They are writable with <code>IgnoreDisabled: true</code></strong> at the payload top level (see <a href="#ignoredisabled">IgnoreDisabled</a>). Key the element by <code>item_id</code> and set the cost type before the value -- verified live, including in the same transaction as a line insert:</p>
+<div class="highlight"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;JOBPRICECOST.jobpricecost&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Form&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;item_id&quot;</span><span class="p">],</span>
+<span class="w">    </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span>
+<span class="w">        </span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">            </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;item_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;WIDGET-001&quot;</span><span class="p">},</span>
+<span class="w">            </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;commission_cost_type_cd&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Value&quot;</span><span class="p">},</span>
+<span class="w">            </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;commission_cost_value&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;17.19&quot;</span><span class="p">}</span>
+<span class="w">        </span><span class="p">]</span>
+<span class="w">    </span><span class="p">}]</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<p><code>commission_cost_type_cd</code> accepts the display labels <code>Order</code>, <code>Source</code>, <code>Value</code>, <code>None</code> (with <code>UseCodeValues: false</code>). Setting only the commission cost leaves <code>other_cost</code> untouched.</p>
+<blockquote>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> verified the <code>IgnoreDisabled</code> commission-cost write path. The Interactive API (JobContractPricing window) remains an alternative.</p>
+</blockquote>
 <h4 id="updating-an-existing-contract">Updating an Existing Contract</h4>
 <p>Use <code>Status = "New"</code> to update existing contracts -- there is no separate "Update" or "Existing" status. The Transaction API distinguishes create from update by whether the FORM key fields land on an existing record:</p>
 <ul>
@@ -1670,10 +1724,76 @@ The <code>target_date</code> edit must appear before <code>start_date</code> in 
       "Keys": [{"Name": "contract_no", "Value": "A120-12"}]
     }]
   }</code>
-- <strong>Per-line latency</strong> observed at ~0.8s. For bulk updates, single-line calls are easier to retry on failure than batches.</p>
+- <strong>Per-line latency</strong> observed at ~0.8s. For bulk updates, single-line calls are easier to retry on failure than batches.
+- <strong><code>end_date</code> must be &gt;= today.</strong> The header is validated on every save; a past date is rejected with <em>"end date must be equal to or greater than today"</em>. This means you cannot edit lines on an <strong>expired</strong> contract without also moving its <code>end_date</code> forward (a real side effect) -- for expired contracts, use the Interactive API instead.
+- <strong>Identify renewals by <code>job_no</code>.</strong> Contract renewals can leave the same <code>contract_no</code> on two header rows; <code>job_no</code> is unique. Include it in the FORM Edits whenever it's known.</p>
+<h4 id="upsert-semantics-keyed-rows-insert-when-absent">Upsert Semantics -- Keyed Rows Insert When Absent</h4>
+<p><code>Status: "New"</code> with a keyed List row is an <strong>upsert</strong>: if the key matches an existing row it updates that row, and if it doesn't match, P21 <strong>inserts a new row</strong>. This means the Transaction API can add brand-new lines to an existing contract -- no Interactive API needed. Verified live: 81 new lines added to an existing contract in one run (price, pricing_method, and commission cost all confirmed in the database with unique <code>line_no</code> values).</p>
+<p>The payload is identical to the update example above -- the only difference is whether <code>item_id</code> already exists on the contract.</p>
+<p><strong>Concurrency gotcha -- one transaction per POST when inserting lines.</strong> Every transaction re-saves the shared FORM header. If you batch several line-insert transactions into one POST:</p>
+<ul>
+<li>all but one fail with an optimistic-concurrency error (<em>"Your changes could not be saved because changes to this information have been made outside of..."</em>), and</li>
+<li>the transactions that do land can get <strong>duplicate <code>line_no</code></strong> values, because <code>line_no</code> is not incremented across transactions within a single POST.</li>
+</ul>
+<p>Submit each insert as its own POST -- each one then sees the current max <code>line_no</code> and increments it correctly. (This applies to <strong>inserts that re-save the same header</strong>; editing existing keyed rows -- prices, bin quantities -- batches fine in one POST.)</p>
+<blockquote>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> verified the upsert behavior and the header-collision failure mode.</p>
+</blockquote>
+<h4 id="editing-bin-quantities-on-an-existing-contract">Editing Bin Quantities on an Existing Contract</h4>
+<p>Contract bin quantities (<code>BINS.bins</code> -- <code>min_qty</code>, <code>max_qty</code>, <code>reorder_qty</code>, <code>capacity</code>) live on a sub-tab that is normally disabled until a parent row is selected, which the stateless Transaction API cannot do. <strong><code>IgnoreDisabled: true</code> unlocks it</strong> (see <a href="#ignoredisabled">IgnoreDisabled</a>). One POST, batchable across many bins:</p>
+<div class="highlight"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;JobContractPricing&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;UseCodeValues&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;IgnoreDisabled&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Transactions&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span>
+<span class="w">        </span><span class="nt">&quot;Status&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;New&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="nt">&quot;DataElements&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">            </span><span class="p">{</span>
+<span class="w">                </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;FORM.d_dw_job_price_hdr&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Form&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[],</span>
+<span class="w">                </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;job_no&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;31&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;customer_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;100198&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;ship_to_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;200&quot;</span><span class="p">}</span>
+<span class="w">                </span><span class="p">]}]</span>
+<span class="w">            </span><span class="p">},</span>
+<span class="w">            </span><span class="p">{</span>
+<span class="w">                </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;JOBPRICELINE.jobpriceline&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;List&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;item_id&quot;</span><span class="p">],</span>
+<span class="w">                </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;item_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;WIDGET-001&quot;</span><span class="p">}</span>
+<span class="w">                </span><span class="p">]}]</span>
+<span class="w">            </span><span class="p">},</span>
+<span class="w">            </span><span class="p">{</span>
+<span class="w">                </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;BINS.bins&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;List&quot;</span><span class="p">,</span>
+<span class="w">                </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;contract_bin_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="s2">&quot;customer_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="s2">&quot;ship_to_id&quot;</span><span class="p">],</span>
+<span class="w">                </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;contract_bin_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;A01-02&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;customer_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;100198&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;ship_to_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;200&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;min_qty&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;30&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;max_qty&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;100&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;reorder_qty&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;40&quot;</span><span class="p">},</span>
+<span class="w">                    </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;capacity&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;100&quot;</span><span class="p">}</span>
+<span class="w">                </span><span class="p">]}]</span>
+<span class="w">            </span><span class="p">}</span>
+<span class="w">        </span><span class="p">]</span>
+<span class="w">    </span><span class="p">}]</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<p>Gotchas (all verified live):</p>
+<ul>
+<li><strong><code>IgnoreDisabled: true</code> is mandatory</strong> -- without it the defaults template trips <em>"Column is disabled: ..."</em> and the BINS tab stays locked.</li>
+<li><strong>Select the line by <code>item_id</code></strong> (the JOBPRICELINE key). Selecting by <code>line_no</code> alone fails with <em>"Sequence contains no matching element."</em> If the same item appears on multiple lines, add <code>line_no</code> as a second key.</li>
+<li><strong>Batching is fine here</strong>: repeat the <code>JOBPRICELINE</code> + <code>BINS.bins</code> pair per bin inside the same Transaction. Unlike line inserts, bin edits don't collide on the header.</li>
+<li><strong>No <code>end_date</code> required</strong> on this path -- it works on expired contracts too, unlike line-field updates.</li>
+<li>HTTP 200 can still carry <code>Summary.Failed &gt; 0</code> -- check <code>Summary</code> and <code>Messages</code>.</li>
+</ul>
+<blockquote>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> discovered and verified the <code>IgnoreDisabled</code> bins path (single and multi-bin batches, database-confirmed). The Interactive API (select ship-to row, then line, then BINS tab) also works as a slower fallback.</p>
+</blockquote>
 <h4 id="known-limitations">Known Limitations</h4>
 <ul>
-<li><strong>Commission fields disabled:</strong> Cannot set commission costs via Transaction API (see above).</li>
+<li><strong>Commission fields disabled by default:</strong> require <code>IgnoreDisabled: true</code> (see <a href="#commission-costs">Commission Costs</a> above).</li>
 <li><strong><code>corp_address_id</code> read-only after save:</strong> Must be set during initial creation.</li>
 <li><strong>Status <code>"Existing"</code> is not a valid Transaction status:</strong> Setting <code>Transactions[0].Status = "Existing"</code> (or <code>"Update"</code>, <code>"Change"</code>) returns HTTP 500 (<code>NullReferenceException</code> at <code>ToInternalBeSpecification</code>). Use <code>"New"</code> for both create and update -- see <a href="#updating-an-existing-contract">Updating an Existing Contract</a>.</li>
 </ul>


### PR DESCRIPTION
## Summary
Realigns our update guidance with verified behavior and adds JobContractPricing patterns cross-checked from community findings (credit: [Alex Westemeier](https://github.com/AWestemeier), verified live on a 25.2 play system mid-2026).

- **Selection guide**: Transaction API `Status:"New"` + keyed rows is a working update path — and an **upsert** (inserts when the key doesn't match; 81 lines added in one verified run). The guide no longer routes all updates to the Interactive API; that stays the answer for dialogs/disabled-tab flows.
- **New `IgnoreDisabled` section**: unlocks writes to disabled columns and disabled sub-tabs (contract BINS quantities, JOBPRICECOST commission fields); placement warning — top level only, silently ignored inside a Transaction object.
- **Field-order cascade**: `pricing_method` must precede `price` or the line lands at $0 while reporting Succeeded.
- **Concurrency**: one transaction per POST when line inserts re-save the shared FORM header (optimistic-concurrency collisions + duplicate `line_no`); keyed edits/bins batch fine.
- **Corrections**: commission costs are writable (previous doc said Interactive-only); `end_date >= today` validation; independent pass/fail of bulk transactions.

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE