### PR TITLE
docs: OData no-joins/no-nextLink; interactive key-field commit; response-window editability reconciled

### DIFF
--- a/docs/02-OData-API.md
+++ b/docs/02-OData-API.md
@@ -31,6 +31,8 @@ The OData API provides **read-only** access to P21 data using the OData v3 proto
 https://play.p21server.com/odataservice/odata/table/supplier
 ```
 
+> **Base host, not ui_server:** OData runs on the P21 **base host** — unlike the Transaction and Interactive APIs, it does **not** use the UI server URL returned by the router endpoint. Don't prefix OData paths with the ui_server.
+
 ---
 
 ## Authentication
@@ -102,6 +104,8 @@ Skip N records (combine with $top for paging):
 ```http
 /odata/table/supplier?$skip=20&$top=10
 ```
+
+> **No `@odata.nextLink`:** P21's OData responses do **not** include a continuation link. Paging is entirely client-driven with `$skip`/`$top` — loop until a page comes back with fewer rows than `$top` (or track `@odata.count`). See the [Pagination Helper](#pagination-helper).
 
 ### $count - Get Count
 
@@ -206,6 +210,22 @@ var filterExpr = $"expiration_date ge {tomorrow}";
 ```
 
 <!-- /tabs -->
+
+### No Joins — Chain Queries by UID
+
+P21 OData has **no joins**: each request hits a single table or view. To traverse relationships, chain queries on the `_uid` key columns — every child table carries its parent's uid. Example, walking a job contract down to its bins and item IDs:
+
+```text
+job_price_hdr    $filter=contract_no eq 'A120-12'          → job_price_hdr_uid
+job_price_line   $filter=job_price_hdr_uid eq {uid}        → job_price_line_uid, inv_mast_uid
+job_price_bin    $filter=job_price_line_uid eq {line_uid}  → min_qty / max_qty / reorder_qty ...
+inv_mast         $filter=inv_mast_uid eq {im_uid}          → item_id
+```
+
+Two ways to avoid long chains:
+
+- **Check for a pre-joined view first.** Many `p21_view_*` views already join the common paths (e.g. `p21_view_bin`) — query `/odataservice/odata/view/{viewname}` instead of chaining tables.
+- **Batch the lookups** — collect the uids from one query and fetch the next level with an `or`-combined filter rather than one call per row (see [Avoiding N+1 Query Patterns](#avoiding-n1-query-patterns)).
 
 ---
 

--- a/docs/04-Interactive-API.md
+++ b/docs/04-Interactive-API.md
@@ -1908,6 +1908,22 @@ public async Task SelectRowSafeAsync(Window window, int row, string datawindowNa
 
 **Important:** This is different from the [row selection synchronization bug](#row-selection-synchronization-bug-list--detail) documented above. That bug is about list-to-detail data sync being one row behind. This quirk is specifically about row 0 being pre-selected after a tab switch.
 
+### Key Fields Commit the Cursor (Later Fields Silently Ignored)
+
+Sending a grid row's **key field** in a `change` request commits the row cursor — any field in the same `List` (or a later call) that follows the key field is **silently ignored** (the call still returns Status 0/Success). Example: on the JobContractPricing BINS grid, `contract_bin_id` is the key; if it appears before the quantity fields, the quantities never land.
+
+**Guidance:**
+
+- When only *changing* values on an already-selected row, **don't send the key field at all** — select the row, then change the non-key fields.
+- When the key field must be sent (identifying a row by value), send it **last**.
+- After the save, read the values back — a silently-dropped edit is indistinguishable from success by status code alone (see [Verifying Writes](#verifying-writes-dont-trust-save-status-alone)).
+
+*(Credit: [Alex Westemeier](https://github.com/AWestemeier))*
+
+### Numeric Values: Send Integer Strings for Whole Numbers
+
+When setting numeric fields, send whole numbers as integer strings (`"30"`), not float-formatted strings (`"30.0"`) — some windows reject or mishandle the float form. Format values the way a user would type them.
+
 ---
 
 ## v1 vs v2 API Differences
@@ -2017,6 +2033,15 @@ On window open, 7 tabs are disabled: `CUSTSHIPTOCONSIGN`, `BINS`, `VALUES`, `BIN
 3. Set `item_id` on `SHIP_TO_ITEM` and dismiss the scan lookup dialog — enables `VALUES`, `BINS`, `BIN_ITEMS`, `ITEM_BIN_NOTES` simultaneously
 
 > **Important:** P21 rejects setting `customer_id` or `ship_to_id` on the FORM header directly. You must create the combination on `CUSTOMER_SHIP_TO` first. Error: *"Before selecting a Customer ID or Ship To ID, make sure that the combination exists in the Customer/Ship To tab."*
+
+**Example: JobContractPricing — EXISTING contract (BINS editing).** The sequence above is the *creation* flow. For an existing contract, the combination already exists and the recipe differs (verified; credit: [Alex Westemeier](https://github.com/AWestemeier)):
+
+1. Load the contract by setting `job_no`, `customer_id`, and `ship_to_id` on `FORM/d_dw_job_price_hdr` (three separate change calls). **Load by `job_no`, not `contract_no`** — renewals can leave the same `contract_no` on two header rows, while `job_no` is unique.
+2. Change to the `CUSTOMER_SHIP_TO` tab and **select the ship-to's grid row** — the BINS tab only unlocks after the ship-to row is selected. Skipping this (or loading by `contract_no` alone) leaves it disabled with *"Tab page is disabled and cannot be selected."*
+3. Per line: `JOBPRICELINE` tab → select the line's row → `BINS` tab → the grid is **filtered to the selected ship-to**, so it has exactly one row per line — `select_row("bins", 1)` always targets the right bin. Edit the quantity fields.
+4. One `save()` at the end persists every edit in the session (save per ship-to on large runs so a mid-run failure doesn't lose everything).
+
+> For bulk bin-quantity changes, the Transaction API with `IgnoreDisabled: true` is faster — see [Editing Bin Quantities](03-Transaction-API.md#editing-bin-quantities-on-an-existing-contract). Use this interactive recipe when a Transaction-API edge case appears or the contract is expired-adjacent work that needs window logic.
 
 **Detecting tab unlock events:**
 
@@ -2228,10 +2253,11 @@ Response windows fall into distinct categories based on what interactions they s
 | Type | Example | Buttons | Field Input | Dismiss Method |
 |------|---------|---------|-------------|----------------|
 | **Button-only dialog** | `w_rule_callback_response` | `cb_1` through `cb_5` | N/A | `POST /tools` with button name |
-| **Form + button dialog** | `w_inventory_scan_lookup` | `cb_ok`, `cb_cancel` | Fields visible but **not writable** via API | `POST /tools` with button name |
+| **Form + button dialog** | `w_inventory_scan_lookup` | `cb_ok`, `cb_cancel` | See editability note below | `POST /tools` with button name |
+| **Editable form dialog** | `w_notepad_response_lite` | `cb_select_all`, `cb_ok` | **Editable with `TabName: null`** | Fill fields, then `POST /tools` |
 | **Message box** | `w_message` | Default-answered | Cannot be inspected | Auto-answered when `ResponseWindowHandlingEnabled: false` |
 
-**Key limitation (verified April 2026):** Form-type response windows can only be **dismissed** (button click), not **interacted with** (field changes). `GET /data` returns 400 and `PUT /change` returns 500 with *"Tab with name FORM does not exist"*. Workflows that depend on filling response window fields cannot be fully automated.
+**Editability (reconciled July 2026):** earlier testing (April 2026) concluded form-type response windows could only be dismissed — `GET /data` returned 400 and `PUT /change` returned 500 with *"Tab with name FORM does not exist"*. Those change attempts addressed the popup's fields with `TabName: "FORM"`. Later work showed form-style response windows **are editable** when the change request uses **`TabName: null`** with the popup's window ID — verified end-to-end on `w_notepad_response_lite` (see [PurchaseOrder Notepad Writes](#purchaseorder-notepad-writes-header-vs-line)). If a popup's fields reject edits, retry with `TabName: null` before concluding the window is dismiss-only. `w_message` boxes remain uneditable and are auto-answered.
 
 **Inspecting and dismissing response windows:**
 

--- a/docs/html/02-OData-API.html
+++ b/docs/html/02-OData-API.html
@@ -412,6 +412,7 @@
 <li><a href="#common-patterns">Common Patterns</a><ul>
 <li><a href="#active-record-filter">Active Record Filter</a></li>
 <li><a href="#non-expired-records">Non-Expired Records</a></li>
+<li><a href="#no-joins-chain-queries-by-uid">No Joins — Chain Queries by UID</a></li>
 </ul>
 </li>
 <li><a href="#data-type-formatting">Data Type Formatting</a><ul>
@@ -504,6 +505,9 @@
 <div class="highlight"><pre><span></span><code><span class="err">https://play.p21server.com/odataservice/odata/table/supplier</span>
 </code></pre></div>
 
+<blockquote>
+<p><strong>Base host, not ui_server:</strong> OData runs on the P21 <strong>base host</strong> — unlike the Transaction and Interactive APIs, it does <strong>not</strong> use the UI server URL returned by the router endpoint. Don't prefix OData paths with the ui_server.</p>
+</blockquote>
 <hr />
 <h2 id="authentication">Authentication</h2>
 <p>Include the Bearer token in the Authorization header:</p>
@@ -552,6 +556,9 @@
 <div class="highlight"><pre><span></span><code><span class="err">/odata/table/supplier?$skip=20&amp;$top=10</span>
 </code></pre></div>
 
+<blockquote>
+<p><strong>No <code>@odata.nextLink</code>:</strong> P21's OData responses do <strong>not</strong> include a continuation link. Paging is entirely client-driven with <code>$skip</code>/<code>$top</code> — loop until a page comes back with fewer rows than <code>$top</code> (or track <code>@odata.count</code>). See the <a href="#pagination-helper">Pagination Helper</a>.</p>
+</blockquote>
 <h3 id="count-get-count">$count - Get Count</h3>
 <p>Include total count in response:</p>
 <div class="highlight"><pre><span></span><code><span class="err">/odata/table/supplier?$count=true</span>
@@ -695,6 +702,19 @@
 </code></pre></div>
 </div>
 </div>
+<h3 id="no-joins-chain-queries-by-uid">No Joins — Chain Queries by UID</h3>
+<p>P21 OData has <strong>no joins</strong>: each request hits a single table or view. To traverse relationships, chain queries on the <code>_uid</code> key columns — every child table carries its parent's uid. Example, walking a job contract down to its bins and item IDs:</p>
+<div class="highlight"><pre><span></span><code>job_price_hdr    $filter=contract_no eq &#39;A120-12&#39;          → job_price_hdr_uid
+job_price_line   $filter=job_price_hdr_uid eq {uid}        → job_price_line_uid, inv_mast_uid
+job_price_bin    $filter=job_price_line_uid eq {line_uid}  → min_qty / max_qty / reorder_qty ...
+inv_mast         $filter=inv_mast_uid eq {im_uid}          → item_id
+</code></pre></div>
+
+<p>Two ways to avoid long chains:</p>
+<ul>
+<li><strong>Check for a pre-joined view first.</strong> Many <code>p21_view_*</code> views already join the common paths (e.g. <code>p21_view_bin</code>) — query <code>/odataservice/odata/view/{viewname}</code> instead of chaining tables.</li>
+<li><strong>Batch the lookups</strong> — collect the uids from one query and fetch the next level with an <code>or</code>-combined filter rather than one call per row (see <a href="#avoiding-n1-query-patterns">Avoiding N+1 Query Patterns</a>).</li>
+</ul>
 <hr />
 <h2 id="data-type-formatting">Data Type Formatting</h2>
 <table>

--- a/docs/html/04-Interactive-API.html
+++ b/docs/html/04-Interactive-API.html
@@ -464,6 +464,8 @@
 <li><a href="#known-issues-and-workarounds">Known Issues and Workarounds</a><ul>
 <li><a href="#row-selection-synchronization-bug-list-detail">Row Selection Synchronization Bug (List → Detail)</a></li>
 <li><a href="#row-0-auto-selection-quirk">Row 0 Auto-Selection Quirk</a></li>
+<li><a href="#key-fields-commit-the-cursor-later-fields-silently-ignored">Key Fields Commit the Cursor (Later Fields Silently Ignored)</a></li>
+<li><a href="#numeric-values-send-integer-strings-for-whole-numbers">Numeric Values: Send Integer Strings for Whole Numbers</a></li>
 </ul>
 </li>
 <li><a href="#v1-vs-v2-api-differences">v1 vs v2 API Differences</a><ul>
@@ -2952,6 +2954,17 @@ Row 5 selected → Detail shows row 4 (1 behind)
 </div>
 </div>
 <p><strong>Important:</strong> This is different from the <a href="#row-selection-synchronization-bug-list--detail">row selection synchronization bug</a> documented above. That bug is about list-to-detail data sync being one row behind. This quirk is specifically about row 0 being pre-selected after a tab switch.</p>
+<h3 id="key-fields-commit-the-cursor-later-fields-silently-ignored">Key Fields Commit the Cursor (Later Fields Silently Ignored)</h3>
+<p>Sending a grid row's <strong>key field</strong> in a <code>change</code> request commits the row cursor — any field in the same <code>List</code> (or a later call) that follows the key field is <strong>silently ignored</strong> (the call still returns Status 0/Success). Example: on the JobContractPricing BINS grid, <code>contract_bin_id</code> is the key; if it appears before the quantity fields, the quantities never land.</p>
+<p><strong>Guidance:</strong></p>
+<ul>
+<li>When only <em>changing</em> values on an already-selected row, <strong>don't send the key field at all</strong> — select the row, then change the non-key fields.</li>
+<li>When the key field must be sent (identifying a row by value), send it <strong>last</strong>.</li>
+<li>After the save, read the values back — a silently-dropped edit is indistinguishable from success by status code alone (see <a href="#verifying-writes-dont-trust-save-status-alone">Verifying Writes</a>).</li>
+</ul>
+<p><em>(Credit: <a href="https://github.com/AWestemeier">Alex Westemeier</a>)</em></p>
+<h3 id="numeric-values-send-integer-strings-for-whole-numbers">Numeric Values: Send Integer Strings for Whole Numbers</h3>
+<p>When setting numeric fields, send whole numbers as integer strings (<code>"30"</code>), not float-formatted strings (<code>"30.0"</code>) — some windows reject or mishandle the float form. Format values the way a user would type them.</p>
 <hr />
 <h2 id="v1-vs-v2-api-differences">v1 vs v2 API Differences</h2>
 <blockquote>
@@ -3093,6 +3106,16 @@ Row 5 selected → Detail shows row 4 (1 behind)
 </ol>
 <blockquote>
 <p><strong>Important:</strong> P21 rejects setting <code>customer_id</code> or <code>ship_to_id</code> on the FORM header directly. You must create the combination on <code>CUSTOMER_SHIP_TO</code> first. Error: <em>"Before selecting a Customer ID or Ship To ID, make sure that the combination exists in the Customer/Ship To tab."</em></p>
+</blockquote>
+<p><strong>Example: JobContractPricing — EXISTING contract (BINS editing).</strong> The sequence above is the <em>creation</em> flow. For an existing contract, the combination already exists and the recipe differs (verified; credit: <a href="https://github.com/AWestemeier">Alex Westemeier</a>):</p>
+<ol>
+<li>Load the contract by setting <code>job_no</code>, <code>customer_id</code>, and <code>ship_to_id</code> on <code>FORM/d_dw_job_price_hdr</code> (three separate change calls). <strong>Load by <code>job_no</code>, not <code>contract_no</code></strong> — renewals can leave the same <code>contract_no</code> on two header rows, while <code>job_no</code> is unique.</li>
+<li>Change to the <code>CUSTOMER_SHIP_TO</code> tab and <strong>select the ship-to's grid row</strong> — the BINS tab only unlocks after the ship-to row is selected. Skipping this (or loading by <code>contract_no</code> alone) leaves it disabled with <em>"Tab page is disabled and cannot be selected."</em></li>
+<li>Per line: <code>JOBPRICELINE</code> tab → select the line's row → <code>BINS</code> tab → the grid is <strong>filtered to the selected ship-to</strong>, so it has exactly one row per line — <code>select_row("bins", 1)</code> always targets the right bin. Edit the quantity fields.</li>
+<li>One <code>save()</code> at the end persists every edit in the session (save per ship-to on large runs so a mid-run failure doesn't lose everything).</li>
+</ol>
+<blockquote>
+<p>For bulk bin-quantity changes, the Transaction API with <code>IgnoreDisabled: true</code> is faster — see <a href="03-Transaction-API.html#editing-bin-quantities-on-an-existing-contract">Editing Bin Quantities</a>. Use this interactive recipe when a Transaction-API edge case appears or the contract is expired-adjacent work that needs window logic.</p>
 </blockquote>
 <p><strong>Detecting tab unlock events:</strong></p>
 <div class="code-tabs">
@@ -3311,8 +3334,15 @@ Row 5 selected → Detail shows row 4 (1 behind)
 <td><strong>Form + button dialog</strong></td>
 <td><code>w_inventory_scan_lookup</code></td>
 <td><code>cb_ok</code>, <code>cb_cancel</code></td>
-<td>Fields visible but <strong>not writable</strong> via API</td>
+<td>See editability note below</td>
 <td><code>POST /tools</code> with button name</td>
+</tr>
+<tr>
+<td><strong>Editable form dialog</strong></td>
+<td><code>w_notepad_response_lite</code></td>
+<td><code>cb_select_all</code>, <code>cb_ok</code></td>
+<td><strong>Editable with <code>TabName: null</code></strong></td>
+<td>Fill fields, then <code>POST /tools</code></td>
 </tr>
 <tr>
 <td><strong>Message box</strong></td>
@@ -3323,7 +3353,7 @@ Row 5 selected → Detail shows row 4 (1 behind)
 </tr>
 </tbody>
 </table>
-<p><strong>Key limitation (verified April 2026):</strong> Form-type response windows can only be <strong>dismissed</strong> (button click), not <strong>interacted with</strong> (field changes). <code>GET /data</code> returns 400 and <code>PUT /change</code> returns 500 with <em>"Tab with name FORM does not exist"</em>. Workflows that depend on filling response window fields cannot be fully automated.</p>
+<p><strong>Editability (reconciled July 2026):</strong> earlier testing (April 2026) concluded form-type response windows could only be dismissed — <code>GET /data</code> returned 400 and <code>PUT /change</code> returned 500 with <em>"Tab with name FORM does not exist"</em>. Those change attempts addressed the popup's fields with <code>TabName: "FORM"</code>. Later work showed form-style response windows <strong>are editable</strong> when the change request uses <strong><code>TabName: null</code></strong> with the popup's window ID — verified end-to-end on <code>w_notepad_response_lite</code> (see <a href="#purchaseorder-notepad-writes-header-vs-line">PurchaseOrder Notepad Writes</a>). If a popup's fields reject edits, retry with <code>TabName: null</code> before concluding the window is dismiss-only. <code>w_message</code> boxes remain uneditable and are auto-answered.</p>
 <p><strong>Inspecting and dismissing response windows:</strong></p>
 <div class="code-tabs">
   <div class="tab-buttons">


### PR DESCRIPTION
## Summary
Final batch of cross-check corrections (credit: [Alex Westemeier](https://github.com/AWestemeier)) plus one internal reconciliation:

- **doc 02**: P21 OData returns no `@odata.nextLink` (client-driven `$skip`/`$top` paging); OData runs on the base host, not the ui_server; new "No Joins — Chain Queries by UID" section with `p21_view_*` guidance.
- **doc 04**: the April 2026 claim that form-type response windows are dismiss-only used `TabName: "FORM"` — reconciled with the July 2026 finding that they're editable via `TabName: null` (verified on `w_notepad_response_lite`). New known issues: key fields commit the cursor (later fields silently ignored — send keys last or omit), integer-string numerics. Added the verified BINS unlock recipe for **existing** contracts (load by `job_no`; renewals duplicate `contract_no`).

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE