### PR TITLE
docs: Item service nested-element recipes + Item Issues Detected handling

### DIFF
--- a/docs/03-Transaction-API.md
+++ b/docs/03-Transaction-API.md
@@ -1460,6 +1460,60 @@ if ((int)result["Summary"]!["Failed"]! > 0)
 ```
 <!-- /tabs -->
 
+### Item Service -- Nested Location Edits
+
+The `Item` service (Item Maintenance window) supports **nested DataElement navigation** that mirrors the UI: select the item, select a location row, then edit that location's detail. This is the Transaction-API equivalent of "select parent row → edit child detail," and it works because the Item window's tabs aren't gated behind row selection. It's a good template for any nested edit.
+
+#### Set an item's primary bin at a location (Form → List → Form)
+
+```json
+{
+    "Name": "Item",
+    "UseCodeValues": false,
+    "Transactions": [{
+        "Status": "New",
+        "DataElements": [
+            { "Name": "TABPAGE_1.tp_1_dw_1", "Type": "Form", "Keys": ["item_id"],
+              "Rows": [{ "Edits": [ {"Name": "item_id", "Value": "WIDGET-001"} ] }] },
+            { "Name": "TABPAGE_17.invloclist", "Type": "List", "Keys": ["location_id"],
+              "Rows": [{ "Edits": [ {"Name": "location_id", "Value": "10"} ] }] },
+            { "Name": "TABPAGE_18.inv_loc_detail", "Type": "Form", "Keys": ["location_id"],
+              "Rows": [{ "Edits": [
+                  {"Name": "location_id", "Value": "10"},
+                  {"Name": "bin", "Value": "A01-02"}
+              ] }] }
+        ]
+    }]
+}
+```
+
+`Status: "New"` with populated `Keys` updates the existing keyed record (it does not create a new item).
+
+#### Set an item's primary supplier at a location (Form → List → List)
+
+Same window, one level different — the third element is the supplier list:
+
+```json
+{ "Name": "SUPPLIER_X_LOCATION.supplier_x_location", "Type": "List", "Keys": ["supplier_id"],
+  "Rows": [{ "Edits": [
+      {"Name": "supplier_id", "Value": "20000"},
+      {"Name": "primary_supplier", "Value": "ON"}
+  ] }] }
+```
+
+What this writes, and the cascade (verified on a 68-item production run):
+
+- `primary_supplier` maps to `inventory_supplier_x_loc.primary_supplier` (a Y/N flag) — **not** `inv_loc.primary_supplier_id`.
+- Setting it `ON` makes P21 auto-unset the previous primary at that location **and** update `inv_loc.primary_supplier_id` to the new supplier. So the flag is the field to **write**; `inv_loc.primary_supplier_id` is the field to **read** when verifying.
+
+#### Item Service Gotchas
+
+- **Silent no-op — the big one.** The target supplier must already have a *location-level* row (`inventory_supplier_x_loc`) at that location. If it doesn't, the transaction still returns `Succeeded = 1` but **nothing flips** — there is no row to promote. (P21 allows cutting a PO to a supplier without location setup, so a supplier can appear in PO history yet be absent from the location's supplier list.) **Always verify `inv_loc.primary_supplier_id` after writing** — do not trust `Succeeded`. Fix: add the location supplier row first, then set the flag.
+- **"Item Issues Detected" popup.** Items with data problems return an `Unexpected response window: Item Issues Detected` (`w_rule_callback_response`) in the response `Messages`. The Transaction API cannot get past this popup — it effectively answers "No" and discards the change. Use the Interactive API for those items and answer the popup with `cb_1` ("Yes, Proceed Anyway") — see [Item window popups](04-Interactive-API.md#worked-example-item-issues-detected-rule-callback). Which items trip the rule differs per environment (it fires on each item's data state) — run transaction-first, verify, and fall back to the Interactive API for whatever didn't stick.
+- `SUPPLIER_X_LOCATION` is keyed by `supplier_id` scoped to the selected location row in the Transaction API, so the nested pattern is safe here. (The equivalent *interactive* flow must match rows on both `location_id` and `supplier_id` — the grid holds every location's rows.)
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — patterns and gotchas verified in production (July 2026).
+
 ---
 
 ## PDF Report Generation

--- a/docs/04-Interactive-API.md
+++ b/docs/04-Interactive-API.md
@@ -626,6 +626,20 @@ Use `GET /api/ui/interactive/v2/tools?windowId={responseWindowId}` to discover w
 
 *Credit: Jon Christie*
 
+### Worked Example: "Item Issues Detected" (rule callback)
+
+A concrete `w_rule_callback_response` case from the Item window. Items with data problems pop an **"Item Issues Detected"** dialog; the Transaction API cannot get past it (the change is discarded — see [Item Service gotchas](03-Transaction-API.md#item-service-gotchas)). Interactively, it's answerable:
+
+1. Start the session with `ResponseWindowHandlingEnabled: true`.
+2. Open the `Item` window and set `item_id` on `TABPAGE_1.tp_1_dw_1`. **Some items pop the dialog at retrieve time** — the moment `item_id` is set — which blocks the location list from loading. Check the result for a `windowopened` event and answer the popup immediately, not just at save.
+3. Navigate and make your edits (e.g. select the location row on `TABPAGE_17.invloclist`, edit `TABPAGE_18.inv_loc_detail`).
+4. `save()` — if the dialog opens, the result is Status 3 (Blocked) with a `windowopened` event carrying the popup's window ID.
+5. Discover the buttons with `GET /v2/tools?windowId={popupId}`: `cb_1` = **"Yes, Proceed Anyway"**, `cb_2` = "No, Cancel". Run `cb_1` via `POST /v2/tools` with the popup's window ID; the save then commits.
+
+Which items trip the rule depends on each item's data state and differs between environments — don't hard-code a fallback list; run the Transaction API first, verify what stuck, and drive the exceptions interactively.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier).
+
 ---
 
 ## Changing Tabs
@@ -1846,6 +1860,8 @@ await http.PutAsync($"{uiUrl}/api/ui/interactive/v2/data",
 - Likely other windows with list/detail patterns
 
 **Note:** This issue may be specific to certain P21 versions or configurations. Test thoroughly with your environment.
+
+**Related trap — never `select_row` on the detail form itself.** A single-row detail form (e.g. `inv_loc_detail`) is *bound* to the currently-selected parent list row. Sending `PUT /v2/row` against the **detail** datawindow does not select within the detail — it re-selects the *parent* list (row N on the detail = row N on `invloclist`) and **silently flips which record the detail is bound to**, typically to the list's first row. The edit then lands on the wrong location while every call reports success. Select only the parent list row, edit the detail directly, and assert the detail shows exactly the intended record before and after the change (abort without saving on mismatch). The Transaction API's nested pattern keys by `location_id` and has no such trap. *(Credit: [Alex Westemeier](https://github.com/AWestemeier))*
 
 ### Row 0 Auto-Selection Quirk
 

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -435,6 +435,7 @@
 <li><a href="#service-reference">Service Reference</a><ul>
 <li><a href="#jobcontractpricing-service">JobContractPricing Service</a></li>
 <li><a href="#assembly-service">Assembly Service</a></li>
+<li><a href="#item-service-nested-location-edits">Item Service -- Nested Location Edits</a></li>
 </ul>
 </li>
 <li><a href="#pdf-report-generation">PDF Report Generation</a><ul>
@@ -2502,6 +2503,53 @@ The <code>target_date</code> edit must appear before <code>start_date</code> in 
 </code></pre></div>
 </div>
 </div>
+<h3 id="item-service-nested-location-edits">Item Service -- Nested Location Edits</h3>
+<p>The <code>Item</code> service (Item Maintenance window) supports <strong>nested DataElement navigation</strong> that mirrors the UI: select the item, select a location row, then edit that location's detail. This is the Transaction-API equivalent of "select parent row → edit child detail," and it works because the Item window's tabs aren't gated behind row selection. It's a good template for any nested edit.</p>
+<h4 id="set-an-items-primary-bin-at-a-location-form-list-form">Set an item's primary bin at a location (Form → List → Form)</h4>
+<div class="highlight"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Item&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;UseCodeValues&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Transactions&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span>
+<span class="w">        </span><span class="nt">&quot;Status&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;New&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="nt">&quot;DataElements&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">            </span><span class="p">{</span><span class="w"> </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;TABPAGE_1.tp_1_dw_1&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Form&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;item_id&quot;</span><span class="p">],</span>
+<span class="w">              </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="w"> </span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w"> </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;item_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;WIDGET-001&quot;</span><span class="p">}</span><span class="w"> </span><span class="p">]</span><span class="w"> </span><span class="p">}]</span><span class="w"> </span><span class="p">},</span>
+<span class="w">            </span><span class="p">{</span><span class="w"> </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;TABPAGE_17.invloclist&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;List&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;location_id&quot;</span><span class="p">],</span>
+<span class="w">              </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="w"> </span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w"> </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;location_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;10&quot;</span><span class="p">}</span><span class="w"> </span><span class="p">]</span><span class="w"> </span><span class="p">}]</span><span class="w"> </span><span class="p">},</span>
+<span class="w">            </span><span class="p">{</span><span class="w"> </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;TABPAGE_18.inv_loc_detail&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Form&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;location_id&quot;</span><span class="p">],</span>
+<span class="w">              </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="w"> </span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">                  </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;location_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;10&quot;</span><span class="p">},</span>
+<span class="w">                  </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;bin&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;A01-02&quot;</span><span class="p">}</span>
+<span class="w">              </span><span class="p">]</span><span class="w"> </span><span class="p">}]</span><span class="w"> </span><span class="p">}</span>
+<span class="w">        </span><span class="p">]</span>
+<span class="w">    </span><span class="p">}]</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<p><code>Status: "New"</code> with populated <code>Keys</code> updates the existing keyed record (it does not create a new item).</p>
+<h4 id="set-an-items-primary-supplier-at-a-location-form-list-list">Set an item's primary supplier at a location (Form → List → List)</h4>
+<p>Same window, one level different — the third element is the supplier list:</p>
+<div class="highlight"><pre><span></span><code><span class="p">{</span><span class="w"> </span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SUPPLIER_X_LOCATION.supplier_x_location&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;List&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Keys&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;supplier_id&quot;</span><span class="p">],</span>
+<span class="w">  </span><span class="nt">&quot;Rows&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="w"> </span><span class="nt">&quot;Edits&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">      </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;supplier_id&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;20000&quot;</span><span class="p">},</span>
+<span class="w">      </span><span class="p">{</span><span class="nt">&quot;Name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;primary_supplier&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;ON&quot;</span><span class="p">}</span>
+<span class="w">  </span><span class="p">]</span><span class="w"> </span><span class="p">}]</span><span class="w"> </span><span class="p">}</span>
+</code></pre></div>
+
+<p>What this writes, and the cascade (verified on a 68-item production run):</p>
+<ul>
+<li><code>primary_supplier</code> maps to <code>inventory_supplier_x_loc.primary_supplier</code> (a Y/N flag) — <strong>not</strong> <code>inv_loc.primary_supplier_id</code>.</li>
+<li>Setting it <code>ON</code> makes P21 auto-unset the previous primary at that location <strong>and</strong> update <code>inv_loc.primary_supplier_id</code> to the new supplier. So the flag is the field to <strong>write</strong>; <code>inv_loc.primary_supplier_id</code> is the field to <strong>read</strong> when verifying.</li>
+</ul>
+<h4 id="item-service-gotchas">Item Service Gotchas</h4>
+<ul>
+<li><strong>Silent no-op — the big one.</strong> The target supplier must already have a <em>location-level</em> row (<code>inventory_supplier_x_loc</code>) at that location. If it doesn't, the transaction still returns <code>Succeeded = 1</code> but <strong>nothing flips</strong> — there is no row to promote. (P21 allows cutting a PO to a supplier without location setup, so a supplier can appear in PO history yet be absent from the location's supplier list.) <strong>Always verify <code>inv_loc.primary_supplier_id</code> after writing</strong> — do not trust <code>Succeeded</code>. Fix: add the location supplier row first, then set the flag.</li>
+<li><strong>"Item Issues Detected" popup.</strong> Items with data problems return an <code>Unexpected response window: Item Issues Detected</code> (<code>w_rule_callback_response</code>) in the response <code>Messages</code>. The Transaction API cannot get past this popup — it effectively answers "No" and discards the change. Use the Interactive API for those items and answer the popup with <code>cb_1</code> ("Yes, Proceed Anyway") — see <a href="04-Interactive-API.html#worked-example-item-issues-detected-rule-callback">Item window popups</a>. Which items trip the rule differs per environment (it fires on each item's data state) — run transaction-first, verify, and fall back to the Interactive API for whatever didn't stick.</li>
+<li><code>SUPPLIER_X_LOCATION</code> is keyed by <code>supplier_id</code> scoped to the selected location row in the Transaction API, so the nested pattern is safe here. (The equivalent <em>interactive</em> flow must match rows on both <code>location_id</code> and <code>supplier_id</code> — the grid holds every location's rows.)</li>
+</ul>
+<blockquote>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> — patterns and gotchas verified in production (July 2026).</p>
+</blockquote>
 <hr />
 <h2 id="pdf-report-generation">PDF Report Generation</h2>
 <p>The Transaction API includes a dedicated endpoint for generating PDF documents -- purchase orders, pick tickets, and other printable reports. The endpoint returns the rendered PDF as a base64-encoded string in the response body.</p>

--- a/docs/html/04-Interactive-API.html
+++ b/docs/html/04-Interactive-API.html
@@ -416,6 +416,7 @@
 </li>
 <li><a href="#response-windows">Response Windows</a><ul>
 <li><a href="#response-window-handling-tabless-windows">Response Window Handling (Tabless Windows)</a></li>
+<li><a href="#worked-example-item-issues-detected-rule-callback">Worked Example: "Item Issues Detected" (rule callback)</a></li>
 </ul>
 </li>
 <li><a href="#changing-tabs">Changing Tabs</a></li>
@@ -1310,6 +1311,19 @@ The API returns Status as an integer. String values (<code>"Success"</code>, <co
 <p><strong>Common response window buttons:</strong> <code>cb_ok</code>, <code>cb_cancel</code>, <code>cb_finish</code>, <code>cb_yes</code>, <code>cb_no</code></p>
 <p>Use <code>GET /api/ui/interactive/v2/tools?windowId={responseWindowId}</code> to discover which buttons are available, then <code>POST /api/ui/interactive/v2/tools</code> to click them. See the <a href="#response-window-types">Response Window Types</a> section below for dismissal patterns.</p>
 <p><em>Credit: Jon Christie</em></p>
+<h3 id="worked-example-item-issues-detected-rule-callback">Worked Example: "Item Issues Detected" (rule callback)</h3>
+<p>A concrete <code>w_rule_callback_response</code> case from the Item window. Items with data problems pop an <strong>"Item Issues Detected"</strong> dialog; the Transaction API cannot get past it (the change is discarded — see <a href="03-Transaction-API.html#item-service-gotchas">Item Service gotchas</a>). Interactively, it's answerable:</p>
+<ol>
+<li>Start the session with <code>ResponseWindowHandlingEnabled: true</code>.</li>
+<li>Open the <code>Item</code> window and set <code>item_id</code> on <code>TABPAGE_1.tp_1_dw_1</code>. <strong>Some items pop the dialog at retrieve time</strong> — the moment <code>item_id</code> is set — which blocks the location list from loading. Check the result for a <code>windowopened</code> event and answer the popup immediately, not just at save.</li>
+<li>Navigate and make your edits (e.g. select the location row on <code>TABPAGE_17.invloclist</code>, edit <code>TABPAGE_18.inv_loc_detail</code>).</li>
+<li><code>save()</code> — if the dialog opens, the result is Status 3 (Blocked) with a <code>windowopened</code> event carrying the popup's window ID.</li>
+<li>Discover the buttons with <code>GET /v2/tools?windowId={popupId}</code>: <code>cb_1</code> = <strong>"Yes, Proceed Anyway"</strong>, <code>cb_2</code> = "No, Cancel". Run <code>cb_1</code> via <code>POST /v2/tools</code> with the popup's window ID; the save then commits.</li>
+</ol>
+<p>Which items trip the rule depends on each item's data state and differs between environments — don't hard-code a fallback list; run the Transaction API first, verify what stuck, and drive the exceptions interactively.</p>
+<blockquote>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a>.</p>
+</blockquote>
 <hr />
 <h2 id="changing-tabs">Changing Tabs</h2>
 <p>Before changing fields on a different tab, select the tab first:</p>
@@ -2899,6 +2913,7 @@ Row 5 selected → Detail shows row 4 (1 behind)
 - Item Maintenance (<code>Item</code> service) - Location Detail tab
 - Likely other windows with list/detail patterns</p>
 <p><strong>Note:</strong> This issue may be specific to certain P21 versions or configurations. Test thoroughly with your environment.</p>
+<p><strong>Related trap — never <code>select_row</code> on the detail form itself.</strong> A single-row detail form (e.g. <code>inv_loc_detail</code>) is <em>bound</em> to the currently-selected parent list row. Sending <code>PUT /v2/row</code> against the <strong>detail</strong> datawindow does not select within the detail — it re-selects the <em>parent</em> list (row N on the detail = row N on <code>invloclist</code>) and <strong>silently flips which record the detail is bound to</strong>, typically to the list's first row. The edit then lands on the wrong location while every call reports success. Select only the parent list row, edit the detail directly, and assert the detail shows exactly the intended record before and after the change (abort without saving on mismatch). The Transaction API's nested pattern keys by <code>location_id</code> and has no such trap. <em>(Credit: <a href="https://github.com/AWestemeier">Alex Westemeier</a>)</em></p>
 <h3 id="row-0-auto-selection-quirk">Row 0 Auto-Selection Quirk</h3>
 <p>After switching to a tab that contains a list or grid datawindow, row 0 is <strong>automatically selected</strong> by the API. Explicitly calling <code>change_row(0)</code> after switching tabs returns HTTP 422 because the row is already selected.</p>
 <p><strong>Symptom:</strong> <code>PUT /api/ui/interactive/v2/row</code> with <code>Row: 0</code> returns 422 error.</p>


### PR DESCRIPTION
## Summary
Documents the Item window patterns (credit: [Alex Westemeier](https://github.com/AWestemeier), verified in production July 2026, 68-item run):

- **doc 03**: `Item` service nested navigation — primary bin (Form→List→Form) and primary supplier (Form→List→List) recipes; `primary_supplier` flag is what you write, `inv_loc.primary_supplier_id` is what you verify; **silent no-op** when the supplier has no location-level row (Succeeded=1, nothing changes).
- **doc 04**: worked example answering the "Item Issues Detected" rule-callback popup (`cb_1` = Yes, Proceed Anyway; some items pop it at retrieve time), plus the detail-form `select_row` trap (re-selects the parent list and silently rebinds the detail).

All examples generalized.

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE