### PR TITLE
docs: Order service gotchas + interactive assembly-line order entry

### DIFF
--- a/docs/03-Transaction-API.md
+++ b/docs/03-Transaction-API.md
@@ -570,6 +570,17 @@ var response = await client.PostAsync(
 ```
 <!-- /tabs -->
 
+#### Order Service Gotchas
+
+All verified live (credit: [Alex Westemeier](https://github.com/AWestemeier)):
+
+- **`source_loc_id` is effectively required.** Omitting it fails with a *"Jurisdiction ID for Order Header Tax"* error — the tax jurisdiction does not auto-populate through the API the way it does in the UI. A realistic header sets `customer_id`, `sales_loc_id`, `source_loc_id`, `order_date`, `requested_date`, `po_no`, `taker`, `ship_to_id`, and `contact_id`.
+- **`requested_date` must be after `order_date`.** The same date trips a date-cascade prompt, which the stateless API can't answer.
+- **`company_id` is a disabled column** on the Order window — don't send it.
+- **DynaChange prompts are auto-answered with the default** (usually "No"), which silently discards the affected line — e.g. *"order line does not have a PO Cost… proceed? [No]"*. On multi-item orders the remaining lines then cascade-fail. This is a P21 configuration matter (exempt the rule for the API user, or fix the data), not something a payload change can work around — see [DynaChange and Popup Handling](#dynachange-and-popup-handling).
+- **Assembly items cannot be entered via the Transaction API** when they should explode or spawn a production order — the *"add as assembly?"* prompt is auto-answered **No**, killing the explode. Use the Interactive API for those lines: see [Sales Order Entry with Assembly Lines](04-Interactive-API.md#sales-order-entry-with-assembly-lines).
+- The created `order_no` comes back in the result rows; check `Summary.Succeeded`, not the HTTP status.
+
 ---
 
 ## Service Reference

--- a/docs/04-Interactive-API.md
+++ b/docs/04-Interactive-API.md
@@ -1560,6 +1560,27 @@ Changes to the popup use the **popup's** window ID with `TabName: null` (it is t
 
 ---
 
+## Sales Order Entry with Assembly Lines
+
+Use the Interactive API to create a sales order when a line is an **assembly** that should explode into components and/or spawn a **production order**. The Transaction API cannot do this: entering an assembly item fires an *"add as assembly?"* prompt, and the stateless API auto-answers **No**, killing the explode (see [Order Service Gotchas](03-Transaction-API.md#order-service-gotchas)). Verified end-to-end: interactive order entry created a sales order whose assembly line (`oe_line.assembly = 'P'`) auto-linked to a new production order.
+
+The flow (session started with `ResponseWindowHandlingEnabled: true`):
+
+1. **Header** on `TabName: "TABPAGE_1"`, `DatawindowName: "order"` — set `quote` (`OFF` = real order, `ON` = quote), `sales_loc_id`, `source_loc_id`, `customer_id`, `ship_to_id`, `contact_id`, `order_date`, `requested_date`, `po_no`, `taker`.
+   - **`taker` defaults to the API user** — override it with the real salesperson or the order is attributed to the service account.
+   - **Setting the dates fires a date-cascade prompt** (`w_response_common`, buttons `cb_ok`/`cb_cancel`) *even on a brand-new order*. Answer **`cb_ok`** via the popup's window ID (see [Response Windows](#response-windows)).
+2. **Lines**: `change_tab` to `TP_ITEMS`, then set fields on the **existing** `items` row (`DatawindowName: "items"` — do **not** add a row for the first line):
+   - Setting `oe_order_item_id` on an assembly item fires the **assembly prompt** (buttons `cb_1` = Yes / `cb_2` = No / `cb_3` = Cancel). Answer **`cb_1`** to explode the assembly / link a production order.
+   - Then set `unit_quantity`.
+   - **Do NOT use the quickmode datawindow** (`d_dw_quickmode_*`) to enter lines — it **bypasses the assembly prompt entirely**, and the line lands without the explode.
+3. **Save**, answering any follow-on prompts with their proceed button. Read the generated `order_no` from the window data (`GET /v2/data`).
+
+Assembly behavior is item-level (`assembly_hdr`): `production_order_processing` `Y` = production-order assembly / `N` = kit; `auto_create_prod_order` `Y` = auto-create and link the production order at save. On the saved order, `oe_line.assembly` codes: `B` = kit parent, `N` = component, `P` = production-order line, `S` = build-to-stock allocation. The production-order link is `prod_order_line_link` (`transaction_uid = oe_line.oe_line_uid`, `trans_type = 'O'`). See the [Production & Labor API guide](12-Production-Labor-API.md) for the full production lifecycle.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — flow and gotchas verified end-to-end on a play environment (June 2026).
+
+---
+
 ## Data Structures Reference
 
 ### Result Object

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -1329,6 +1329,16 @@ The <code>target_date</code> edit must appear before <code>start_date</code> in 
 </code></pre></div>
 </div>
 </div>
+<h4 id="order-service-gotchas">Order Service Gotchas</h4>
+<p>All verified live (credit: <a href="https://github.com/AWestemeier">Alex Westemeier</a>):</p>
+<ul>
+<li><strong><code>source_loc_id</code> is effectively required.</strong> Omitting it fails with a <em>"Jurisdiction ID for Order Header Tax"</em> error — the tax jurisdiction does not auto-populate through the API the way it does in the UI. A realistic header sets <code>customer_id</code>, <code>sales_loc_id</code>, <code>source_loc_id</code>, <code>order_date</code>, <code>requested_date</code>, <code>po_no</code>, <code>taker</code>, <code>ship_to_id</code>, and <code>contact_id</code>.</li>
+<li><strong><code>requested_date</code> must be after <code>order_date</code>.</strong> The same date trips a date-cascade prompt, which the stateless API can't answer.</li>
+<li><strong><code>company_id</code> is a disabled column</strong> on the Order window — don't send it.</li>
+<li><strong>DynaChange prompts are auto-answered with the default</strong> (usually "No"), which silently discards the affected line — e.g. <em>"order line does not have a PO Cost… proceed? [No]"</em>. On multi-item orders the remaining lines then cascade-fail. This is a P21 configuration matter (exempt the rule for the API user, or fix the data), not something a payload change can work around — see <a href="#dynachange-and-popup-handling">DynaChange and Popup Handling</a>.</li>
+<li><strong>Assembly items cannot be entered via the Transaction API</strong> when they should explode or spawn a production order — the <em>"add as assembly?"</em> prompt is auto-answered <strong>No</strong>, killing the explode. Use the Interactive API for those lines: see <a href="04-Interactive-API.html#sales-order-entry-with-assembly-lines">Sales Order Entry with Assembly Lines</a>.</li>
+<li>The created <code>order_no</code> comes back in the result rows; check <code>Summary.Succeeded</code>, not the HTTP status.</li>
+</ul>
 <hr />
 <h2 id="service-reference">Service Reference</h2>
 <h3 id="jobcontractpricing-service">JobContractPricing Service</h3>

--- a/docs/html/04-Interactive-API.html
+++ b/docs/html/04-Interactive-API.html
@@ -445,6 +445,7 @@
 <li><a href="#recipe-add-a-line-note">Recipe: Add a Line Note</a></li>
 </ul>
 </li>
+<li><a href="#sales-order-entry-with-assembly-lines">Sales Order Entry with Assembly Lines</a></li>
 <li><a href="#data-structures-reference">Data Structures Reference</a><ul>
 <li><a href="#result-object">Result Object</a></li>
 <li><a href="#messages">Messages</a></li>
@@ -2367,6 +2368,24 @@ The API returns Status as an integer. String values (<code>"Success"</code>, <co
 <ol>
 <li>Complete the Notepad Entry popup exactly as in the header recipe (<code>topic</code>/<code>note</code> on <code>_dw_hdr</code> with <code>TabName: null</code>, then <code>cb_select_all</code>, <code>cb_ok</code>) — the popup's <code>_dw_hdr</code> shows which <code>line_no</code>/<code>item_id</code> the note will attach to. Save and verify.</li>
 </ol>
+<hr />
+<h2 id="sales-order-entry-with-assembly-lines">Sales Order Entry with Assembly Lines</h2>
+<p>Use the Interactive API to create a sales order when a line is an <strong>assembly</strong> that should explode into components and/or spawn a <strong>production order</strong>. The Transaction API cannot do this: entering an assembly item fires an <em>"add as assembly?"</em> prompt, and the stateless API auto-answers <strong>No</strong>, killing the explode (see <a href="03-Transaction-API.html#order-service-gotchas">Order Service Gotchas</a>). Verified end-to-end: interactive order entry created a sales order whose assembly line (<code>oe_line.assembly = 'P'</code>) auto-linked to a new production order.</p>
+<p>The flow (session started with <code>ResponseWindowHandlingEnabled: true</code>):</p>
+<ol>
+<li><strong>Header</strong> on <code>TabName: "TABPAGE_1"</code>, <code>DatawindowName: "order"</code> — set <code>quote</code> (<code>OFF</code> = real order, <code>ON</code> = quote), <code>sales_loc_id</code>, <code>source_loc_id</code>, <code>customer_id</code>, <code>ship_to_id</code>, <code>contact_id</code>, <code>order_date</code>, <code>requested_date</code>, <code>po_no</code>, <code>taker</code>.</li>
+<li><strong><code>taker</code> defaults to the API user</strong> — override it with the real salesperson or the order is attributed to the service account.</li>
+<li><strong>Setting the dates fires a date-cascade prompt</strong> (<code>w_response_common</code>, buttons <code>cb_ok</code>/<code>cb_cancel</code>) <em>even on a brand-new order</em>. Answer <strong><code>cb_ok</code></strong> via the popup's window ID (see <a href="#response-windows">Response Windows</a>).</li>
+<li><strong>Lines</strong>: <code>change_tab</code> to <code>TP_ITEMS</code>, then set fields on the <strong>existing</strong> <code>items</code> row (<code>DatawindowName: "items"</code> — do <strong>not</strong> add a row for the first line):</li>
+<li>Setting <code>oe_order_item_id</code> on an assembly item fires the <strong>assembly prompt</strong> (buttons <code>cb_1</code> = Yes / <code>cb_2</code> = No / <code>cb_3</code> = Cancel). Answer <strong><code>cb_1</code></strong> to explode the assembly / link a production order.</li>
+<li>Then set <code>unit_quantity</code>.</li>
+<li><strong>Do NOT use the quickmode datawindow</strong> (<code>d_dw_quickmode_*</code>) to enter lines — it <strong>bypasses the assembly prompt entirely</strong>, and the line lands without the explode.</li>
+<li><strong>Save</strong>, answering any follow-on prompts with their proceed button. Read the generated <code>order_no</code> from the window data (<code>GET /v2/data</code>).</li>
+</ol>
+<p>Assembly behavior is item-level (<code>assembly_hdr</code>): <code>production_order_processing</code> <code>Y</code> = production-order assembly / <code>N</code> = kit; <code>auto_create_prod_order</code> <code>Y</code> = auto-create and link the production order at save. On the saved order, <code>oe_line.assembly</code> codes: <code>B</code> = kit parent, <code>N</code> = component, <code>P</code> = production-order line, <code>S</code> = build-to-stock allocation. The production-order link is <code>prod_order_line_link</code> (<code>transaction_uid = oe_line.oe_line_uid</code>, <code>trans_type = 'O'</code>). See the <a href="12-Production-Labor-API.html">Production &amp; Labor API guide</a> for the full production lifecycle.</p>
+<blockquote>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> — flow and gotchas verified end-to-end on a play environment (June 2026).</p>
+</blockquote>
 <hr />
 <h2 id="data-structures-reference">Data Structures Reference</h2>
 <h3 id="result-object">Result Object</h3>


### PR DESCRIPTION
## Summary
Adds verified Order-service behavior to docs/03 and a new interactive order-entry section to docs/04 (credit: [Alex Westemeier](https://github.com/AWestemeier), verified live mid-2026).

- Transaction API: `source_loc_id` requirement (jurisdiction error), `requested_date > order_date`, `company_id` disabled, DynaChange auto-answer silently killing lines, assembly limitation.
- Interactive API: full assembly-line entry flow — assembly prompt `cb_1`, `w_response_common` date cascade on new orders, `taker` default trap, quickmode bypassing the assembly prompt, `oe_line.assembly` codes and `prod_order_line_link`.

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE