### PR TITLE
docs: recipes cookbook — 10 self-contained task pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ When editing docs, keep INDEX.md's anchors in sync (renaming a heading breaks it
 p21-api-documentation/
 ├── docs/
 │   ├── INDEX.md                 # Task → section routing map (start here)
+│   ├── recipes/                 # Self-contained copy-and-run task pages (one task = one page)
 │   ├── 00-Authentication.md
 │   ├── 01-API-Selection-Guide.md
 │   ├── 02-OData-API.md

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,6 +4,8 @@
 
 Every task assumes you already have a token and (for Transaction/Interactive) the UI server URL — see [Getting a token](#first-call-of-any-session) below.
 
+**Doing, not studying?** The [recipes cookbook](recipes/README.md) has self-contained copy-and-run pages (complete payload + full script + gotchas) for the most common tasks — start there and fall back to the manual sections for depth.
+
 ---
 
 ## First call of any session
@@ -48,17 +50,16 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 
 ### By record type
 
-| Task | Where |
-|------|-------|
-| Create a **sales order** + gotchas (source_loc_id, dates, DynaChange) | [03 § Create Order](03-Transaction-API.md#create-order) · [03 § Order Service Gotchas](03-Transaction-API.md#order-service-gotchas) |
-| Order with an **assembly line** (explode / spawn prod order) | [04 § Sales Order Entry with Assembly Lines](04-Interactive-API.md#sales-order-entry-with-assembly-lines) |
-| **Job contract**: create, lines, breaks | [03 § JobContractPricing Service](03-Transaction-API.md#jobcontractpricing-service) |
-| Job contract: update / add lines | [03 § Updating an Existing Contract](03-Transaction-API.md#updating-an-existing-contract) · [03 § Upsert Semantics](03-Transaction-API.md#upsert-semantics----keyed-rows-insert-when-absent) |
-| Job contract: **bin quantities** | [03 § Editing Bin Quantities](03-Transaction-API.md#editing-bin-quantities-on-an-existing-contract) (Interactive fallback: [04 § Tab Unlock Sequences](04-Interactive-API.md#tab-unlock-sequences)) |
-| Job contract: commission costs | [03 § Commission Costs](03-Transaction-API.md#commission-costs) |
-| **Assembly / BOM** definition | [03 § Assembly Service](03-Transaction-API.md#assembly-service) |
-| Item: **primary bin / primary supplier** at a location | [03 § Item Service](03-Transaction-API.md#item-service----nested-location-edits) |
-| **Create warehouse bins** | [03 § BinLocation Service](03-Transaction-API.md#binlocation-service----creating-bins) |
+| Task | Recipe | Manual |
+|------|--------|--------|
+| Create a **sales order** + gotchas (source_loc_id, dates, DynaChange) | [create-sales-order](recipes/create-sales-order.md) | [03 § Create Order](03-Transaction-API.md#create-order) · [03 § Order Service Gotchas](03-Transaction-API.md#order-service-gotchas) |
+| Order with an **assembly line** (explode / spawn prod order) | [order-with-assembly](recipes/order-with-assembly.md) | [04 § Sales Order Entry with Assembly Lines](04-Interactive-API.md#sales-order-entry-with-assembly-lines) |
+| **Job contract**: create, lines, breaks | — | [03 § JobContractPricing Service](03-Transaction-API.md#jobcontractpricing-service) |
+| Job contract: update / add lines / commission costs | [update-contract-lines](recipes/update-contract-lines.md) | [03 § Updating an Existing Contract](03-Transaction-API.md#updating-an-existing-contract) · [03 § Upsert Semantics](03-Transaction-API.md#upsert-semantics----keyed-rows-insert-when-absent) · [03 § Commission Costs](03-Transaction-API.md#commission-costs) |
+| Job contract: **bin quantities** | [edit-contract-bins](recipes/edit-contract-bins.md) | [03 § Editing Bin Quantities](03-Transaction-API.md#editing-bin-quantities-on-an-existing-contract) (Interactive fallback: [04 § Tab Unlock Sequences](04-Interactive-API.md#tab-unlock-sequences)) |
+| **Assembly / BOM** definition | — | [03 § Assembly Service](03-Transaction-API.md#assembly-service) |
+| Item: **primary bin / primary supplier** at a location | [set-primary-bin-supplier](recipes/set-primary-bin-supplier.md) | [03 § Item Service](03-Transaction-API.md#item-service----nested-location-edits) |
+| **Create warehouse bins** | [create-bins](recipes/create-bins.md) | [03 § BinLocation Service](03-Transaction-API.md#binlocation-service----creating-bins) |
 | **Sales price pages** (codes, breaks, field order) | [08 SalesPricePage Codes](08-SalesPricePage-Codes.md) |
 | Customers / vendors / contacts / addresses (simple CRUD) | [05 § CRUD Operations](05-Entity-API.md#crud-operations) |
 | Inventory items: read / create / update locations | [11 § Reading Items](11-Inventory-REST-API.md#reading-items) · [11 § Minimum Create Payload](11-Inventory-REST-API.md#minimum-create-payload) · [11 § Updating Existing Location Fields](11-Inventory-REST-API.md#updating-existing-location-fields) |
@@ -89,20 +90,20 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 |------|-------|
 | Service catalog & schemas (ProductionOrder, TimeEntry, …) | [12 § Available Services](12-Production-Labor-API.md#available-services) |
 | Assembly behavior flags (prod-order vs kit vs build-to-stock) | [12 § Assembly Behavior Flags](12-Production-Labor-API.md#assembly-behavior-flags) |
-| **Full runbook: create → print → confirm → complete → ship** | [12 § Production Order Lifecycle](12-Production-Labor-API.md#production-order-lifecycle-end-to-end) |
+| **Full runbook: create → print → confirm → complete → ship** | [recipe: production-order-runbook](recipes/production-order-runbook.md) · [12 § Production Order Lifecycle](12-Production-Labor-API.md#production-order-lifecycle-end-to-end) |
 | Pick ticket won't generate (make loc vs stock loc) | [12 § Printing the Pick Ticket](12-Production-Labor-API.md#printing-the-pick-ticket-and-form) · [03 § m_picktickets example](03-Transaction-API.md#example-generate-a-production-order-pick-ticket-m_picktickets) |
 | Confirm a pick (shell-confirm trap — use Interactive) | [12 § Confirming the Pick](12-Production-Labor-API.md#confirming-the-pick--use-the-interactive-api) |
 | Complete / production receipt (+ per-component cost override) | [12 § Completing the Production Order](12-Production-Labor-API.md#completing-the-production-order-production-receipt) |
-| Record labor hours | [12 § Recording Labor Hours](12-Production-Labor-API.md#recording-labor-hours-timeentry-service) · [12 § Time Entry Against a Production Order](12-Production-Labor-API.md#time-entry-against-a-production-order-quick-time-entry) |
+| Record labor hours | [recipe: record-labor-time](recipes/record-labor-time.md) · [12 § Recording Labor Hours](12-Production-Labor-API.md#recording-labor-hours-timeentry-service) · [12 § Time Entry Against a Production Order](12-Production-Labor-API.md#time-entry-against-a-production-order-quick-time-entry) |
 | Ship + invoice | [12 § Shipping and Invoicing](12-Production-Labor-API.md#shipping-and-invoicing-the-linked-sales-order) |
-| Inventory write-off / adjustment | [12 § Inventory Adjustment](12-Production-Labor-API.md#inventory-adjustment-write-offs) |
+| Inventory write-off / adjustment | [recipe: inventory-adjustment](recipes/inventory-adjustment.md) · [12 § Inventory Adjustment](12-Production-Labor-API.md#inventory-adjustment-write-offs) |
 | Why COGS doesn't match the receipt | [12 § Cost Model](12-Production-Labor-API.md#cost-model--know-this-before-trusting-cogs) |
 
 ## Documents & reports (PDF)
 
 | Task | Where |
 |------|-------|
-| Generate any `m_*` report as PDF | [03 § PDF Report Generation](03-Transaction-API.md#pdf-report-generation) |
+| Generate any `m_*` report as PDF | [recipe: generate-pick-ticket-pdf](recipes/generate-pick-ticket-pdf.md) · [03 § PDF Report Generation](03-Transaction-API.md#pdf-report-generation) |
 | Discover callable report names (hidden from /services) | [03 § PDF Report Generation](03-Transaction-API.md#pdf-report-generation) (Discovery note) |
 | Production pick ticket at a specific location | [03 § m_picktickets example](03-Transaction-API.md#example-generate-a-production-order-pick-ticket-m_picktickets) |
 | PDFs from print flags on a normal transaction | [03 § PDFs from the /transaction endpoint](03-Transaction-API.md#pdfs-from-the-transaction-endpoint-print-flags) |

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,104 @@
+# Recipes — Copy-and-Run Task Pages
+
+One page per task, **self-contained**: the complete working payload, a full runnable script (Python and C#), the verified gotchas, and a verify step. Doing one task? Load one recipe — not the whole manual. For concept depth, each recipe links into the [manual](../INDEX.md); for the complete field list of any service, load its JSON from [`definitions/`](../../definitions/README.md).
+
+> If you're an AI assistant: read this file, then **only** the recipe for your task. The recipe is the source of truth for that process; the manual sections it links to are the deep dive.
+
+## Index
+
+| Recipe | Task | API |
+|--------|------|-----|
+| [update-contract-lines](update-contract-lines.md) | Update or insert job-contract lines, prices, commission costs | Transaction |
+| [edit-contract-bins](edit-contract-bins.md) | Change contract bin min/max/reorder/capacity | Transaction (`IgnoreDisabled`), Interactive fallback |
+| [create-bins](create-bins.md) | Bulk-create warehouse bins | Transaction (`BinLocation`) |
+| [create-sales-order](create-sales-order.md) | Create a sales order | Transaction (`Order`) |
+| [order-with-assembly](order-with-assembly.md) | Order a line that explodes / spawns a production order | Interactive |
+| [set-primary-bin-supplier](set-primary-bin-supplier.md) | Set an item's primary bin or primary supplier at a location | Transaction (`Item`), Interactive fallback |
+| [generate-pick-ticket-pdf](generate-pick-ticket-pdf.md) | Generate/reprint pick tickets and POs as PDF | `pdfreport` (`m_*` services) |
+| [production-order-runbook](production-order-runbook.md) | Full production cycle: create → print → confirm → complete → ship | Transaction + Interactive |
+| [record-labor-time](record-labor-time.md) | Post labor hours to a production order | Transaction (`TimeEntry`) |
+| [inventory-adjustment](inventory-adjustment.md) | Adjust on-hand quantity (write-offs) | Transaction (`InventoryAdjustment`) |
+
+## Shared conventions (recipes don't repeat these)
+
+**Environment.** Examples use `https://play.p21server.com` with user `api_user` and generic data (`ACME`, `WIDGET-001`, customer `100198`). Substitute your own. Always run against a **test/play environment first**.
+
+**Auth preamble.** Every script below starts with this (shown once here; recipes reference `p21_auth()` / `P21Session.CreateAsync()`):
+
+<!-- tabs -->
+```python
+import httpx
+
+def p21_auth(base_url: str, username: str, password: str) -> tuple[str, str, dict]:
+    """Authenticate and resolve the UI server. Returns (token, ui_server, headers)."""
+    auth = httpx.post(
+        f"{base_url}/api/security/token/v2",
+        json={"username": username, "password": password},
+        headers={"Accept": "application/json"},
+        verify=False,
+    )
+    auth.raise_for_status()
+    token = auth.json()["AccessToken"]
+
+    router = httpx.get(
+        f"{base_url}/api/ui/router/v1/?urlType=external",  # trailing slash avoids a 307
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        verify=False, follow_redirects=True,
+    )
+    router.raise_for_status()
+    ui_server = router.json()["Url"].rstrip("/")
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    return token, ui_server, headers
+```
+
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+public sealed class P21Session
+{
+    public required HttpClient Http { get; init; }
+    public required string UiServer { get; init; }
+
+    public static async Task<P21Session> CreateAsync(
+        string baseUrl, string username, string password)
+    {
+        var http = new HttpClient();
+        http.DefaultRequestHeaders.Add("Accept", "application/json");
+
+        var authBody = new JObject { ["username"] = username, ["password"] = password };
+        var authResp = await http.PostAsync(
+            $"{baseUrl}/api/security/token/v2",
+            new StringContent(authBody.ToString(), Encoding.UTF8, "application/json"));
+        authResp.EnsureSuccessStatusCode();
+        var token = JObject.Parse(await authResp.Content.ReadAsStringAsync())["AccessToken"]!.ToString();
+
+        http.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        // trailing slash avoids a 307 redirect on some installs
+        var routerResp = await http.GetAsync($"{baseUrl}/api/ui/router/v1/?urlType=external");
+        routerResp.EnsureSuccessStatusCode();
+        var uiServer = JObject.Parse(await routerResp.Content.ReadAsStringAsync())["Url"]!
+            .ToString().TrimEnd('/');
+
+        return new P21Session { Http = http, UiServer = uiServer };
+    }
+}
+```
+<!-- /tabs -->
+
+**Check the result, not the HTTP status.** The Transaction API returns HTTP 200 even when everything failed. Every recipe checks `Summary.Succeeded` / `Summary.Failed` and prints `Messages` on failure; transactions in one POST pass/fail independently.
+
+**Verify after writing.** A `Succeeded` response is not proof the value landed (field-order cascades and silent no-ops exist). Each recipe ends with a read-back — OData or `POST /api/v2/transaction/get`.
+
+**Full field lists.** Recipes show the fields that matter for the task. For *every* field a service accepts (names, types, keys, labels, payload template), load `definitions/{Service}.json` — see the [definitions README](../../definitions/README.md).
+
+> **Credit:** the cookbook pattern and much of the verified content come from [Alex Westemeier](https://github.com/AWestemeier)'s process playbook.

--- a/docs/recipes/create-bins.md
+++ b/docs/recipes/create-bins.md
@@ -1,0 +1,242 @@
+# Create Bins (Bulk)
+
+Bulk-create warehouse bins with the `BinLocation` service — one transaction per bin, tens per POST, verified in production at hundreds of bins per run.
+
+**API:** Transaction · **Service:** `BinLocation` · **Deep dive:** [BinLocation Service — Creating Bins](../03-Transaction-API.md#binlocation-service----creating-bins), [IgnoreDisabled](../03-Transaction-API.md#ignoredisabled) · **Full schema:** [`definitions/BinLocation.json`](../../definitions/BinLocation.json)
+
+The `BinLocation` service *is* the **Bin Location Maintenance** window: its form element `FORM.form` is business object `bin` (datawindow `d_dw_bin_form`), and every field in the payload is a real field on that screen.
+
+## Prerequisites
+
+- Bearer token + UI server from the [shared auth helper](README.md#shared-conventions-recipes-dont-repeat-these).
+- A **"twin"** — an existing bin of the same `bin_type` at the target location. Copy its type, both zone codes, dimensions, sequences, `max_unique_items`, and flags rather than inventing them; that guarantees new bins match what the warehouse already uses. (Zone codes come from joining `bin.putaway_zone_uid` / `bin.pick_zone_uid` → `bin_zone.bin_zone_uid` → `bin_zone.bin_zone_id`.)
+- OData read access to the `p21_view_bin` view — for the skip-existing check and the read-back (the raw `bin` table isn't always exposed via OData).
+
+## Payload
+
+One bin per Transaction. `Status: "New"` with the three-field key makes this a **create** when the `(company_id, location_id, bin_id)` combination doesn't exist yet. Note `IgnoreDisabled: true` at the **top level** — not inside a Transaction (see Gotchas).
+
+```json
+{
+  "Name": "BinLocation",
+  "UseCodeValues": false,
+  "IgnoreDisabled": true,
+  "Transactions": [
+    {
+      "Status": "New",
+      "DataElements": [
+        { "Name": "FORM.form", "Type": "Form",
+          "Keys": ["company_id", "location_id", "bin_id"],
+          "Rows": [ { "Edits": [
+            {"Name": "company_id",      "Value": "ACME"},
+            {"Name": "location_id",     "Value": "10"},
+            {"Name": "bin_id",          "Value": "A01-02-03"},
+            {"Name": "bin_type",        "Value": "SHELF"},
+            {"Name": "putaway_zone_id", "Value": "ZONE-A"},
+            {"Name": "pick_zone_id",    "Value": "ZONE-A"},
+            {"Name": "bin_length", "Value": "10"}, {"Name": "bin_width", "Value": "10"}, {"Name": "bin_height", "Value": "11"},
+            {"Name": "warehouse_sequence", "Value": "1"}, {"Name": "putaway_zone_sequence", "Value": "1"}, {"Name": "pick_zone_sequence", "Value": "1"},
+            {"Name": "max_unique_items", "Value": "0"},
+            {"Name": "pick_locked_flag", "Value": "OFF"}, {"Name": "put_locked_flag", "Value": "OFF"},
+            {"Name": "full_flag", "Value": "OFF"}, {"Name": "frozen_flag", "Value": "OFF"},
+            {"Name": "consolidation_bin_flag", "Value": "OFF"}, {"Name": "stage_bin_flag", "Value": "OFF"}, {"Name": "door_bin_flag", "Value": "OFF"}
+          ] } ] }
+      ]
+    }
+  ]
+}
+```
+
+## Complete example
+
+Builds each bin's transaction from a twin's constants, skips bins that already exist (re-running is then safe), batches several transactions per POST, and checks per-transaction results — not the HTTP status.
+
+<!-- tabs -->
+```python
+import httpx
+
+BASE_URL = "https://play.p21server.com"
+token, ui_server, headers = p21_auth(BASE_URL, "api_user", "password")
+
+COMPANY_ID = "ACME"
+LOCATION_ID = "10"
+NEW_BIN_IDS = ["A01-02-01", "A01-02-02", "A01-02-03", "A01-02-04"]
+
+# Constants cloned from a "twin" bin of the same bin_type at this location.
+# Flags come back Y/N from the database — convert to ON/OFF for the form.
+TWIN = {
+    "bin_type": "SHELF",
+    "putaway_zone_id": "ZONE-A", "pick_zone_id": "ZONE-A",
+    "bin_length": "10", "bin_width": "10", "bin_height": "11",
+    "warehouse_sequence": "1", "putaway_zone_sequence": "1", "pick_zone_sequence": "1",
+    "max_unique_items": "0",
+    "pick_locked_flag": "OFF", "put_locked_flag": "OFF",
+    "full_flag": "OFF", "frozen_flag": "OFF",
+    "consolidation_bin_flag": "OFF", "stage_bin_flag": "OFF", "door_bin_flag": "OFF",
+}
+
+
+def build_bin_transaction(bin_id: str, location_id: str, twin: dict) -> dict:
+    """One Transaction object per bin (keys first, then the twin's constants)."""
+    edits = [
+        {"Name": "company_id", "Value": COMPANY_ID},
+        {"Name": "location_id", "Value": location_id},
+        {"Name": "bin_id", "Value": bin_id},
+    ] + [{"Name": name, "Value": value} for name, value in twin.items()]
+    return {
+        "Status": "New",
+        "DataElements": [{
+            "Name": "FORM.form", "Type": "Form",
+            "Keys": ["company_id", "location_id", "bin_id"],
+            "Rows": [{"Edits": edits}],
+        }],
+    }
+
+
+# Skip-existing check via the p21_view_bin view (raw bin table isn't always in OData)
+existing_resp = httpx.get(
+    f"{BASE_URL}/odataservice/odata/view/p21_view_bin",
+    params={"$filter": f"location_id eq {LOCATION_ID}", "$select": "bin_id"},
+    headers=headers, verify=False,
+)
+existing_resp.raise_for_status()
+existing = {row["bin_id"] for row in existing_resp.json()["value"]}
+
+to_create = [b for b in NEW_BIN_IDS if b not in existing]
+print(f"{len(NEW_BIN_IDS) - len(to_create)} already exist, creating {len(to_create)}")
+
+BATCH_SIZE = 20  # tens of transactions per POST is fine and fast
+for start in range(0, len(to_create), BATCH_SIZE):
+    batch = to_create[start:start + BATCH_SIZE]
+    payload = {
+        "Name": "BinLocation",
+        "UseCodeValues": False,
+        "IgnoreDisabled": True,  # TOP LEVEL — inside a Transaction it is silently ignored
+        "Transactions": [build_bin_transaction(b, LOCATION_ID, TWIN) for b in batch],
+    }
+    resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                      headers=headers, json=payload, verify=False, timeout=300)
+    resp.raise_for_status()
+    result = resp.json()
+
+    summary = result["Summary"]
+    print(f"Batch {start // BATCH_SIZE + 1}: "
+          f"Succeeded={summary['Succeeded']}, Failed={summary['Failed']}")
+    if summary["Failed"] > 0:
+        for msg in result.get("Messages") or []:
+            print(f"  {msg}")
+    # Transactions pass/fail independently — check each one
+    for bin_id, txn in zip(batch, (result.get("Results") or {}).get("Transactions") or []):
+        if txn["Status"] != "Passed":
+            print(f"  FAILED: {bin_id}")
+```
+
+```csharp
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "password");
+
+const string CompanyId = "ACME";
+const string LocationId = "10";
+var newBinIds = new[] { "A01-02-01", "A01-02-02", "A01-02-03", "A01-02-04" };
+
+// Constants cloned from a "twin" bin of the same bin_type at this location.
+// Flags come back Y/N from the database — convert to ON/OFF for the form.
+var twin = new (string Name, string Value)[]
+{
+    ("bin_type", "SHELF"),
+    ("putaway_zone_id", "ZONE-A"), ("pick_zone_id", "ZONE-A"),
+    ("bin_length", "10"), ("bin_width", "10"), ("bin_height", "11"),
+    ("warehouse_sequence", "1"), ("putaway_zone_sequence", "1"), ("pick_zone_sequence", "1"),
+    ("max_unique_items", "0"),
+    ("pick_locked_flag", "OFF"), ("put_locked_flag", "OFF"),
+    ("full_flag", "OFF"), ("frozen_flag", "OFF"),
+    ("consolidation_bin_flag", "OFF"), ("stage_bin_flag", "OFF"), ("door_bin_flag", "OFF"),
+};
+
+JObject BuildBinTransaction(string binId)
+{
+    var edits = new JArray
+    {
+        new JObject { ["Name"] = "company_id", ["Value"] = CompanyId },
+        new JObject { ["Name"] = "location_id", ["Value"] = LocationId },
+        new JObject { ["Name"] = "bin_id", ["Value"] = binId },
+    };
+    foreach (var (name, value) in twin)
+        edits.Add(new JObject { ["Name"] = name, ["Value"] = value });
+
+    return new JObject
+    {
+        ["Status"] = "New",
+        ["DataElements"] = new JArray
+        {
+            new JObject
+            {
+                ["Name"] = "FORM.form", ["Type"] = "Form",
+                ["Keys"] = new JArray("company_id", "location_id", "bin_id"),
+                ["Rows"] = new JArray(new JObject { ["Edits"] = edits }),
+            }
+        },
+    };
+}
+
+// Skip-existing check via the p21_view_bin view (raw bin table isn't always in OData)
+var existingResp = await session.Http.GetAsync(
+    "https://play.p21server.com/odataservice/odata/view/p21_view_bin" +
+    $"?$filter=location_id eq {LocationId}&$select=bin_id");
+existingResp.EnsureSuccessStatusCode();
+var existing = JObject.Parse(await existingResp.Content.ReadAsStringAsync())["value"]!
+    .Select(r => (string)r["bin_id"]!).ToHashSet();
+
+var toCreate = newBinIds.Where(b => !existing.Contains(b)).ToList();
+Console.WriteLine($"{newBinIds.Length - toCreate.Count} already exist, creating {toCreate.Count}");
+
+const int BatchSize = 20; // tens of transactions per POST is fine and fast
+foreach (var batch in toCreate.Chunk(BatchSize))
+{
+    var payload = new JObject
+    {
+        ["Name"] = "BinLocation",
+        ["UseCodeValues"] = false,
+        ["IgnoreDisabled"] = true, // TOP LEVEL — inside a Transaction it is silently ignored
+        ["Transactions"] = new JArray(batch.Select(BuildBinTransaction)),
+    };
+    var resp = await session.Http.PostAsync(
+        $"{session.UiServer}/api/v2/transaction",
+        new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+    resp.EnsureSuccessStatusCode();
+    var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+
+    Console.WriteLine($"Succeeded={result["Summary"]!["Succeeded"]}, " +
+                      $"Failed={result["Summary"]!["Failed"]}");
+    if ((int)result["Summary"]!["Failed"]! > 0)
+        foreach (var msg in result["Messages"] as JArray ?? new JArray())
+            Console.WriteLine($"  {msg}");
+
+    // Transactions pass/fail independently — check each one
+    var txns = result["Results"]?["Transactions"] as JArray ?? new JArray();
+    foreach (var (binId, txn) in batch.Zip(txns))
+        if ((string?)txn["Status"] != "Passed")
+            Console.WriteLine($"  FAILED: {binId}");
+}
+```
+<!-- /tabs -->
+
+## Gotchas
+
+- **`IgnoreDisabled: true` is mandatory — and it must be at the payload top level**, alongside `Name` and `Transactions`. `frozen_flag` and other system columns are disabled on the bin form; without the flag every transaction fails with `General Exception: Column is disabled: frozen_flag`. Placed inside a Transaction object instead of the top level, the flag is **silently ignored** and you get the same failure. See [IgnoreDisabled](../03-Transaction-API.md#ignoredisabled).
+- **Pass codes, not uids.** `bin_type` and the zone fields take the **code** (`SHELF`, `ZONE-A`), not the internal uid. The zone code is the same across stocking locations; only the internal uid differs, and P21 resolves it from code + location.
+- **Flags are `ON`/`OFF` on the form but stored `Y`/`N` in `dbo.bin`.** When cloning field values from an existing bin, convert (`Y`→`ON`, `N`→`OFF`).
+- **Don't send `master_bin_flag`** — P21 auto-sets it.
+- **Clone the constants from a "twin," don't invent them.** Query an existing bin of the same `bin_type` and copy the type, both zone codes, dimensions, sequences, `max_unique_items`, and flags.
+- **HTTP 200 ≠ success.** Check `Results.Transactions[].Status == "Passed"` (or `Summary`) — in a bulk POST each transaction passes/fails independently; one failing does not roll back the others.
+- **Re-running is safe** if you skip `(bin_id, location_id)` pairs that already exist — the script above does.
+
+## Verify
+
+The raw `bin` table isn't always exposed via OData — read back through the **`p21_view_bin`** view instead, and compare **field-for-field against the twin** after the first run (remember the `Y`/`N` ↔ `ON`/`OFF` flag mapping):
+
+```http
+GET /odataservice/odata/view/p21_view_bin?$filter=location_id eq 10 and bin_id eq 'A01-02-03'
+```
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — pattern verified in production (July 2026), including the `IgnoreDisabled` placement failure mode.

--- a/docs/recipes/create-sales-order.md
+++ b/docs/recipes/create-sales-order.md
@@ -1,0 +1,264 @@
+# Create a Sales Order
+
+Create a sales order — header plus line items — in one stateless Transaction API call.
+
+**API:** Transaction · **Service:** `Order` · **Deep dive:** [Create Order](../03-Transaction-API.md#create-order) · [Order Service Gotchas](../03-Transaction-API.md#order-service-gotchas) · **Full schema:** [Order.json](../../definitions/Order.json)
+
+## Prerequisites
+
+- Token + UI server URL (shared auth helper — see the [recipes README](README.md)).
+- The customer, ship-to, contact, and items already exist; the items are stocked at the source location.
+- **No assembly lines.** If a line should explode into components or spawn a production order, the Transaction API auto-answers the *"add as assembly?"* prompt **No** and kills the explode — use the [order-with-assembly](order-with-assembly.md) recipe for those.
+
+## Payload
+
+Two DataElements: the header form and the items list. Names come from the [service definition](../../definitions/Order.json) — `TABPAGE_1.order` (Form, datawindow `d_oe_header`, key `order_no`) and `TP_ITEMS.items` (List, datawindow `d_dw_oe_line_dataentry`, key `oe_order_item_id`).
+
+The minimal example in the manual sends only `customer_id` + one item, but a **realistic header sets all of the fields below** — in particular `source_loc_id`, without which the save fails with a *"Jurisdiction ID for Order Header Tax"* error (see Gotchas).
+
+```json
+POST {ui_server}/api/v2/transaction
+
+{
+    "Name": "Order",
+    "UseCodeValues": false,
+    "Transactions": [{
+        "Status": "New",
+        "DataElements": [
+            {
+                "Name": "TABPAGE_1.order",
+                "Type": "Form",
+                "Keys": [],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "customer_id",    "Value": "100198"},
+                        {"Name": "sales_loc_id",   "Value": "10"},
+                        {"Name": "source_loc_id",  "Value": "10"},
+                        {"Name": "order_date",     "Value": "2030-01-05"},
+                        {"Name": "requested_date", "Value": "2030-01-06"},
+                        {"Name": "po_no",          "Value": "PO-TEST-001"},
+                        {"Name": "taker",          "Value": "JSMITH"},
+                        {"Name": "ship_to_id",     "Value": "200"},
+                        {"Name": "contact_id",     "Value": "300"}
+                    ],
+                    "RelativeDateEdits": []
+                }]
+            },
+            {
+                "Name": "TP_ITEMS.items",
+                "Type": "List",
+                "Keys": [],
+                "Rows": [
+                    {
+                        "Edits": [
+                            {"Name": "oe_order_item_id", "Value": "WIDGET-001"},
+                            {"Name": "unit_quantity",    "Value": "5"}
+                        ],
+                        "RelativeDateEdits": []
+                    },
+                    {
+                        "Edits": [
+                            {"Name": "oe_order_item_id", "Value": "WIDGET-002"},
+                            {"Name": "unit_quantity",    "Value": "2"}
+                        ],
+                        "RelativeDateEdits": []
+                    }
+                ]
+            }
+        ]
+    }]
+}
+```
+
+Do **not** send `company_id` — it is a disabled column on the Order window. For every other field the service accepts, load [`definitions/Order.json`](../../definitions/Order.json).
+
+## Complete example
+
+<!-- tabs -->
+```python
+BASE_URL = "https://play.p21server.com"
+USERNAME = "api_user"
+PASSWORD = "api_pass"
+
+token, ui_server, headers = p21_auth(BASE_URL, USERNAME, PASSWORD)
+
+payload = {
+    "Name": "Order",
+    "UseCodeValues": False,
+    "Transactions": [{
+        "Status": "New",
+        "DataElements": [
+            {
+                "Name": "TABPAGE_1.order",
+                "Type": "Form",
+                "Keys": [],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "customer_id",    "Value": "100198"},
+                        {"Name": "sales_loc_id",   "Value": "10"},
+                        {"Name": "source_loc_id",  "Value": "10"},   # required in practice
+                        {"Name": "order_date",     "Value": "2030-01-05"},
+                        {"Name": "requested_date", "Value": "2030-01-06"},  # must be AFTER order_date
+                        {"Name": "po_no",          "Value": "PO-TEST-001"},
+                        {"Name": "taker",          "Value": "JSMITH"},
+                        {"Name": "ship_to_id",     "Value": "200"},
+                        {"Name": "contact_id",     "Value": "300"},
+                    ],
+                    "RelativeDateEdits": [],
+                }],
+            },
+            {
+                "Name": "TP_ITEMS.items",
+                "Type": "List",
+                "Keys": [],
+                "Rows": [
+                    {"Edits": [
+                        {"Name": "oe_order_item_id", "Value": "WIDGET-001"},
+                        {"Name": "unit_quantity",    "Value": "5"},
+                    ], "RelativeDateEdits": []},
+                    {"Edits": [
+                        {"Name": "oe_order_item_id", "Value": "WIDGET-002"},
+                        {"Name": "unit_quantity",    "Value": "2"},
+                    ], "RelativeDateEdits": []},
+                ],
+            },
+        ],
+    }],
+}
+
+response = httpx.post(
+    f"{ui_server}/api/v2/transaction",
+    headers=headers, json=payload, verify=False, timeout=120,
+)
+response.raise_for_status()
+result = response.json()
+
+# HTTP 200 even on failure -- check the Summary, never the status code
+summary = result["Summary"]
+print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+if summary["Failed"] > 0 or summary["Succeeded"] == 0:
+    for msg in result.get("Messages", []):
+        print(msg)
+    raise SystemExit("Order create failed")
+
+# The generated order_no comes back in the result rows of TABPAGE_1.order
+order_no = None
+for txn in result["Results"]["Transactions"]:
+    if txn.get("Status") != "Passed":
+        continue
+    for element in txn.get("DataElements", []):
+        if element.get("Name") != "TABPAGE_1.order":
+            continue
+        for row in element.get("Rows", []):
+            for edit in row.get("Edits", []):
+                if edit.get("Name") == "order_no":
+                    order_no = edit.get("Value")
+
+print(f"Created order_no: {order_no}")
+```
+
+```csharp
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+
+JObject Row(params (string Name, string Value)[] edits) => new JObject
+{
+    ["Edits"] = new JArray(edits.Select(e =>
+        new JObject { ["Name"] = e.Name, ["Value"] = e.Value })),
+    ["RelativeDateEdits"] = new JArray(),
+};
+
+var payload = new JObject
+{
+    ["Name"] = "Order",
+    ["UseCodeValues"] = false,
+    ["Transactions"] = new JArray
+    {
+        new JObject
+        {
+            ["Status"] = "New",
+            ["DataElements"] = new JArray
+            {
+                new JObject
+                {
+                    ["Name"] = "TABPAGE_1.order",
+                    ["Type"] = "Form",
+                    ["Keys"] = new JArray(),
+                    ["Rows"] = new JArray
+                    {
+                        Row(("customer_id", "100198"),
+                            ("sales_loc_id", "10"),
+                            ("source_loc_id", "10"),          // required in practice
+                            ("order_date", "2030-01-05"),
+                            ("requested_date", "2030-01-06"), // must be AFTER order_date
+                            ("po_no", "PO-TEST-001"),
+                            ("taker", "JSMITH"),
+                            ("ship_to_id", "200"),
+                            ("contact_id", "300")),
+                    },
+                },
+                new JObject
+                {
+                    ["Name"] = "TP_ITEMS.items",
+                    ["Type"] = "List",
+                    ["Keys"] = new JArray(),
+                    ["Rows"] = new JArray
+                    {
+                        Row(("oe_order_item_id", "WIDGET-001"), ("unit_quantity", "5")),
+                        Row(("oe_order_item_id", "WIDGET-002"), ("unit_quantity", "2")),
+                    },
+                },
+            },
+        },
+    },
+};
+
+var response = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction",
+    new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+response.EnsureSuccessStatusCode();
+var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+// HTTP 200 even on failure -- check the Summary, never the status code
+var succeeded = (int)result["Summary"]!["Succeeded"]!;
+var failed = (int)result["Summary"]!["Failed"]!;
+Console.WriteLine($"Succeeded: {succeeded}, Failed: {failed}");
+if (failed > 0 || succeeded == 0)
+{
+    foreach (var msg in result["Messages"] ?? new JArray())
+        Console.WriteLine(msg);
+    throw new InvalidOperationException("Order create failed");
+}
+
+// The generated order_no comes back in the result rows of TABPAGE_1.order
+var orderNo = result.SelectTokens(
+        "$.Results.Transactions[?(@.Status == 'Passed')].DataElements[?(@.Name == 'TABPAGE_1.order')].Rows[*].Edits[?(@.Name == 'order_no')].Value")
+    .FirstOrDefault()?.ToString();
+
+Console.WriteLine($"Created order_no: {orderNo}");
+```
+<!-- /tabs -->
+
+## Gotchas
+
+All verified live — details in [Order Service Gotchas](../03-Transaction-API.md#order-service-gotchas):
+
+- **`source_loc_id` is effectively required.** Omitting it fails with a *"Jurisdiction ID for Order Header Tax"* error — the tax jurisdiction does not auto-populate through the API the way it does in the UI.
+- **`requested_date` must be after `order_date`.** The same date trips a date-cascade prompt, which the stateless API can't answer.
+- **`company_id` is a disabled column** on the Order window — don't send it.
+- **DynaChange prompts are auto-answered with the default** (usually "No"), which silently discards the affected line — e.g. *"order line does not have a PO Cost… proceed? [No]"*. On multi-item orders the remaining lines then cascade-fail. This is a P21 configuration matter (exempt the rule for the API user, or fix the data), not something a payload change can work around — see [DynaChange and Popup Handling](../03-Transaction-API.md#dynachange-and-popup-handling).
+- **Assembly items cannot be entered via the Transaction API** when they should explode or spawn a production order — the *"add as assembly?"* prompt is auto-answered **No**, killing the explode. Use the [order-with-assembly](order-with-assembly.md) recipe (Interactive API) for those lines.
+- **HTTP 200 ≠ success.** The created `order_no` comes back in the result rows; check `Summary.Succeeded` and `Results.Transactions[].Status == "Passed"`, never the HTTP status. Transactions in one POST pass/fail independently.
+
+## Verify
+
+Read the order back — a `Succeeded` response is not proof every value landed:
+
+```http
+GET {base_url}/odataservice/odata/table/oe_hdr?$filter=order_no eq '1013938'
+GET {base_url}/odataservice/odata/table/oe_line?$filter=order_no eq '1013938'
+```
+
+Confirm the header fields you sent (`taker`, `po_no`, dates, ship-to) and that **every** line row exists — a DynaChange auto-answer can drop a line while the transaction still reports `Succeeded` (see Gotchas).
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier)

--- a/docs/recipes/edit-contract-bins.md
+++ b/docs/recipes/edit-contract-bins.md
@@ -1,0 +1,286 @@
+# Edit Contract Bin Quantities
+
+Change `min_qty`, `max_qty`, `reorder_qty`, and `capacity` on the bins of an existing job contract.
+
+**API:** Transaction with `IgnoreDisabled: true` (Interactive API fallback) · **Service:** `JobContractPricing` · **Deep dive:** [Editing Bin Quantities](../03-Transaction-API.md#editing-bin-quantities-on-an-existing-contract) · [IgnoreDisabled](../03-Transaction-API.md#ignoredisabled) · [Tab Unlock Sequences (Interactive fallback)](../04-Interactive-API.md#tab-unlock-sequences) · **Full schema:** [`definitions/JobContractPricing.json`](../../definitions/JobContractPricing.json)
+
+## Prerequisites
+
+- The contract, its lines, and its bins already exist. Know the contract's `job_no`, the `customer_id`/`ship_to_id` combination, and per bin the line's `item_id` and the `contract_bin_id` (e.g. `A01-02`).
+- The BINS grid lives on a sub-tab that is normally disabled until a parent row is selected — which the stateless Transaction API cannot do. `IgnoreDisabled: true` at the **payload top level** is what unlocks it.
+- No `end_date` is required on this path — it works on **expired** contracts too, unlike line-field updates.
+
+## Payload
+
+One POST, batchable: repeat the `JOBPRICELINE` + `BINS.bins` pair per bin inside the same Transaction. The `JOBPRICELINE` element only *selects* the line (by `item_id`); the `BINS.bins` element carries the edits.
+
+```jsonc
+{
+    "Name": "JobContractPricing",
+    "UseCodeValues": false,
+    "IgnoreDisabled": true,        // MANDATORY, and at the top level — inside a Transaction it is silently ignored
+    "Transactions": [{
+        "Status": "New",           // "New" even though the contract exists — "Existing" returns HTTP 500
+        "DataElements": [
+            {
+                // Load the contract header. job_no is unique across renewals.
+                "Name": "FORM.d_dw_job_price_hdr", "Type": "Form", "Keys": [],
+                "Rows": [{"Edits": [
+                    {"Name": "job_no",      "Value": "31"},
+                    {"Name": "customer_id", "Value": "100198"},
+                    {"Name": "ship_to_id",  "Value": "200"}
+                ]}]
+            },
+            {
+                // Select the line by item_id (NOT line_no).
+                "Name": "JOBPRICELINE.jobpriceline", "Type": "List", "Keys": ["item_id"],
+                "Rows": [{"Edits": [
+                    {"Name": "item_id", "Value": "WIDGET-001"}
+                ]}]
+            },
+            {
+                // Edit the bin quantities.
+                "Name": "BINS.bins", "Type": "List",
+                "Keys": ["contract_bin_id", "customer_id", "ship_to_id"],
+                "Rows": [{"Edits": [
+                    {"Name": "contract_bin_id", "Value": "A01-02"},
+                    {"Name": "customer_id",     "Value": "100198"},
+                    {"Name": "ship_to_id",      "Value": "200"},
+                    {"Name": "min_qty",         "Value": "30"},
+                    {"Name": "max_qty",         "Value": "100"},
+                    {"Name": "reorder_qty",     "Value": "40"},
+                    {"Name": "capacity",        "Value": "100"}
+                ]}]
+            }
+            // ...repeat the JOBPRICELINE + BINS.bins pair for each additional bin
+        ]
+    }]
+}
+```
+
+## Complete example
+
+<!-- tabs -->
+```python
+import httpx  # p21_auth() from recipes/README.md
+
+BASE_URL = "https://play.p21server.com"
+token, ui_server, headers = p21_auth(BASE_URL, "api_user", "api_pass")
+
+CONTRACT_NO = "A120-12"
+JOB_NO, CUSTOMER_ID, SHIP_TO_ID = "31", "100198", "200"
+
+# Per bin: the line's item_id, the bin id, and the new quantities.
+bin_edits = [
+    {"item_id": "WIDGET-001", "bin_id": "A01-02",
+     "min_qty": 30, "max_qty": 100, "reorder_qty": 40, "capacity": 100},
+    {"item_id": "WIDGET-002", "bin_id": "A01-02",
+     "min_qty": 5,  "max_qty": 50,  "reorder_qty": 10, "capacity": 50},
+]
+
+
+def build_bin_payload(job_no: str, customer_id: str, ship_to_id: str,
+                      edits: list[dict]) -> dict:
+    """One Transaction, one JOBPRICELINE + BINS.bins pair per bin."""
+    elements = [
+        {"Name": "FORM.d_dw_job_price_hdr", "Type": "Form", "Keys": [],
+         "Rows": [{"Edits": [
+             {"Name": "job_no",      "Value": job_no},
+             {"Name": "customer_id", "Value": customer_id},
+             {"Name": "ship_to_id",  "Value": ship_to_id},
+         ]}]},
+    ]
+    for e in edits:
+        elements.append(
+            {"Name": "JOBPRICELINE.jobpriceline", "Type": "List",
+             "Keys": ["item_id"],   # select by item_id, NOT line_no
+             "Rows": [{"Edits": [{"Name": "item_id", "Value": e["item_id"]}]}]})
+        elements.append(
+            {"Name": "BINS.bins", "Type": "List",
+             "Keys": ["contract_bin_id", "customer_id", "ship_to_id"],
+             "Rows": [{"Edits": [
+                 {"Name": "contract_bin_id", "Value": e["bin_id"]},
+                 {"Name": "customer_id",     "Value": customer_id},
+                 {"Name": "ship_to_id",      "Value": ship_to_id},
+                 {"Name": "min_qty",         "Value": str(e["min_qty"])},
+                 {"Name": "max_qty",         "Value": str(e["max_qty"])},
+                 {"Name": "reorder_qty",     "Value": str(e["reorder_qty"])},
+                 {"Name": "capacity",        "Value": str(e["capacity"])},
+             ]}]})
+    return {"Name": "JobContractPricing", "UseCodeValues": False,
+            "IgnoreDisabled": True,  # top level — mandatory for the BINS sub-tab
+            "Transactions": [{"Status": "New", "DataElements": elements}]}
+
+
+payload = build_bin_payload(JOB_NO, CUSTOMER_ID, SHIP_TO_ID, bin_edits)
+resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                  headers=headers, json=payload, verify=False, timeout=60)
+resp.raise_for_status()  # HTTP 200 even when the transaction failed
+result = resp.json()
+summary = result["Summary"]
+print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+if summary["Failed"] or not summary["Succeeded"]:
+    for msg in result.get("Messages", []):
+        print(f"  FAILED: {msg}")
+    raise SystemExit(1)
+
+# --- Verify via OData (no joins: chain the uid columns) ---
+def odata(table: str, filter_expr: str) -> list[dict]:
+    resp = httpx.get(f"{BASE_URL}/odataservice/odata/table/{table}",
+                     params={"$filter": filter_expr},
+                     headers=headers, verify=False)
+    resp.raise_for_status()
+    return resp.json()["value"]
+
+hdr = odata("job_price_hdr", f"contract_no eq '{CONTRACT_NO}'")[0]
+for e in bin_edits:
+    im_uid = odata("inv_mast", f"item_id eq '{e['item_id']}'")[0]["inv_mast_uid"]
+    line = odata("job_price_line",
+                 f"job_price_hdr_uid eq {hdr['job_price_hdr_uid']} "
+                 f"and inv_mast_uid eq {im_uid}")[0]
+    for bin_row in odata("job_price_bin",
+                         f"job_price_line_uid eq {line['job_price_line_uid']}"):
+        print(f"{e['item_id']}: min={bin_row['min_qty']} max={bin_row['max_qty']} "
+              f"reorder={bin_row['reorder_qty']} "
+              f"(expected {e['min_qty']}/{e['max_qty']}/{e['reorder_qty']})")
+```
+
+```csharp
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+const string BaseUrl = "https://play.p21server.com";
+
+const string ContractNo = "A120-12";
+const string JobNo = "31", CustomerId = "100198", ShipToId = "200";
+
+// Per bin: the line's item_id, the bin id, and the new quantities.
+var binEdits = new (string ItemId, string BinId, int Min, int Max, int Reorder, int Capacity)[]
+{
+    ("WIDGET-001", "A01-02", 30, 100, 40, 100),
+    ("WIDGET-002", "A01-02", 5, 50, 10, 50),
+};
+
+JObject Edit(string name, string value) =>
+    new JObject { ["Name"] = name, ["Value"] = value };
+
+JObject BuildBinPayload()
+{
+    var elements = new JArray
+    {
+        new JObject
+        {
+            ["Name"] = "FORM.d_dw_job_price_hdr", ["Type"] = "Form",
+            ["Keys"] = new JArray(),
+            ["Rows"] = new JArray { new JObject { ["Edits"] = new JArray {
+                Edit("job_no",      JobNo),
+                Edit("customer_id", CustomerId),
+                Edit("ship_to_id",  ShipToId),
+            } } }
+        }
+    };
+    foreach (var e in binEdits)
+    {
+        elements.Add(new JObject
+        {
+            ["Name"] = "JOBPRICELINE.jobpriceline", ["Type"] = "List",
+            ["Keys"] = new JArray { "item_id" },   // select by item_id, NOT line_no
+            ["Rows"] = new JArray { new JObject {
+                ["Edits"] = new JArray { Edit("item_id", e.ItemId) } } }
+        });
+        elements.Add(new JObject
+        {
+            ["Name"] = "BINS.bins", ["Type"] = "List",
+            ["Keys"] = new JArray { "contract_bin_id", "customer_id", "ship_to_id" },
+            ["Rows"] = new JArray { new JObject { ["Edits"] = new JArray {
+                Edit("contract_bin_id", e.BinId),
+                Edit("customer_id",     CustomerId),
+                Edit("ship_to_id",      ShipToId),
+                Edit("min_qty",         e.Min.ToString()),
+                Edit("max_qty",         e.Max.ToString()),
+                Edit("reorder_qty",     e.Reorder.ToString()),
+                Edit("capacity",        e.Capacity.ToString()),
+            } } }
+        });
+    }
+    return new JObject
+    {
+        ["Name"] = "JobContractPricing", ["UseCodeValues"] = false,
+        ["IgnoreDisabled"] = true,  // top level — mandatory for the BINS sub-tab
+        ["Transactions"] = new JArray {
+            new JObject { ["Status"] = "New", ["DataElements"] = elements } }
+    };
+}
+
+var resp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction",
+    new StringContent(BuildBinPayload().ToString(), Encoding.UTF8, "application/json"));
+resp.EnsureSuccessStatusCode();  // HTTP 200 even when the transaction failed
+var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+var summary = result["Summary"]!;
+Console.WriteLine($"Succeeded: {summary["Succeeded"]}, Failed: {summary["Failed"]}");
+if ((int)summary["Failed"]! > 0 || (int)summary["Succeeded"]! == 0)
+{
+    foreach (var msg in result["Messages"] as JArray ?? new JArray())
+        Console.WriteLine($"  FAILED: {msg}");
+    return;
+}
+
+// --- Verify via OData (no joins: chain the uid columns) ---
+async Task<JArray> ODataAsync(string table, string filter)
+{
+    var url = $"{BaseUrl}/odataservice/odata/table/{table}" +
+              $"?$filter={Uri.EscapeDataString(filter)}";
+    var r = await session.Http.GetAsync(url);
+    r.EnsureSuccessStatusCode();
+    return (JArray)JObject.Parse(await r.Content.ReadAsStringAsync())["value"]!;
+}
+
+var hdr = (JObject)(await ODataAsync("job_price_hdr", $"contract_no eq '{ContractNo}'"))[0];
+foreach (var e in binEdits)
+{
+    var imUid = (await ODataAsync("inv_mast", $"item_id eq '{e.ItemId}'"))[0]["inv_mast_uid"];
+    var line = (await ODataAsync("job_price_line",
+        $"job_price_hdr_uid eq {hdr["job_price_hdr_uid"]} and inv_mast_uid eq {imUid}"))[0];
+    foreach (var binRow in await ODataAsync("job_price_bin",
+        $"job_price_line_uid eq {line["job_price_line_uid"]}"))
+    {
+        Console.WriteLine($"{e.ItemId}: min={binRow["min_qty"]} max={binRow["max_qty"]} " +
+                          $"reorder={binRow["reorder_qty"]} " +
+                          $"(expected {e.Min}/{e.Max}/{e.Reorder})");
+    }
+}
+```
+<!-- /tabs -->
+
+## Gotchas
+
+All verified live:
+
+- **`IgnoreDisabled: true` is mandatory** — without it the defaults template trips *"Column is disabled: ..."* and the BINS tab stays locked.
+- **`IgnoreDisabled` goes at the payload top level** (alongside `Name`/`Transactions`). Inside a Transaction object it is **silently ignored** and every transaction fails with `Column is disabled: <column>`.
+- **Select the line by `item_id`** (the `JOBPRICELINE` key). Selecting by `line_no` alone fails with *"Sequence contains no matching element."* If the same item appears on multiple lines, add `line_no` as a second key.
+- **Batching is fine here** — repeat the `JOBPRICELINE` + `BINS.bins` pair per bin inside the same Transaction. Unlike line inserts, bin edits don't collide on the header.
+- **No `end_date` required on this path** — it works on **expired** contracts too, unlike line-field updates.
+- **`Status: "New"` even for an existing contract** — `"Existing"` returns HTTP 500 (`NullReferenceException`).
+- **HTTP 200 can still carry `Summary.Failed > 0`** — check `Summary` and `Messages`, never the HTTP status.
+- **Interactive fallback** (slower; use when a Transaction-API edge case appears or the work needs window logic) — the EXISTING-contract unlock sequence from [Tab Unlock Sequences](../04-Interactive-API.md#tab-unlock-sequences):
+  1. Load the contract by setting `job_no`, `customer_id`, and `ship_to_id` on `FORM/d_dw_job_price_hdr` (three separate change calls). **Load by `job_no`, not `contract_no`** — renewals can leave the same `contract_no` on two header rows.
+  2. Change to the `CUSTOMER_SHIP_TO` tab and **select the ship-to's grid row** — the BINS tab only unlocks after the row is selected. Skipping this (or loading by `contract_no` alone) leaves it disabled with *"Tab page is disabled and cannot be selected."*
+  3. Per line: `JOBPRICELINE` tab → select the line's row → `BINS` tab. The grid is **filtered to the selected ship-to**, so it has exactly one row per line — selecting row 1 of `bins` always targets the right bin. Edit the quantity fields.
+  4. One save at the end persists every edit in the session (save per ship-to on large runs so a mid-run failure doesn't lose everything).
+
+## Verify
+
+Chain OData uid lookups (no joins): `job_price_hdr` by `contract_no` → `job_price_line` by `job_price_hdr_uid` (+ `inv_mast_uid` from `inv_mast` for the item) → `job_price_bin` by `job_price_line_uid`, then confirm `min_qty` / `max_qty` / `reorder_qty`:
+
+```http
+GET /odataservice/odata/table/job_price_bin?$filter=job_price_line_uid eq {line_uid}
+```
+
+The complete example above does this for every edited bin.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — discovered and verified the `IgnoreDisabled` bins path (single and multi-bin batches, database-confirmed) and the Interactive-API existing-contract unlock sequence.

--- a/docs/recipes/generate-pick-ticket-pdf.md
+++ b/docs/recipes/generate-pick-ticket-pdf.md
@@ -1,0 +1,220 @@
+# Generate Pick Ticket and PO PDFs
+
+Generate or reprint pick tickets and purchase orders as base64-encoded PDFs via the dedicated report endpoint.
+
+**API:** Transaction (`POST /api/v2/process/pdfreport`) · **Service:** `m_picktickets`, `m_reprintpicktickets`, `m_reprintpurchaseorders` · **Deep dive:** [PDF Report Generation](../03-Transaction-API.md#pdf-report-generation) · **Full schema:** [m_picktickets.json](../../definitions/m_picktickets.json) · [m_reprintpicktickets.json](../../definitions/m_reprintpicktickets.json) · [m_reprintpurchaseorders.json](../../definitions/m_reprintpurchaseorders.json)
+
+## Prerequisites
+
+- Token + UI server URL (shared auth helper — see the [recipes README](README.md)).
+- **For `m_picktickets` against a production order**: the production order's form must already be printed (`prod_order_hdr.printed = 'Y'`) — run a `ProductionOrder` transaction with `print_form = ON` first.
+- The `m_*` report services are **hidden from `GET /api/v2/services`** (`?type=report` returns an empty list), but `GET /api/v2/definition/{service_name}` and `GET /api/v2/defaults/{service_name}` both work for them — use those for criteria field names and defaults. On a 25.2 test system, probing candidates from the `window_x_menu` table yields ~157 callable report services (`m_picktickets`, `m_reprintpicktickets`, `m_productionorders`, `m_orderacknowledgements`, `m_invoices`, `m_packinglists`, `m_customerstatements`, …) — see the Discovery note in the [deep dive](../03-Transaction-API.md#pdf-report-generation).
+
+> **Wrong-endpoint trap:** `POST /api/v2/transaction` *accepts* an `m_*` report payload and returns `Succeeded` — but **emits nothing**. A report is a process, not a record edit; it must go to `POST /api/v2/process/pdfreport`.
+
+## Payload
+
+Constants for **every** report payload: `Status` and `Type` are **numeric `0`** (not the `"New"` record-edit shape) and the DataElement carries `Keys: []`. Only `Name`, the DataElement name, and the criteria `Edits` change per service.
+
+**`m_picktickets`** — *creates* the pick-ticket record at `location_id` **and** returns its PDF in one call (verified worked example). Requires `UseCodeValues: true` with the code `"P"` (Production Order):
+
+```json
+POST {ui_server}/api/v2/process/pdfreport
+
+{
+  "Name": "m_picktickets",
+  "UseCodeValues": true,
+  "Transactions": [{
+    "Status": 0,
+    "DataElements": [{
+      "Keys": [],
+      "Type": 0,
+      "Name": "TABPAGE_1.tp_1_dw_1",
+      "Rows": [{ "Edits": [
+        { "Name": "create_pick_ticket_type", "Value": "P" },
+        { "Name": "beg_prod_order", "Value": "1000123" },
+        { "Name": "end_prod_order", "Value": "1000123" },
+        { "Name": "location_id",    "Value": "10" }
+      ] }]
+    }]
+  }]
+}
+```
+
+**`m_reprintpurchaseorders`** — PO reprint (verified with `UseCodeValues: false`). DataElement name is `TABPAGE_1.poreportcriteriadw`:
+
+```json
+{ "Name": "company_id", "Value": "ACME" },
+{ "Name": "beg_po_no",  "Value": "500100" },
+{ "Name": "end_po_no",  "Value": "500100" },
+{ "Name": "reprint_flag", "Value": "Y" }
+```
+
+**`m_reprintpicktickets`** — pick-ticket reprint. DataElement name is `TABPAGE_1.tp_1_dw_1` (datawindow `d_reprint_pick_ticket_criteria`); the [definition](../../definitions/m_reprintpicktickets.json) marks `company_id`, `location_id`, and `print_qty` required, with ranges `beg_pick_ticket_no`/`end_pick_ticket_no` (sales-order tickets) and `beg_prod_pick_ticket_no`/`end_prod_pick_ticket_no` (production tickets).
+
+For any *other* report, swap `Name` and the criteria `Edits` (field names from `GET /api/v2/definition/{name}`); the endpoint, `Status`/`Type: 0`, `Keys: []`, and the `DocumentData` extraction stay the same.
+
+## Complete example
+
+Generates a production-order pick ticket with `m_picktickets`, decodes the base64 PDF, and handles both failure shapes (document-level `ResponseStatus` and the P21 error envelope).
+
+<!-- tabs -->
+```python
+import base64
+
+BASE_URL = "https://play.p21server.com"
+USERNAME = "api_user"
+PASSWORD = "api_pass"
+
+token, ui_server, headers = p21_auth(BASE_URL, USERNAME, PASSWORD)
+
+payload = {
+    "Name": "m_picktickets",
+    "UseCodeValues": True,   # required here -- False returns HTTP 500
+    "Transactions": [{
+        "Status": 0,         # numeric 0 for report payloads
+        "DataElements": [{
+            "Keys": [],      # always empty for reports
+            "Type": 0,       # numeric 0 for report payloads
+            "Name": "TABPAGE_1.tp_1_dw_1",
+            "Rows": [{"Edits": [
+                # code "P" = Production Order (the display label is rejected)
+                {"Name": "create_pick_ticket_type", "Value": "P"},
+                {"Name": "beg_prod_order", "Value": "1000123"},
+                {"Name": "end_prod_order", "Value": "1000123"},
+                # location whose inventory the components pick from
+                {"Name": "location_id", "Value": "10"},
+            ]}],
+        }],
+    }],
+}
+
+response = httpx.post(
+    f"{ui_server}/api/v2/process/pdfreport",
+    headers=headers, json=payload, verify=False, timeout=120,
+)
+
+# Errors come back as the standard P21 error envelope (ErrorType/ErrorMessage),
+# NOT the Summary/Messages format used by /transaction.
+if response.status_code >= 400:
+    raise SystemExit(f"HTTP {response.status_code}: {response.text}")
+result = response.json()
+if isinstance(result, dict) and "ErrorMessage" in result:
+    raise SystemExit(f"{result.get('ErrorType')}: {result['ErrorMessage']}")
+
+# Success is a JSON ARRAY -- even for a single document
+if not (isinstance(result, list) and result):
+    raise SystemExit(f"No documents returned: {result}")
+
+for doc in result:
+    status = doc.get("ResponseStatus", {}).get("StatusCode")
+    if status != "Success" or not doc.get("DocumentData"):
+        msg = doc.get("ResponseStatus", {}).get("Message", "Unknown error")
+        print(f"Document failed: {msg}")
+        continue
+    pdf_bytes = base64.b64decode(doc["DocumentData"])
+    # FileName includes .pdf, e.g. "PPT<nnn> PRODUCTION_PICK_TICKET.pdf"
+    filename = doc.get("FileName", "pick_ticket.pdf")
+    with open(filename, "wb") as f:
+        f.write(pdf_bytes)
+    print(f"Saved {filename} ({len(pdf_bytes)} bytes)")
+```
+
+```csharp
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+
+var payload = new JObject
+{
+    ["Name"] = "m_picktickets",
+    ["UseCodeValues"] = true,   // required here -- false returns HTTP 500
+    ["Transactions"] = new JArray
+    {
+        new JObject
+        {
+            ["Status"] = 0,     // numeric 0 for report payloads
+            ["DataElements"] = new JArray
+            {
+                new JObject
+                {
+                    ["Keys"] = new JArray(),  // always empty for reports
+                    ["Type"] = 0,             // numeric 0 for report payloads
+                    ["Name"] = "TABPAGE_1.tp_1_dw_1",
+                    ["Rows"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Edits"] = new JArray
+                            {
+                                // code "P" = Production Order (label is rejected)
+                                new JObject { ["Name"] = "create_pick_ticket_type", ["Value"] = "P" },
+                                new JObject { ["Name"] = "beg_prod_order", ["Value"] = "1000123" },
+                                new JObject { ["Name"] = "end_prod_order", ["Value"] = "1000123" },
+                                // location whose inventory the components pick from
+                                new JObject { ["Name"] = "location_id", ["Value"] = "10" },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+var response = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/process/pdfreport",
+    new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+var bodyText = await response.Content.ReadAsStringAsync();
+
+// Errors come back as the standard P21 error envelope (ErrorType/ErrorMessage),
+// NOT the Summary/Messages format used by /transaction.
+if (!response.IsSuccessStatusCode)
+    throw new InvalidOperationException($"HTTP {(int)response.StatusCode}: {bodyText}");
+
+var parsed = JToken.Parse(bodyText);
+if (parsed is JObject envelope && envelope["ErrorMessage"] != null)
+    throw new InvalidOperationException(
+        $"{envelope["ErrorType"]}: {envelope["ErrorMessage"]}");
+
+// Success is a JSON ARRAY -- even for a single document
+if (parsed is not JArray documents || documents.Count == 0)
+    throw new InvalidOperationException($"No documents returned: {parsed}");
+
+foreach (var doc in documents.OfType<JObject>())
+{
+    var status = doc["ResponseStatus"]?["StatusCode"]?.ToString();
+    var documentData = doc["DocumentData"]?.ToString();
+    if (status != "Success" || string.IsNullOrEmpty(documentData))
+    {
+        var msg = doc["ResponseStatus"]?["Message"]?.ToString() ?? "Unknown error";
+        Console.WriteLine($"Document failed: {msg}");
+        continue;
+    }
+    var pdfBytes = Convert.FromBase64String(documentData);
+    // FileName includes .pdf, e.g. "PPT<nnn> PRODUCTION_PICK_TICKET.pdf"
+    var filename = doc["FileName"]?.ToString() ?? "pick_ticket.pdf";
+    await File.WriteAllBytesAsync(filename, pdfBytes);
+    Console.WriteLine($"Saved {filename} ({pdfBytes.Length} bytes)");
+}
+```
+<!-- /tabs -->
+
+## Gotchas
+
+All verified live — details in [PDF Report Generation](../03-Transaction-API.md#pdf-report-generation):
+
+- **Wrong-endpoint trap** — `POST /api/v2/transaction` *accepts* an `m_*` payload and returns `Succeeded`, but **emits nothing**. Reports must go to `POST /api/v2/process/pdfreport`. ("This was the single biggest gotcha.")
+- **`UseCodeValues` requirements vary per report service.** `m_reprintpurchaseorders` works with `UseCodeValues: false`, but `m_picktickets` **requires `UseCodeValues: true` with code values** — `create_pick_ticket_type` must be the code `"P"`; the display label `"Production Order"` is rejected, and `UseCodeValues: false` returns HTTP 500. When a report errors on seemingly-correct criteria, retry with `UseCodeValues: true` and the code values from the definition's `ValidValues`.
+- **`Status` and `Type` are numeric `0`** with `Keys: []` — not the `"New"` record-edit shape.
+- **`m_picktickets` prerequisite**: the production order's form must already be printed (`prod_order_hdr.printed = 'Y'`) — run a `ProductionOrder` transaction with `print_form = ON` first. No date range is needed; `location_id` is the location the components pick from.
+- **`m_picktickets` has a side effect**: the pick-ticket row now exists in P21 at that location and can be confirmed/completed like any other.
+- **Print flags on `/transaction` have limits.** A service's print flags (e.g. `ProductionOrder` `print_pick_ticket`/`print_form` on `TABPAGE_1.tp_1_dw_1`) return PDFs at `Results.Transactions[].Documents[].DocumentData`, but only on a **savable** transaction (a bare reprint errors with *"Save is not enabled"*), and `print_pick_ticket` emits only at the order's **make location** — if components stock elsewhere, generate with `m_picktickets` at the stock `location_id` instead.
+- **Success is a JSON array** (even for one document); **errors use the P21 error envelope** (`ErrorType`/`ErrorMessage`), not the `Summary`/`Messages` format of `/transaction` — e.g. *"No records to print for this range."* when the range matches nothing.
+
+## Verify
+
+- The saved file opens as a PDF (`DocumentContentType` is `"application/pdf"`, `DocumentFormat` is `5`, and the decoded bytes start with `%PDF`).
+- `ResponseStatus.StatusCode` is `"Success"` and `ResponseStatus.Message` reports the form request completed.
+- For `m_picktickets`: the ticket number is in `FileName` (`"PPT<nnn> PRODUCTION_PICK_TICKET.pdf"`). Confirm the record landed by reprinting it — run `m_reprintpicktickets` with `beg_prod_pick_ticket_no`/`end_prod_pick_ticket_no` set to that number; a second PDF proves the pick-ticket row exists.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — worked example verified end-to-end (report run → pick ticket row created → PDF returned → ticket confirmed and completed). Jeff Poss discovered the `/api/v2/process/pdfreport` endpoint.

--- a/docs/recipes/inventory-adjustment.md
+++ b/docs/recipes/inventory-adjustment.md
@@ -1,0 +1,266 @@
+# Adjust On-Hand Quantity (Write-Off)
+
+Post an inventory adjustment — a signed on-hand quantity change with no invoice — via the `InventoryAdjustment` service.
+
+**API:** Transaction · **Service:** `InventoryAdjustment` · **Deep dive:** [Inventory Adjustment (Write-Offs)](../12-Production-Labor-API.md#inventory-adjustment-write-offs) · **Full schema:** [definitions/InventoryAdjustment.json](../../definitions/InventoryAdjustment.json)
+
+## Prerequisites
+
+- The item (here `WIDGET-001`) is set up at the location (here `10`).
+- An adjustment **reason** exists in P21 (here the display text `ADJUST`) — you pass its display text, not its code.
+- Run against a test/play environment first: the save **posts the adjustment** immediately.
+
+## Payload
+
+`POST {ui_server}/api/v2/transaction`, `Status: "New"`, `UseCodeValues: false`. Two DataElements:
+
+**Header — `TABPAGE_1.tp_1_dw_1` (Form, business object `inv_adj_hdr`, key `adjustment_number`)**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `adjustment_number` | Decimal | Key | Server-generated — leave unset on a new adjustment |
+| `company_id` | Char | Yes | Company ID |
+| `location_id` | Decimal | Yes | Location being adjusted |
+| `reason_id` | Char | Yes | The reason's **display text** (with `UseCodeValues: false`), not its code |
+| `period` / `year_for_period` | Decimal | Yes (per definition) | Accounting period / year for the adjustment |
+| `inv_adj_description` | Char | No | Free-text description |
+| `approved` | Char | No | `ON` / `OFF` |
+
+The verified minimal header from the manual is `location_id` + `reason_id`; the definition additionally marks `company_id`, `period`, and `year_for_period` as `Required`.
+
+**Lines — `TABPAGE_17.tp_17_dw_17` (List, business object `inv_adj_line`)**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `item_id` | Char | Yes | Item to adjust |
+| `unit_quantity` | Decimal | Yes | **The signed delta** (label "Adjustment Amount") — e.g. `-5` writes off 5 units; negative on-hand zeroes it out |
+| `unit_of_measure` | Char | No | |
+| `unit_size` | Decimal | Yes (per definition) | From `item_uom.unit_size` |
+| `new_qoh` | Decimal | No | Resulting quantity on hand (display) |
+
+The verified minimal line from the manual is `item_id` + `unit_quantity`.
+
+## Complete example
+
+Writes off 5 units of `WIDGET-001` at location `10`, then reads the adjustment back by its server-generated `adjustment_number`. Auth comes from the [shared helper](README.md#shared-conventions-recipes-dont-repeat-these).
+
+<!-- tabs -->
+```python
+import httpx
+
+BASE_URL = "https://play.p21server.com"
+token, ui_server, headers = p21_auth(BASE_URL, "api_user", "api_pass")
+
+payload = {
+    "Name": "InventoryAdjustment",
+    "UseCodeValues": False,  # reason_id is the display text, not the code
+    "Transactions": [{
+        "Status": "New",
+        "DataElements": [
+            {
+                "Name": "TABPAGE_1.tp_1_dw_1",
+                "Type": "Form",
+                "Keys": [],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "company_id", "Value": "ACME"},
+                        {"Name": "location_id", "Value": "10"},
+                        {"Name": "reason_id", "Value": "ADJUST"},  # display text
+                        {"Name": "inv_adj_description", "Value": "Cycle count write-off"},
+                    ],
+                    "RelativeDateEdits": [],
+                }],
+            },
+            {
+                "Name": "TABPAGE_17.tp_17_dw_17",
+                "Type": "List",
+                "Keys": [],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "item_id", "Value": "WIDGET-001"},
+                        {"Name": "unit_quantity", "Value": "-5"},  # signed delta, NOT new on-hand
+                    ],
+                    "RelativeDateEdits": [],
+                }],
+            },
+        ],
+    }],
+}
+
+resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                  headers=headers, json=payload, verify=False, timeout=120)
+resp.raise_for_status()  # HTTP 200 even on failure -- check the Summary
+result = resp.json()
+
+summary = result["Summary"]
+print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+if summary["Failed"] > 0:
+    for msg in result.get("Messages", []):
+        print(f"  {msg}")
+    raise SystemExit("Adjustment failed")
+
+# Pull the server-generated adjustment_number out of the echoed DataElements
+adjustment_number = None
+for txn in result.get("Results", {}).get("Transactions", []):
+    for de in txn.get("DataElements", []):
+        if de.get("Name") == "TABPAGE_1.tp_1_dw_1":
+            for row in de.get("Rows", []):
+                for edit in row.get("Edits", []):
+                    if edit["Name"] == "adjustment_number" and edit.get("Value"):
+                        adjustment_number = edit["Value"]
+print(f"Adjustment number: {adjustment_number}")
+
+# --- Read the adjustment back ---
+get_payload = {
+    "ServiceName": "InventoryAdjustment",
+    "TransactionStates": [{
+        "DataElementName": "TABPAGE_1.tp_1_dw_1",
+        "Keys": [{"Name": "adjustment_number", "Value": adjustment_number}],
+    }],
+}
+resp = httpx.post(f"{ui_server}/api/v2/transaction/get",
+                  headers=headers, json=get_payload, verify=False)
+resp.raise_for_status()
+for txn in resp.json().get("Transactions", []):
+    for de in txn.get("DataElements", []):
+        for row in de.get("Rows", []):
+            for edit in row.get("Edits", []):
+                if edit["Name"] in ("adjustment_number", "location_id", "reason_id",
+                                    "item_id", "unit_quantity", "new_qoh"):
+                    print(f"  {edit['Name']}: {edit['Value']}")
+```
+
+```csharp
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+
+var payload = new JObject
+{
+    ["Name"] = "InventoryAdjustment",
+    ["UseCodeValues"] = false,  // reason_id is the display text, not the code
+    ["Transactions"] = new JArray
+    {
+        new JObject
+        {
+            ["Status"] = "New",
+            ["DataElements"] = new JArray
+            {
+                new JObject
+                {
+                    ["Name"] = "TABPAGE_1.tp_1_dw_1",
+                    ["Type"] = "Form",
+                    ["Keys"] = new JArray(),
+                    ["Rows"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Edits"] = new JArray
+                            {
+                                new JObject { ["Name"] = "company_id", ["Value"] = "ACME" },
+                                new JObject { ["Name"] = "location_id", ["Value"] = "10" },
+                                new JObject { ["Name"] = "reason_id", ["Value"] = "ADJUST" }, // display text
+                                new JObject { ["Name"] = "inv_adj_description", ["Value"] = "Cycle count write-off" }
+                            },
+                            ["RelativeDateEdits"] = new JArray()
+                        }
+                    }
+                },
+                new JObject
+                {
+                    ["Name"] = "TABPAGE_17.tp_17_dw_17",
+                    ["Type"] = "List",
+                    ["Keys"] = new JArray(),
+                    ["Rows"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Edits"] = new JArray
+                            {
+                                new JObject { ["Name"] = "item_id", ["Value"] = "WIDGET-001" },
+                                // signed delta, NOT new on-hand
+                                new JObject { ["Name"] = "unit_quantity", ["Value"] = "-5" }
+                            },
+                            ["RelativeDateEdits"] = new JArray()
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+var resp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction",
+    new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+resp.EnsureSuccessStatusCode();  // HTTP 200 even on failure -- check the Summary
+var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+
+var summary = result["Summary"]!;
+Console.WriteLine($"Succeeded: {summary["Succeeded"]}, Failed: {summary["Failed"]}");
+if ((int)summary["Failed"]! > 0)
+{
+    foreach (var msg in result["Messages"] as JArray ?? new JArray())
+        Console.WriteLine($"  {msg}");
+    throw new Exception("Adjustment failed");
+}
+
+// Pull the server-generated adjustment_number out of the echoed DataElements
+string? adjustmentNumber = null;
+foreach (var txn in result["Results"]?["Transactions"] as JArray ?? new JArray())
+foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+{
+    if (de["Name"]?.ToString() != "TABPAGE_1.tp_1_dw_1") continue;
+    foreach (var row in de["Rows"] as JArray ?? new JArray())
+    foreach (var edit in row["Edits"] as JArray ?? new JArray())
+        if (edit["Name"]?.ToString() == "adjustment_number" &&
+            !string.IsNullOrEmpty(edit["Value"]?.ToString()))
+            adjustmentNumber = edit["Value"]!.ToString();
+}
+Console.WriteLine($"Adjustment number: {adjustmentNumber}");
+
+// --- Read the adjustment back ---
+var getPayload = new JObject
+{
+    ["ServiceName"] = "InventoryAdjustment",
+    ["TransactionStates"] = new JArray
+    {
+        new JObject
+        {
+            ["DataElementName"] = "TABPAGE_1.tp_1_dw_1",
+            ["Keys"] = new JArray
+            {
+                new JObject { ["Name"] = "adjustment_number", ["Value"] = adjustmentNumber }
+            }
+        }
+    }
+};
+var getResp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction/get",
+    new StringContent(getPayload.ToString(), Encoding.UTF8, "application/json"));
+getResp.EnsureSuccessStatusCode();
+var getResult = JObject.Parse(await getResp.Content.ReadAsStringAsync());
+
+var wanted = new[] { "adjustment_number", "location_id", "reason_id",
+                     "item_id", "unit_quantity", "new_qoh" };
+foreach (var txn in getResult["Transactions"] as JArray ?? new JArray())
+foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+foreach (var row in de["Rows"] as JArray ?? new JArray())
+foreach (var edit in row["Edits"] as JArray ?? new JArray())
+    if (wanted.Contains(edit["Name"]?.ToString()))
+        Console.WriteLine($"  {edit["Name"]}: {edit["Value"]}");
+```
+<!-- /tabs -->
+
+## Gotchas
+
+- **`reason_id` takes the display text** of the reason — not its code — with `UseCodeValues: false`.
+- **`unit_quantity` is the signed delta**, not the new on-hand. `-5` removes 5 units; the resulting quantity shows in `new_qoh`. To zero an item out, post the negative of its current on-hand.
+- **The save posts the adjustment** — there is no draft state in this flow, and no invoice is involved.
+- **Definition-required header fields:** besides `location_id` and `reason_id` (the manual's verified pair), the [definition](../../definitions/InventoryAdjustment.json) marks `company_id`, `period`, and `year_for_period` as `Required` on `tp_1_dw_1`.
+- **HTTP 200 is not success** — check `Summary.Succeeded` / `Summary.Failed` and print `Messages`.
+
+## Verify
+
+Read the adjustment back by its key (second half of the example): `POST /api/v2/transaction/get` on `InventoryAdjustment`, element `TABPAGE_1.tp_1_dw_1`, keyed by the server-generated `adjustment_number` — confirm the header (`location_id`, `reason_id`) and the line's `item_id` / `unit_quantity` landed, and check `new_qoh` for the resulting on-hand.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier)

--- a/docs/recipes/order-with-assembly.md
+++ b/docs/recipes/order-with-assembly.md
@@ -1,0 +1,391 @@
+# Order with an Assembly Line
+
+Enter a sales order interactively when a line is an assembly that must explode into components and/or spawn a production order.
+
+**API:** Interactive · **Service:** `Order` (window) · **Deep dive:** [Sales Order Entry with Assembly Lines](../04-Interactive-API.md#sales-order-entry-with-assembly-lines) · [Response Windows](../04-Interactive-API.md#response-windows) · **Full schema:** [Order.json](../../definitions/Order.json)
+
+## Prerequisites
+
+- Token + UI server URL (shared auth helper — see the [recipes README](README.md)).
+- The item is configured as an assembly (`assembly_hdr`): `production_order_processing` `Y` = production-order assembly / `N` = kit; `auto_create_prod_order` `Y` = auto-create and link the production order at save.
+- **Why not the Transaction API?** Entering an assembly item there fires an *"add as assembly?"* prompt which the stateless API auto-answers **No**, killing the explode ([Order Service Gotchas](../03-Transaction-API.md#order-service-gotchas)). The Interactive API lets you answer it. For plain (non-assembly) orders, use the simpler [create-sales-order](create-sales-order.md) recipe instead.
+- The session must be started with **`ResponseWindowHandlingEnabled: true`** so you can inspect and answer the prompts yourself.
+
+## Flow
+
+1. **Start a session** with response-window handling enabled:
+
+   ```json
+   POST /api/ui/interactive/sessions
+   { "ResponseWindowHandlingEnabled": true }
+   ```
+
+2. **Open the Order window**:
+
+   ```json
+   POST /api/ui/interactive/v2/window
+   { "ServiceName": "Order" }
+   ```
+
+3. **Set header fields** on `TabName: "TABPAGE_1"`, `DatawindowName: "order"` — `quote` (`OFF` = real order, `ON` = quote), `sales_loc_id`, `source_loc_id`, `customer_id`, `ship_to_id`, `contact_id`, `order_date`, `requested_date`, `po_no`, `taker`:
+
+   ```json
+   PUT /api/ui/interactive/v2/change
+   {
+       "WindowId": "{windowId}",
+       "List": [{
+           "TabName": "TABPAGE_1",
+           "DatawindowName": "order",
+           "FieldName": "customer_id",
+           "Value": "100198"
+       }]
+   }
+   ```
+
+   **Setting the dates fires a date-cascade prompt** (`w_response_common`, buttons `cb_ok`/`cb_cancel`) *even on a brand-new order*: the change result comes back `Status: 3` (Blocked) with a `windowopened` event carrying the popup's window ID. Answer **`cb_ok`** against the **popup's** window ID:
+
+   ```json
+   POST /api/ui/interactive/v2/tools
+   { "WindowId": "{popupWindowId}", "ToolName": "cb_ok" }
+   ```
+
+4. **Switch to the lines tab**:
+
+   ```json
+   PUT /api/ui/interactive/v2/tab
+   { "WindowId": "{windowId}", "PageName": "TP_ITEMS" }
+   ```
+
+5. **Set `oe_order_item_id` on the *existing* `items` row** (`TabName: "TP_ITEMS"`, `DatawindowName: "items"` — do **not** add a row for the first line). On an assembly item this fires the **assembly prompt** (buttons `cb_1` = Yes / `cb_2` = No / `cb_3` = Cancel) — answer **`cb_1`** to explode the assembly / link a production order.
+
+6. **Set `unit_quantity`** on the same row.
+
+7. **Save** — in v2 the body is the bare window-ID string, *not* an object:
+
+   ```json
+   PUT /api/ui/interactive/v2/data
+   "{windowId}"
+   ```
+
+   Answer any follow-on prompts with their proceed button.
+
+8. **Read the generated `order_no`** from the window data: `GET /api/ui/interactive/v2/data?id={windowId}` (returns the datawindows on the active surface — switch back to `TABPAGE_1` first so the `order` datawindow is active).
+
+9. **Clean up**: `DELETE /api/ui/interactive/v2/window?id={windowId}`, then `DELETE /api/ui/interactive/sessions`.
+
+## Complete example
+
+Includes an `answer_response_windows` helper grounded in the [Response Windows](../04-Interactive-API.md#response-windows) pattern: loop over `windowopened` events, discover the popup's buttons with `GET /v2/tools?windowId={popupId}`, click one with `POST /v2/tools`.
+
+<!-- tabs -->
+```python
+BASE_URL = "https://play.p21server.com"
+USERNAME = "api_user"
+PASSWORD = "api_pass"
+
+token, ui_server, headers = p21_auth(BASE_URL, USERNAME, PASSWORD)
+iapi = f"{ui_server}/api/ui/interactive"
+
+
+def is_blocked(result: dict) -> bool:
+    # Status is an integer (ResultStatus enum: 0 None, 1 Success, 2 Failure,
+    # 3 Blocked) but may appear as a string in some contexts -- handle both.
+    return result.get("Status") in (3, "Blocked")
+
+
+def popup_ids(result: dict) -> list[str]:
+    """Window IDs of popups opened by the last action.
+
+    Events[].Data is a key-value list: [{"Key": "windowid", "Value": "..."}].
+    """
+    ids = []
+    for event in result.get("Events", []):
+        if event.get("Name") == "windowopened":
+            for kv in event.get("Data", []):
+                if kv.get("Key") == "windowid":
+                    ids.append(kv["Value"])
+    return ids
+
+
+def answer_response_windows(result: dict, button: str | None = None) -> dict:
+    """Answer every popup the last action opened, then return the last result.
+
+    Discovers buttons via GET /v2/tools?windowId= (the tools endpoint takes
+    ?windowId=, NOT ?id=), then clicks via POST /v2/tools with the POPUP's
+    window ID. If `button` is None, picks the first proceed-style button.
+    """
+    for popup_id in popup_ids(result):
+        tools = httpx.get(
+            f"{iapi}/v2/tools", params={"windowId": popup_id},
+            headers=headers, verify=False,
+        )
+        tools.raise_for_status()
+        available = [t.get("Name") or t.get("ToolName") for t in tools.json()]
+        pick = button
+        if pick is None:  # prefer common proceed buttons
+            pick = next((b for b in ("cb_ok", "cb_1", "cb_yes") if b in available), None)
+        if pick is None or pick not in available:
+            raise RuntimeError(f"Popup {popup_id}: buttons {available}, wanted {button}")
+        click = httpx.post(
+            f"{iapi}/v2/tools", headers=headers, verify=False,
+            json={"WindowId": popup_id, "ToolName": pick},
+        )
+        click.raise_for_status()
+        result = click.json()
+    return result
+
+
+def change(window_id: str, tab: str, dw: str, field: str, value: str,
+           answer: str | None = None) -> dict:
+    """Change one field; answer the popup it triggers (if any) with `answer`."""
+    resp = httpx.put(
+        f"{iapi}/v2/change", headers=headers, verify=False,
+        json={"WindowId": window_id, "List": [{
+            "TabName": tab, "DatawindowName": dw,  # DatawindowName required on 25.2+
+            "FieldName": field, "Value": value,
+        }]},
+    )
+    resp.raise_for_status()
+    result = resp.json()
+    if result.get("Status") in (2, "Failure"):
+        raise RuntimeError(f"{field}: {result.get('Messages')}")
+    if is_blocked(result):
+        result = answer_response_windows(result, answer)
+    return result
+
+
+# 1. Session with response-window handling ON
+httpx.post(
+    f"{iapi}/sessions", headers=headers, verify=False,
+    json={"ResponseWindowHandlingEnabled": True},
+).raise_for_status()
+
+# 2. Open the Order window
+win = httpx.post(
+    f"{iapi}/v2/window", headers=headers, verify=False,
+    json={"ServiceName": "Order"},
+)
+win.raise_for_status()
+window_id = win.json()["WindowId"]
+
+try:
+    # 3. Header -- TABPAGE_1 / datawindow "order". quote OFF = real order.
+    change(window_id, "TABPAGE_1", "order", "quote", "OFF")
+    change(window_id, "TABPAGE_1", "order", "sales_loc_id", "10")
+    change(window_id, "TABPAGE_1", "order", "source_loc_id", "10")
+    change(window_id, "TABPAGE_1", "order", "customer_id", "100198")
+    change(window_id, "TABPAGE_1", "order", "ship_to_id", "200")
+    change(window_id, "TABPAGE_1", "order", "contact_id", "300")
+    # Dates fire the w_response_common date-cascade prompt even on a NEW order
+    change(window_id, "TABPAGE_1", "order", "order_date", "2030-01-05", answer="cb_ok")
+    change(window_id, "TABPAGE_1", "order", "requested_date", "2030-01-06", answer="cb_ok")
+    change(window_id, "TABPAGE_1", "order", "po_no", "PO-TEST-001")
+    change(window_id, "TABPAGE_1", "order", "taker", "JSMITH")  # else = API user
+
+    # 4. Lines tab
+    httpx.put(
+        f"{iapi}/v2/tab", headers=headers, verify=False,
+        json={"WindowId": window_id, "PageName": "TP_ITEMS"},
+    ).raise_for_status()
+
+    # 5. Item on the EXISTING items row (no /v2/row add for the first line).
+    #    Assembly prompt: cb_1 = Yes (explode / link prod order).
+    change(window_id, "TP_ITEMS", "items", "oe_order_item_id", "WIDGET-001", answer="cb_1")
+    # 6. Quantity
+    change(window_id, "TP_ITEMS", "items", "unit_quantity", "5")
+
+    # 7. Save -- v2 body is the bare window-ID string (an object => 422)
+    save = httpx.put(f"{iapi}/v2/data", headers=headers, verify=False, json=window_id)
+    save.raise_for_status()
+    result = save.json()
+    while is_blocked(result):  # follow-on prompts: answer with proceed button
+        result = answer_response_windows(result)
+    if result.get("Status") in (2, "Failure"):
+        raise RuntimeError(f"Save failed: {result.get('Messages')}")
+
+    # 8. Read order_no back. GET /v2/data returns the ACTIVE surface --
+    #    switch back to the header tab first.
+    httpx.put(
+        f"{iapi}/v2/tab", headers=headers, verify=False,
+        json={"WindowId": window_id, "PageName": "TABPAGE_1"},
+    ).raise_for_status()
+    data = httpx.get(
+        f"{iapi}/v2/data", params={"id": window_id},
+        headers=headers, verify=False,
+    )
+    data.raise_for_status()
+    for dw in data.json():
+        if dw.get("Name") == "order":
+            row = dw["Data"][dw.get("ActiveRow", 0)]
+            order_no = row[dw["Columns"].index("order_no")]
+            print(f"Created order_no: {order_no}")
+finally:
+    # 9. Clean up (window uses ?id=; sessions endpoint takes no parameter)
+    httpx.delete(f"{iapi}/v2/window", params={"id": window_id},
+                 headers=headers, verify=False)
+    httpx.delete(f"{iapi}/sessions", headers=headers, verify=False)
+```
+
+```csharp
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+var http = session.Http;
+var iapi = $"{session.UiServer}/api/ui/interactive";
+
+bool IsBlocked(JObject r) =>
+    r["Status"]?.ToString() is "3" or "Blocked";  // int or string form
+
+List<string> PopupIds(JObject r) =>
+    (r["Events"] as JArray ?? new JArray())
+        .Where(e => e["Name"]?.ToString() == "windowopened")
+        .SelectMany(e => e["Data"] as JArray ?? new JArray())
+        .Where(kv => kv["Key"]?.ToString() == "windowid")
+        .Select(kv => kv["Value"]!.ToString())
+        .ToList();
+
+// Answer every popup the last action opened; button null => first proceed button.
+async Task<JObject> AnswerResponseWindowsAsync(JObject result, string? button = null)
+{
+    foreach (var popupId in PopupIds(result))
+    {
+        // Tools endpoint takes ?windowId=, NOT ?id=
+        var toolsResp = await http.GetAsync($"{iapi}/v2/tools?windowId={popupId}");
+        toolsResp.EnsureSuccessStatusCode();
+        var available = JArray.Parse(await toolsResp.Content.ReadAsStringAsync())
+            .Select(t => (t["Name"] ?? t["ToolName"])?.ToString()).ToList();
+        var pick = button
+            ?? new[] { "cb_ok", "cb_1", "cb_yes" }.FirstOrDefault(available.Contains)
+            ?? throw new InvalidOperationException(
+                $"Popup {popupId}: buttons [{string.Join(", ", available)}]");
+        var clickBody = new JObject { ["WindowId"] = popupId, ["ToolName"] = pick };
+        var clickResp = await http.PostAsync($"{iapi}/v2/tools",
+            new StringContent(clickBody.ToString(), Encoding.UTF8, "application/json"));
+        clickResp.EnsureSuccessStatusCode();
+        result = JObject.Parse(await clickResp.Content.ReadAsStringAsync());
+    }
+    return result;
+}
+
+async Task<JObject> ChangeAsync(string windowId, string tab, string dw,
+    string field, string value, string? answer = null)
+{
+    var body = new JObject
+    {
+        ["WindowId"] = windowId,
+        ["List"] = new JArray { new JObject
+        {
+            ["TabName"] = tab,
+            ["DatawindowName"] = dw,   // required on 25.2+
+            ["FieldName"] = field,
+            ["Value"] = value,
+        }},
+    };
+    var resp = await http.PutAsync($"{iapi}/v2/change",
+        new StringContent(body.ToString(), Encoding.UTF8, "application/json"));
+    resp.EnsureSuccessStatusCode();
+    var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+    if (result["Status"]?.ToString() is "2" or "Failure")
+        throw new InvalidOperationException($"{field}: {result["Messages"]}");
+    return IsBlocked(result) ? await AnswerResponseWindowsAsync(result, answer) : result;
+}
+
+// 1. Session with response-window handling ON
+var sessBody = new JObject { ["ResponseWindowHandlingEnabled"] = true };
+(await http.PostAsync($"{iapi}/sessions",
+    new StringContent(sessBody.ToString(), Encoding.UTF8, "application/json")))
+    .EnsureSuccessStatusCode();
+
+// 2. Open the Order window
+var winBody = new JObject { ["ServiceName"] = "Order" };
+var winResp = await http.PostAsync($"{iapi}/v2/window",
+    new StringContent(winBody.ToString(), Encoding.UTF8, "application/json"));
+winResp.EnsureSuccessStatusCode();
+var windowId = JObject.Parse(await winResp.Content.ReadAsStringAsync())["WindowId"]!.ToString();
+
+try
+{
+    // 3. Header -- TABPAGE_1 / datawindow "order". quote OFF = real order.
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "quote", "OFF");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "sales_loc_id", "10");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "source_loc_id", "10");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "customer_id", "100198");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "ship_to_id", "200");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "contact_id", "300");
+    // Dates fire the w_response_common date-cascade prompt even on a NEW order
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "order_date", "2030-01-05", "cb_ok");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "requested_date", "2030-01-06", "cb_ok");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "po_no", "PO-TEST-001");
+    await ChangeAsync(windowId, "TABPAGE_1", "order", "taker", "JSMITH"); // else = API user
+
+    // 4. Lines tab
+    var tabBody = new JObject { ["WindowId"] = windowId, ["PageName"] = "TP_ITEMS" };
+    (await http.PutAsync($"{iapi}/v2/tab",
+        new StringContent(tabBody.ToString(), Encoding.UTF8, "application/json")))
+        .EnsureSuccessStatusCode();
+
+    // 5. Item on the EXISTING items row; assembly prompt: cb_1 = Yes (explode)
+    await ChangeAsync(windowId, "TP_ITEMS", "items", "oe_order_item_id", "WIDGET-001", "cb_1");
+    // 6. Quantity
+    await ChangeAsync(windowId, "TP_ITEMS", "items", "unit_quantity", "5");
+
+    // 7. Save -- v2 body is the bare window-ID JSON string (an object => 422)
+    var saveResp = await http.PutAsync($"{iapi}/v2/data",
+        new StringContent(JsonConvert.SerializeObject(windowId), Encoding.UTF8, "application/json"));
+    saveResp.EnsureSuccessStatusCode();
+    var result = JObject.Parse(await saveResp.Content.ReadAsStringAsync());
+    while (IsBlocked(result))  // follow-on prompts: answer with proceed button
+        result = await AnswerResponseWindowsAsync(result);
+    if (result["Status"]?.ToString() is "2" or "Failure")
+        throw new InvalidOperationException($"Save failed: {result["Messages"]}");
+
+    // 8. Read order_no back -- /v2/data returns the ACTIVE surface, so
+    //    switch back to the header tab first.
+    var backBody = new JObject { ["WindowId"] = windowId, ["PageName"] = "TABPAGE_1" };
+    (await http.PutAsync($"{iapi}/v2/tab",
+        new StringContent(backBody.ToString(), Encoding.UTF8, "application/json")))
+        .EnsureSuccessStatusCode();
+    var dataResp = await http.GetAsync($"{iapi}/v2/data?id={windowId}");
+    dataResp.EnsureSuccessStatusCode();
+    foreach (var dw in JArray.Parse(await dataResp.Content.ReadAsStringAsync()))
+    {
+        if (dw["Name"]?.ToString() != "order") continue;
+        var columns = (dw["Columns"] as JArray)!.Select(c => c.ToString()).ToList();
+        var row = (dw["Data"] as JArray)![(int?)dw["ActiveRow"] ?? 0];
+        Console.WriteLine($"Created order_no: {row[columns.IndexOf("order_no")]}");
+    }
+}
+finally
+{
+    // 9. Clean up (window uses ?id=; sessions endpoint takes no parameter)
+    await http.DeleteAsync($"{iapi}/v2/window?id={windowId}");
+    await http.DeleteAsync($"{iapi}/sessions");
+}
+```
+<!-- /tabs -->
+
+## Gotchas
+
+All verified end-to-end — details in [Sales Order Entry with Assembly Lines](../04-Interactive-API.md#sales-order-entry-with-assembly-lines) and [Response Windows](../04-Interactive-API.md#response-windows):
+
+- **Do NOT use the quickmode datawindow** (`d_dw_quickmode_*`) to enter lines — it **bypasses the assembly prompt entirely**, and the line lands without the explode.
+- **`taker` defaults to the API user** — override it with the real salesperson or the order is attributed to the service account.
+- **The date-cascade prompt fires even on a brand-new order** (`w_response_common`, `cb_ok`/`cb_cancel`). Answer `cb_ok` via the **popup's** window ID, not the Order window's.
+- **Set the first line on the existing `items` row** — do not `POST /v2/row` a new row for it.
+- **Assembly prompt buttons are `cb_1` = Yes / `cb_2` = No / `cb_3` = Cancel** — `cb_1` explodes the assembly / links the production order. This is exactly the prompt the Transaction API auto-answers No, which is why that API can't do this job.
+- **Save body shape**: `PUT /v2/data` takes the bare window-ID string as the JSON body — wrapping it in an object is a common source of 422 errors.
+- **`?id=` vs `?windowId=`**: `/v2/window` and `/v2/data` take `?id=`, but `/v2/tools` takes `?windowId=` — the wrong one errors, there is no fallback.
+- **Status may be an integer or a string** (`3` or `"Blocked"`, from the `ResultStatus` enum `None=0, Success=1, Failure=2, Blocked=3`) — handle both.
+- **`DatawindowName` is required in v2 change requests on P21 25.2+** — the 3-parameter form (TabName + FieldName + Value) no longer works.
+
+## Verify
+
+On the saved order, `oe_line.assembly` codes: `B` = kit parent, `N` = component, `P` = production-order line, `S` = build-to-stock allocation. The production-order link is `prod_order_line_link` (`transaction_uid = oe_line.oe_line_uid`, `trans_type = 'O'`):
+
+```http
+GET {base_url}/odataservice/odata/table/oe_line?$filter=order_no eq '1013938'
+GET {base_url}/odataservice/odata/table/prod_order_line_link?$filter=trans_type eq 'O'
+```
+
+Confirm the assembly line shows the expected `assembly` code (e.g. `P`) and — for `auto_create_prod_order = 'Y'` items — that a `prod_order_line_link` row points at the line's `oe_line_uid`. See the [Production & Labor API guide](../12-Production-Labor-API.md) for the full production lifecycle.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier)

--- a/docs/recipes/production-order-runbook.md
+++ b/docs/recipes/production-order-runbook.md
@@ -1,0 +1,291 @@
+# Production Order Runbook — Create to Invoice
+
+Run a production order end-to-end: create it, log labor, print the pick ticket(s), confirm the pick, complete (receive) the order, and ship + invoice the linked sales order.
+
+**API:** Transaction + Interactive · **Service:** `ProductionOrder`, `m_picktickets`, `TimeEntry`, `ProductionOrderPicking`, `ProductionOrderProcessing`, `Order`, `Shipping` · **Deep dive:** [Production Order Lifecycle (End-to-End)](../12-Production-Labor-API.md#production-order-lifecycle-end-to-end) · **Full schema:** [ProductionOrder](../../definitions/ProductionOrder.json), [ProductionOrderPicking](../../definitions/ProductionOrderPicking.json), [ProductionOrderProcessing](../../definitions/ProductionOrderProcessing.json), [m_picktickets](../../definitions/m_picktickets.json)
+
+This page is a **checklist**, not a script. Each stage says what to call, the fields that matter, and the trap that costs an afternoon — with a link to the deep section. The one complete example below covers the stage most people automate first: generating the pick ticket and reading back its status. For runnable code on the other stages, see [record-labor-time](record-labor-time.md), [inventory-adjustment](inventory-adjustment.md), [order-with-assembly](order-with-assembly.md), [create-sales-order](create-sales-order.md), and [generate-pick-ticket-pdf](generate-pick-ticket-pdf.md).
+
+## Prerequisites
+
+- **An assembly (BOM) definition exists** for the item — you cannot create a production order for an item without one. Create it with the Transaction API `Assembly` service ([manual](../12-Production-Labor-API.md#assembly-service-cross-reference)).
+- **The finished item is set up at the source location**, or the save fails with *"item ID does not exist at your source location."*
+- **Know your assembly behavior flags** ([manual](../12-Production-Labor-API.md#assembly-behavior-flags)) — three ON/OFF flags on `assembly_hdr` decide how the item behaves:
+
+| Flag | `Y` | `N` |
+|------|-----|-----|
+| `production_order_processing` | Production-order assembly (sales order line spawns/links a production order) | Kit — explodes to components, no production order |
+| `auto_create_prod_order` | Auto-create + link the production order when the sales order saves | Create and link manually |
+| `assembly_for_stock` | Build-to-stock (units dwell in inventory) | Make-to-order |
+
+On a saved sales order, `oe_line.assembly` shows the outcome: `B` kit parent, `N` kit component, `P` production-order line, `S` build-to-stock line allocated from on-hand.
+
+## Runbook
+
+### Stage 1 — Create the production order
+
+Two paths ([deep dive](../12-Production-Labor-API.md#how-production-orders-get-created)):
+
+- **Path A — sales order auto-create (make-to-order).** Enter a sales order line for a `production_order_processing = Y` assembly (via the Interactive API when the line must explode — [order-with-assembly recipe](order-with-assembly.md)). With `auto_create_prod_order = Y`, P21 **nets against available stock**: stock on hand → the line allocates it and **no production order spawns**; short → an order spawns for the shortfall, linked via `prod_order_line_link`.
+- **Path B — direct build-to-stock.** Drive the `ProductionOrder` window: header `source_loc_id` (the make location) plus any required user-defined fields, then on `TABPAGE_17.tp_17_dw_17` set `assembly_item_id` and `qty_to_make` (add + select a row per extra line). No sales order involved.
+
+**The traps:** on Path A, the customer's **salesrep must be valid at the sales location** (a DynaChange rule blocks the order otherwise) and the **order date must differ from the required date**. A production order commonly gets **two pick tickets** — parts, plus labor/intangibles when intangible components source from a paired non-stock location.
+
+### Stage 2 — Log labor BEFORE printing
+
+Post labor via the `TimeEntry` service — [record-labor-time recipe](record-labor-time.md), [deep dive](../12-Production-Labor-API.md#labor-timing--log-labor-before-printing). Labor becomes a charge component that **must land on a pick ticket to be consumed at completion**.
+
+**The trap:** print first, add labor after (no reprint) → the labor is allocated but on no ticket (`qty_on_pick_tickets = 0`) and completion fails with *"components have a quantity used of 0."* Fix: reprint (generates a separate labor/intangibles ticket), then confirm the new ticket.
+
+### Stage 3 — Print the pick ticket and form
+
+Two ways ([deep dive](../12-Production-Labor-API.md#printing-the-pick-ticket-and-form)):
+
+- **`ProductionOrder` transaction** with `print_pick_ticket = ON` and `print_form = ON` on `TABPAGE_1.tp_1_dw_1` — creates the ticket, sets `prod_order_hdr.printed = 'Y'`, returns the PDFs in the response ([manual](../03-Transaction-API.md#pdfs-from-the-transaction-endpoint-print-flags)).
+- **`m_picktickets` report** at `POST /api/v2/process/pdfreport` — creates the ticket at whatever `location_id` you specify and returns the PDF ([worked example](../03-Transaction-API.md#example-generate-a-production-order-pick-ticket-m_picktickets), and the complete example below).
+
+**The traps:** `print_pick_ticket` emits **only at the make location** — components stocked elsewhere means the form comes back but no usable ticket; use `m_picktickets` at the stock location instead. A parts ticket only generates if the components have **stock at the source location**. Documents only return on a **savable** order — a bare reprint with nothing new errors *"Save is not enabled."* And never post an `m_*` report to `/api/v2/transaction` — it returns `Succeeded` and **emits nothing**.
+
+### Stage 4 — Confirm the pick (Interactive API ONLY)
+
+Open the `ProductionOrderPicking` window, load the ticket on header `TP_PRODPICKTICKETCONF.tp_prodpickticketconf` (key `prod_pick_ticket_number`), set the Confirm Pick field `row_status_flag` to `"Confirm"`, save. Confirm **every** ticket — parts *and* labor/intangibles. [Deep dive](../12-Production-Labor-API.md#confirming-the-pick--use-the-interactive-api).
+
+**The trap (the star of this page):** posting `row_status_flag = 'Confirm'` through a bare `POST /api/v2/transaction` produces a **shell confirm** — the ticket status flips to `1962` and `qty_confirmed` gets stamped, but **`qty_applied` stays 0 and no stock moves**. The per-bin posted quantities live in a disabled `TP_BIN` grid that only the windowed (Interactive API or desktop) confirm populates. The real confirm applies the pick and moves components to the make location's WIP bin (`inv_loc.primary_bin` at `prod_order_hdr.source_location_id`; bin `0` when no primary is set).
+
+Ticket status codes (`prod_pick_ticket_hdr.row_status_flag`): `702` Open · `1962` Confirmed · `1268` Completed. Detail rows: `704` normal, `1268` at completion.
+
+### Stage 5 — Complete the order (production receipt)
+
+Drive the `ProductionOrderProcessing` window ([deep dive](../12-Production-Labor-API.md#completing-the-production-order-production-receipt)):
+
+1. Select the line on `TABPAGE_17.tp_17_dw_17`, set **`qty_to_complete`** (partial completion is supported; `qty_completed` is a read-only rollup).
+2. On `TABPAGE_ASSEMBLY_BIN.tabpage_assembly_bin` set **`bin_cd`** (the finished item's `inv_loc.primary_bin`, often `0`) and **`unit_quantity`** (= the completion quantity) — **as two separate change calls**.
+3. Optional per-component cost override: once `qty_to_complete` is set, `TABPAGE_18.tp_18_dw_18` exposes an editable **`new_cost`** per component; it flows `new_cost` → `PROP` receipt cost → moving average → invoice COGS.
+4. Save → the assembly is received into inventory (`inv_tran` type `PROP`) and the ticketed components are consumed.
+
+**The trap:** combining `bin_cd` and `unit_quantity` in one change call **drops the quantity**, and a later completion errors *"sum of bin quantity ... does not equal quantity made."*
+
+### Stage 6 — Ship and invoice the linked sales order
+
+[Deep dive](../12-Production-Labor-API.md#shipping-and-invoicing-the-linked-sales-order):
+
+1. Print the **sales order** pick ticket: `Order` service transaction with `print_tix = ON` on `TP_FRONTCOUNTER.tp_frontcounter` (creates `oe_pick_ticket`).
+2. Ship + invoice: the `Shipping` service, header `tp_1_dw_1` keyed by `pick_ticket_no` — retrieve and **save**. `create_invoice` defaults ON, so the save ships **and** invoices in one step. Partial shipments are supported.
+
+**The traps:** the item needs a **packaging code** or the save fails. For contract pricing, leave `unit_price` unset and P21 auto-fills the job-contract price (binding `oe_line.job_price_hdr_uid`) — the contract must cover that **specific ship-to**.
+
+### Stage 7 — Fix quantity fallout (write-offs)
+
+If on-hand ends up wrong, post an `InventoryAdjustment` — [inventory-adjustment recipe](inventory-adjustment.md), [deep dive](../12-Production-Labor-API.md#inventory-adjustment-write-offs).
+
+> **Cost model — before trusting COGS** ([deep dive](../12-Production-Labor-API.md#cost-model--know-this-before-trusting-cogs)): the `PROP` receipt cost = components + labor posted **before** completion. Shipment COGS is the **moving average at ship time**, not that order's receipt — while 2+ units sit in stock, a cost added to one smears across all (build-to-stock is exposed by design; make-to-order is largely immune). Labor posted after invoicing spawns a separate *"Post Freight/Labor Prod. Order: NNNN"* invoice ($0 price, ± COGS); the original invoice is untouched.
+
+## Complete example — print the pick ticket and read back its status
+
+Generates the production pick ticket at the **stock** location with `m_picktickets` (creates the ticket record *and* returns the PDF), then reads the new ticket back with `POST /api/v2/transaction/get` to check its status. Prerequisite: the order's form must already be printed (`prod_order_hdr.printed = 'Y'`) — run a `ProductionOrder` transaction with `print_form = ON` first. Auth comes from the [shared helper](README.md#shared-conventions-recipes-dont-repeat-these).
+
+<!-- tabs -->
+```python
+import base64
+import re
+
+import httpx
+
+BASE_URL = "https://play.p21server.com"
+token, ui_server, headers = p21_auth(BASE_URL, "api_user", "api_pass")
+
+PROD_ORDER = "1000123"   # production order number
+STOCK_LOCATION = "10"    # where the components stock (NOT necessarily the make location)
+
+# --- 1. Generate the pick ticket (creates the record + returns the PDF) ---
+report = {
+    "Name": "m_picktickets",
+    "UseCodeValues": True,  # m_picktickets REQUIRES code values; False returns HTTP 500
+    "Transactions": [{
+        "Status": 0,        # reports use numeric 0, not "New"
+        "DataElements": [{
+            "Keys": [],
+            "Type": 0,
+            "Name": "TABPAGE_1.tp_1_dw_1",
+            "Rows": [{"Edits": [
+                {"Name": "create_pick_ticket_type", "Value": "P"},  # code "P" = Production Order
+                {"Name": "beg_prod_order", "Value": PROD_ORDER},
+                {"Name": "end_prod_order", "Value": PROD_ORDER},
+                {"Name": "location_id", "Value": STOCK_LOCATION},
+            ]}],
+        }],
+    }],
+}
+
+resp = httpx.post(
+    f"{ui_server}/api/v2/process/pdfreport",  # NOT /api/v2/transaction (silent no-op there)
+    headers=headers, json=report, verify=False, timeout=120,
+)
+resp.raise_for_status()
+result = resp.json()
+
+if not isinstance(result, list):  # errors come back as an envelope, not an array
+    raise SystemExit(f"Report failed: {result.get('ErrorMessage')}")
+
+doc = result[0]
+if doc["ResponseStatus"]["StatusCode"] != "Success" or not doc.get("DocumentData"):
+    raise SystemExit(f"Report failed: {doc['ResponseStatus'].get('Message')}")
+
+file_name = doc["FileName"]  # e.g. "PPT123456 PRODUCTION_PICK_TICKET.pdf"
+with open(file_name, "wb") as f:
+    f.write(base64.b64decode(doc["DocumentData"]))
+print(f"Saved {file_name}")
+
+# --- 2. Read the new ticket back (ticket number comes from the FileName) ---
+ticket_no = re.match(r"PPT(\d+)", file_name).group(1)
+get_payload = {
+    "ServiceName": "ProductionOrderPicking",
+    "TransactionStates": [{
+        "DataElementName": "TP_PRODPICKTICKETCONF.tp_prodpickticketconf",
+        "Keys": [{"Name": "prod_pick_ticket_number", "Value": ticket_no}],
+    }],
+}
+resp = httpx.post(
+    f"{ui_server}/api/v2/transaction/get",
+    headers=headers, json=get_payload, verify=False,
+)
+resp.raise_for_status()
+
+for txn in resp.json().get("Transactions", []):
+    for de in txn.get("DataElements", []):
+        for row in de.get("Rows", []):
+            fields = {e["Name"]: e["Value"] for e in row.get("Edits", [])}
+            if "row_status_flag" in fields:
+                # 702 = Open, 1962 = Confirmed, 1268 = Completed
+                print(f"Ticket {fields.get('prod_pick_ticket_number')} "
+                      f"for prod order {fields.get('prod_order_number')}: "
+                      f"status {fields.get('row_status_flag')}")
+```
+
+```csharp
+using System.Text.RegularExpressions;
+
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+
+const string prodOrder = "1000123";   // production order number
+const string stockLocation = "10";    // where the components stock
+
+// --- 1. Generate the pick ticket (creates the record + returns the PDF) ---
+var report = new JObject
+{
+    ["Name"] = "m_picktickets",
+    ["UseCodeValues"] = true,  // m_picktickets REQUIRES code values; false returns HTTP 500
+    ["Transactions"] = new JArray
+    {
+        new JObject
+        {
+            ["Status"] = 0,    // reports use numeric 0, not "New"
+            ["DataElements"] = new JArray
+            {
+                new JObject
+                {
+                    ["Keys"] = new JArray(),
+                    ["Type"] = 0,
+                    ["Name"] = "TABPAGE_1.tp_1_dw_1",
+                    ["Rows"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Edits"] = new JArray
+                            {
+                                new JObject { ["Name"] = "create_pick_ticket_type", ["Value"] = "P" },
+                                new JObject { ["Name"] = "beg_prod_order", ["Value"] = prodOrder },
+                                new JObject { ["Name"] = "end_prod_order", ["Value"] = prodOrder },
+                                new JObject { ["Name"] = "location_id", ["Value"] = stockLocation }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// NOT /api/v2/transaction (silent no-op there)
+var reportResp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/process/pdfreport",
+    new StringContent(report.ToString(), Encoding.UTF8, "application/json"));
+reportResp.EnsureSuccessStatusCode();
+var reportBody = JToken.Parse(await reportResp.Content.ReadAsStringAsync());
+
+if (reportBody.Type != JTokenType.Array)  // errors come back as an envelope, not an array
+    throw new Exception($"Report failed: {reportBody["ErrorMessage"]}");
+
+var doc = (JObject)((JArray)reportBody)[0];
+if (doc["ResponseStatus"]?["StatusCode"]?.ToString() != "Success")
+    throw new Exception($"Report failed: {doc["ResponseStatus"]?["Message"]}");
+
+var fileName = doc["FileName"]!.ToString(); // e.g. "PPT123456 PRODUCTION_PICK_TICKET.pdf"
+await File.WriteAllBytesAsync(fileName, Convert.FromBase64String(doc["DocumentData"]!.ToString()));
+Console.WriteLine($"Saved {fileName}");
+
+// --- 2. Read the new ticket back (ticket number comes from the FileName) ---
+var ticketNo = Regex.Match(fileName, @"PPT(\d+)").Groups[1].Value;
+var getPayload = new JObject
+{
+    ["ServiceName"] = "ProductionOrderPicking",
+    ["TransactionStates"] = new JArray
+    {
+        new JObject
+        {
+            ["DataElementName"] = "TP_PRODPICKTICKETCONF.tp_prodpickticketconf",
+            ["Keys"] = new JArray
+            {
+                new JObject { ["Name"] = "prod_pick_ticket_number", ["Value"] = ticketNo }
+            }
+        }
+    }
+};
+
+var getResp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction/get",
+    new StringContent(getPayload.ToString(), Encoding.UTF8, "application/json"));
+getResp.EnsureSuccessStatusCode();
+var getResult = JObject.Parse(await getResp.Content.ReadAsStringAsync());
+
+foreach (var txn in getResult["Transactions"] as JArray ?? new JArray())
+foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+foreach (var row in de["Rows"] as JArray ?? new JArray())
+{
+    var fields = new Dictionary<string, string>();
+    foreach (var edit in row["Edits"] as JArray ?? new JArray())
+        fields[edit["Name"]!.ToString()] = edit["Value"]?.ToString() ?? "";
+    if (fields.ContainsKey("row_status_flag"))
+        // 702 = Open, 1962 = Confirmed, 1268 = Completed
+        Console.WriteLine($"Ticket {fields.GetValueOrDefault("prod_pick_ticket_number")} " +
+                          $"for prod order {fields.GetValueOrDefault("prod_order_number")}: " +
+                          $"status {fields.GetValueOrDefault("row_status_flag")}");
+}
+```
+<!-- /tabs -->
+
+## Gotchas
+
+- **Shell confirm (the big one).** Confirming a pick with a bare Transaction API POST flips the status to `1962` and stamps `qty_confirmed`, but leaves **`qty_applied = 0` and moves no stock** — confirm through the Interactive API `ProductionOrderPicking` window (Stage 4).
+- **Labor must be on a pick ticket before completion.** Labor added after printing, without a reprint, sits at `qty_on_pick_tickets = 0` and completion fails with *"components have a quantity used of 0"* (Stage 2).
+- **`bin_cd` and `unit_quantity` are two separate change calls** at completion — one combined call drops the quantity → *"sum of bin quantity ... does not equal quantity made"* (Stage 5).
+- **`print_pick_ticket` emits only at the make location** — components stocked elsewhere need `m_picktickets` at the stock `location_id` (Stage 3).
+- **`m_picktickets` needs `UseCodeValues: true`** and the code `"P"`; the display label is rejected, `UseCodeValues: false` returns HTTP 500. `Status`/`Type` numeric `0`, `Keys: []`.
+- **Reports go to `/api/v2/process/pdfreport`.** `/api/v2/transaction` accepts the payload, returns `Succeeded`, and emits nothing.
+- **Status codes:** `702` Open, `1962` Confirmed, `1268` Completed — a `1962` alone does not prove stock moved (see shell confirm).
+- **Auto-create nets against stock** — stock on hand means no production order spawns; salesrep must be valid at the sales location; order date must differ from required date (Stage 1).
+- **Confirm every ticket** — parts *and* the labor/intangibles ticket.
+
+## Verify
+
+After each stage, read back — don't trust the HTTP status:
+
+| Stage | Check |
+|-------|-------|
+| Print | Pick ticket exists and is `702` Open (example above); `prod_order_hdr.printed = 'Y'` |
+| Confirm | Ticket `row_status_flag = 1962` **and** quantities applied (`qty_applied > 0`) — a `1962` with `qty_applied = 0` is a shell confirm |
+| Complete | Ticket/detail rows at `1268`; assembly receipt posted as `inv_tran` type `PROP` |
+| Ship + invoice | Invoice created by the `Shipping` save; shipment posts `inv_tran` type `WO` |
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier)

--- a/docs/recipes/record-labor-time.md
+++ b/docs/recipes/record-labor-time.md
@@ -1,0 +1,260 @@
+# Record Labor Time on a Production Order
+
+Post a technician's labor hours to a production order with the `TimeEntry` service.
+
+**API:** Transaction · **Service:** `TimeEntry` · **Deep dive:** [Recording Labor Hours](../12-Production-Labor-API.md#recording-labor-hours-timeentry-service), [Quick Time Entry mechanics](../12-Production-Labor-API.md#time-entry-against-a-production-order-quick-time-entry), [Labor timing](../12-Production-Labor-API.md#labor-timing--log-labor-before-printing) · **Full schema:** [definitions/TimeEntry.json](../../definitions/TimeEntry.json)
+
+## Prerequisites
+
+- A production order exists (here `1000123`) with an assembly line (item `ASSY-100`) carrying a labor component (here `LABOR-SHOP`).
+- `technician_id` is a **contact ID** (here `300`) — not a P21 user ID.
+- The **accounting period for `entry_date` must be open**, or the save fails.
+- If the order will be completed later: **log labor before printing the pick ticket** (or reprint after) — labor must land on a pick ticket to be consumed at completion. See [the runbook](production-order-runbook.md).
+- For labor against **service orders**, use the separate `TimeEntrySO` service instead.
+
+## Payload
+
+`POST {ui_server}/api/v2/transaction`, `Status: "New"`, `UseCodeValues: false`. Two DataElements:
+
+**Header — `TP_TECHNICIAN.tp_technician` (Form)**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `company_id` | Char | Yes | Company ID |
+| `technician_id` | Char | Yes | **A contact ID**, not a user ID |
+| `entry_date` | Datetime | Yes | Accounting period for this date must be open |
+
+**Labor lines — `TP_LABORRECORDING.prod_order_line_comp_labor` (List, key `prod_order_number`)**
+
+Enter the fields **in this order** — out of order, the downstream fields stay disabled:
+
+| # | Field | Type | Notes |
+|---|-------|------|-------|
+| 1 | `prod_order_number` | Decimal | Key. The production order |
+| 2 | `item_id` | Char | The assembly **line's** item (not the component) |
+| 3 | `component_labor_id` | Char | The labor component on that line |
+| 4 | `start_time` | Datetime | |
+| 5 | `end_time` | Datetime | |
+
+Other fields from the definition: `service_labor_id` (labor ID from the `Labor` service — the alternate lookup used in the [manual's reference example](../12-Production-Labor-API.md#recording-labor-hours-timeentry-service)), `time_worked` (Char, `HH:MM`), `labor_type_cd` (Long, **required** — valid values `Rate`, `OT Rate`, `Prem Rate`), `operation_cd`, `cc_completeprodorder`.
+
+Time is stored per line at minute granularity and **accumulates across entries**; cost = minutes × the labor code's rate.
+
+## Complete example
+
+Posts 4 hours against the labor component, then reads the labor grid back. Auth comes from the [shared helper](README.md#shared-conventions-recipes-dont-repeat-these).
+
+<!-- tabs -->
+```python
+import httpx
+
+BASE_URL = "https://play.p21server.com"
+token, ui_server, headers = p21_auth(BASE_URL, "api_user", "api_pass")
+
+PROD_ORDER = "1000123"
+
+payload = {
+    "Name": "TimeEntry",
+    "UseCodeValues": False,
+    "Transactions": [{
+        "Status": "New",
+        "DataElements": [
+            {
+                "Name": "TP_TECHNICIAN.tp_technician",
+                "Type": "Form",
+                "Keys": [],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "company_id", "Value": "ACME"},
+                        {"Name": "technician_id", "Value": "300"},  # CONTACT id
+                        {"Name": "entry_date", "Value": "2030-01-05"},
+                    ],
+                    "RelativeDateEdits": [],
+                }],
+            },
+            {
+                "Name": "TP_LABORRECORDING.prod_order_line_comp_labor",
+                "Type": "List",
+                "Keys": ["prod_order_number"],
+                "Rows": [{
+                    # Strict order: prod_order_number -> item_id ->
+                    # component_labor_id -> start_time -> end_time
+                    "Edits": [
+                        {"Name": "prod_order_number", "Value": PROD_ORDER},
+                        {"Name": "item_id", "Value": "ASSY-100"},
+                        {"Name": "component_labor_id", "Value": "LABOR-SHOP"},
+                        {"Name": "start_time", "Value": "2030-01-05T08:00:00"},
+                        {"Name": "end_time", "Value": "2030-01-05T12:00:00"},
+                        {"Name": "labor_type_cd", "Value": "Rate"},
+                    ],
+                    "RelativeDateEdits": [],
+                }],
+            },
+        ],
+    }],
+}
+
+resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                  headers=headers, json=payload, verify=False, timeout=120)
+resp.raise_for_status()  # HTTP 200 even on failure -- check the Summary
+result = resp.json()
+
+summary = result["Summary"]
+print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+if summary["Failed"] > 0:
+    for msg in result.get("Messages", []):
+        print(f"  {msg}")
+    raise SystemExit("Time entry failed")
+
+# --- Read back the labor grid for the order ---
+get_payload = {
+    "ServiceName": "TimeEntry",
+    "TransactionStates": [{
+        "DataElementName": "TP_LABORRECORDING.prod_order_line_comp_labor",
+        "Keys": [{"Name": "prod_order_number", "Value": PROD_ORDER}],
+    }],
+}
+resp = httpx.post(f"{ui_server}/api/v2/transaction/get",
+                  headers=headers, json=get_payload, verify=False)
+resp.raise_for_status()
+for txn in resp.json().get("Transactions", []):
+    for de in txn.get("DataElements", []):
+        for row in de.get("Rows", []):
+            fields = {e["Name"]: e["Value"] for e in row.get("Edits", [])}
+            if fields.get("prod_order_number"):
+                print(f"  {fields.get('component_labor_id') or fields.get('service_labor_id')}: "
+                      f"time_worked={fields.get('time_worked')}")
+```
+
+```csharp
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+
+const string prodOrder = "1000123";
+
+var payload = new JObject
+{
+    ["Name"] = "TimeEntry",
+    ["UseCodeValues"] = false,
+    ["Transactions"] = new JArray
+    {
+        new JObject
+        {
+            ["Status"] = "New",
+            ["DataElements"] = new JArray
+            {
+                new JObject
+                {
+                    ["Name"] = "TP_TECHNICIAN.tp_technician",
+                    ["Type"] = "Form",
+                    ["Keys"] = new JArray(),
+                    ["Rows"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Edits"] = new JArray
+                            {
+                                new JObject { ["Name"] = "company_id", ["Value"] = "ACME" },
+                                new JObject { ["Name"] = "technician_id", ["Value"] = "300" }, // CONTACT id
+                                new JObject { ["Name"] = "entry_date", ["Value"] = "2030-01-05" }
+                            },
+                            ["RelativeDateEdits"] = new JArray()
+                        }
+                    }
+                },
+                new JObject
+                {
+                    ["Name"] = "TP_LABORRECORDING.prod_order_line_comp_labor",
+                    ["Type"] = "List",
+                    ["Keys"] = new JArray { "prod_order_number" },
+                    ["Rows"] = new JArray
+                    {
+                        new JObject
+                        {
+                            // Strict order: prod_order_number -> item_id ->
+                            // component_labor_id -> start_time -> end_time
+                            ["Edits"] = new JArray
+                            {
+                                new JObject { ["Name"] = "prod_order_number", ["Value"] = prodOrder },
+                                new JObject { ["Name"] = "item_id", ["Value"] = "ASSY-100" },
+                                new JObject { ["Name"] = "component_labor_id", ["Value"] = "LABOR-SHOP" },
+                                new JObject { ["Name"] = "start_time", ["Value"] = "2030-01-05T08:00:00" },
+                                new JObject { ["Name"] = "end_time", ["Value"] = "2030-01-05T12:00:00" },
+                                new JObject { ["Name"] = "labor_type_cd", ["Value"] = "Rate" }
+                            },
+                            ["RelativeDateEdits"] = new JArray()
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+var resp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction",
+    new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+resp.EnsureSuccessStatusCode();  // HTTP 200 even on failure -- check the Summary
+var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+
+var summary = result["Summary"]!;
+Console.WriteLine($"Succeeded: {summary["Succeeded"]}, Failed: {summary["Failed"]}");
+if ((int)summary["Failed"]! > 0)
+{
+    foreach (var msg in result["Messages"] as JArray ?? new JArray())
+        Console.WriteLine($"  {msg}");
+    throw new Exception("Time entry failed");
+}
+
+// --- Read back the labor grid for the order ---
+var getPayload = new JObject
+{
+    ["ServiceName"] = "TimeEntry",
+    ["TransactionStates"] = new JArray
+    {
+        new JObject
+        {
+            ["DataElementName"] = "TP_LABORRECORDING.prod_order_line_comp_labor",
+            ["Keys"] = new JArray
+            {
+                new JObject { ["Name"] = "prod_order_number", ["Value"] = prodOrder }
+            }
+        }
+    }
+};
+var getResp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction/get",
+    new StringContent(getPayload.ToString(), Encoding.UTF8, "application/json"));
+getResp.EnsureSuccessStatusCode();
+var getResult = JObject.Parse(await getResp.Content.ReadAsStringAsync());
+
+foreach (var txn in getResult["Transactions"] as JArray ?? new JArray())
+foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+foreach (var row in de["Rows"] as JArray ?? new JArray())
+{
+    var fields = new Dictionary<string, string>();
+    foreach (var edit in row["Edits"] as JArray ?? new JArray())
+        fields[edit["Name"]!.ToString()] = edit["Value"]?.ToString() ?? "";
+    if (!string.IsNullOrEmpty(fields.GetValueOrDefault("prod_order_number")))
+        Console.WriteLine($"  {fields.GetValueOrDefault("component_labor_id")}: " +
+                          $"time_worked={fields.GetValueOrDefault("time_worked")}");
+}
+```
+<!-- /tabs -->
+
+## Gotchas
+
+- **Strict field order** on the labor grid: `prod_order_number` → `item_id` → `component_labor_id` → `start_time` → `end_time`. Out of order, the downstream fields stay disabled and the values don't land.
+- **`technician_id` is a contact ID**, not a P21 user ID.
+- **The accounting period for `entry_date` must be open** — a closed period fails the save.
+- **Time accumulates.** Each entry adds to the line's stored hours/minutes; re-posting the same entry doubles the labor (and its cost = minutes × the labor code's rate).
+- **Log labor before printing the pick ticket** (or reprint after adding it). Labor on no ticket has `qty_on_pick_tickets = 0` and order completion fails with *"components have a quantity used of 0."*
+- **Cost timing:** labor posted before completion lands in the `PROP` receipt cost; labor posted after completion misses it; labor posted after invoicing generates a separate *"Post Freight/Labor Prod. Order: NNNN"* invoice ($0 price, ± COGS). See [the cost model](../12-Production-Labor-API.md#cost-model--know-this-before-trusting-cogs).
+- **`labor_type_cd` is required** — valid values `Rate`, `OT Rate`, `Prem Rate` (with `UseCodeValues: false`).
+- **HTTP 200 is not success** — check `Summary.Succeeded` / `Summary.Failed` and print `Messages`.
+
+## Verify
+
+Read the labor grid back (second half of the example): `POST /api/v2/transaction/get` on `TimeEntry`, element `TP_LABORRECORDING.prod_order_line_comp_labor`, keyed by `prod_order_number` — the line's `time_worked` should reflect the **accumulated** total, not just this entry. A successful post also returns `Status: "Passed"` on the transaction with `Summary.Succeeded: 1`.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier)

--- a/docs/recipes/set-primary-bin-supplier.md
+++ b/docs/recipes/set-primary-bin-supplier.md
@@ -1,0 +1,219 @@
+# Set an Item's Primary Bin or Primary Supplier at a Location
+
+Update an item's primary bin or primary supplier for one stocking location via the `Item` service's nested Form → List → detail pattern — with a mandatory read-back, because the primary-supplier write can silently no-op.
+
+**API:** Transaction (`Item`), Interactive fallback · **Service:** `Item` · **Deep dive:** [Item Service — Nested Location Edits](../03-Transaction-API.md#item-service----nested-location-edits), [Item Service Gotchas](../03-Transaction-API.md#item-service-gotchas), [Worked Example: "Item Issues Detected"](../04-Interactive-API.md#worked-example-item-issues-detected-rule-callback) · **Full schema:** [`definitions/Item.json`](../../definitions/Item.json)
+
+The `Item` service (Item Maintenance window) supports **nested DataElement navigation** that mirrors the UI: select the item, select a location row, then edit that location's detail. It works because the Item window's tabs aren't gated behind row selection — a good template for any nested edit.
+
+## Prerequisites
+
+- Bearer token + UI server from the [shared auth helper](README.md#shared-conventions-recipes-dont-repeat-these).
+- The item and stocking location already exist.
+- **For the primary-supplier write:** the target supplier must already have a *location-level* row (`inventory_supplier_x_loc`) at that location. If it doesn't, the write is a **silent no-op** — see Gotchas.
+- OData read access to `inv_mast` and `inv_loc` for the mandatory verification.
+
+## Payload
+
+**Primary bin** (Form → List → Form). `Status: "New"` with populated `Keys` updates the existing keyed record — it does not create a new item.
+
+```json
+{
+    "Name": "Item",
+    "UseCodeValues": false,
+    "Transactions": [{
+        "Status": "New",
+        "DataElements": [
+            { "Name": "TABPAGE_1.tp_1_dw_1", "Type": "Form", "Keys": ["item_id"],
+              "Rows": [{ "Edits": [ {"Name": "item_id", "Value": "WIDGET-001"} ] }] },
+            { "Name": "TABPAGE_17.invloclist", "Type": "List", "Keys": ["location_id"],
+              "Rows": [{ "Edits": [ {"Name": "location_id", "Value": "10"} ] }] },
+            { "Name": "TABPAGE_18.inv_loc_detail", "Type": "Form", "Keys": ["location_id"],
+              "Rows": [{ "Edits": [
+                  {"Name": "location_id", "Value": "10"},
+                  {"Name": "bin", "Value": "A01-02"}
+              ] }] }
+        ]
+    }]
+}
+```
+
+**Primary supplier** (Form → List → List). Same window, one level different — swap the third element for the supplier list:
+
+```json
+{ "Name": "SUPPLIER_X_LOCATION.supplier_x_location", "Type": "List", "Keys": ["supplier_id"],
+  "Rows": [{ "Edits": [
+      {"Name": "supplier_id", "Value": "20000"},
+      {"Name": "primary_supplier", "Value": "ON"}
+  ] }] }
+```
+
+What the supplier write does (verified on a 68-item production run): `primary_supplier` maps to `inventory_supplier_x_loc.primary_supplier` (a Y/N flag) — **not** `inv_loc.primary_supplier_id`. Setting it `ON` makes P21 auto-unset the previous primary at that location **and** update `inv_loc.primary_supplier_id` to the new supplier. The flag is the field to **write**; `inv_loc.primary_supplier_id` is the field to **read** when verifying.
+
+## Complete example
+
+Sets the primary supplier, then performs the **mandatory** OData verification of `inv_loc.primary_supplier_id` — `Succeeded = 1` alone proves nothing here (see Gotchas). For the primary-bin variant, swap in the `TABPAGE_18.inv_loc_detail` element from the payload above and verify `inv_loc.primary_bin` the same way.
+
+<!-- tabs -->
+```python
+import httpx
+
+BASE_URL = "https://play.p21server.com"
+token, ui_server, headers = p21_auth(BASE_URL, "api_user", "password")
+
+ITEM_ID = "WIDGET-001"
+LOCATION_ID = "10"
+SUPPLIER_ID = "20000"
+
+payload = {
+    "Name": "Item",
+    "UseCodeValues": False,
+    "Transactions": [{
+        "Status": "New",  # updates the keyed record; does not create a new item
+        "DataElements": [
+            {"Name": "TABPAGE_1.tp_1_dw_1", "Type": "Form", "Keys": ["item_id"],
+             "Rows": [{"Edits": [{"Name": "item_id", "Value": ITEM_ID}]}]},
+            {"Name": "TABPAGE_17.invloclist", "Type": "List", "Keys": ["location_id"],
+             "Rows": [{"Edits": [{"Name": "location_id", "Value": LOCATION_ID}]}]},
+            {"Name": "SUPPLIER_X_LOCATION.supplier_x_location", "Type": "List",
+             "Keys": ["supplier_id"],
+             "Rows": [{"Edits": [
+                 {"Name": "supplier_id", "Value": SUPPLIER_ID},
+                 {"Name": "primary_supplier", "Value": "ON"},
+             ]}]},
+        ],
+    }],
+}
+
+resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                  headers=headers, json=payload, verify=False, timeout=120)
+resp.raise_for_status()
+result = resp.json()
+print(f"Succeeded: {result['Summary']['Succeeded']}, "
+      f"Failed: {result['Summary']['Failed']}")
+for msg in result.get("Messages") or []:
+    print(f"  {msg}")  # watch for 'Unexpected response window: Item Issues Detected'
+
+# MANDATORY verification — a silent no-op still reports Succeeded = 1.
+# Write target is the inventory_supplier_x_loc flag; READ inv_loc.primary_supplier_id.
+mast = httpx.get(
+    f"{BASE_URL}/odataservice/odata/table/inv_mast",
+    params={"$filter": f"item_id eq '{ITEM_ID}'", "$select": "inv_mast_uid"},
+    headers=headers, verify=False,
+)
+mast.raise_for_status()
+inv_mast_uid = mast.json()["value"][0]["inv_mast_uid"]
+
+loc = httpx.get(
+    f"{BASE_URL}/odataservice/odata/table/inv_loc",
+    params={
+        "$filter": f"inv_mast_uid eq {inv_mast_uid} and location_id eq {LOCATION_ID}",
+        "$select": "primary_supplier_id",
+    },
+    headers=headers, verify=False,
+)
+loc.raise_for_status()
+actual = str(loc.json()["value"][0]["primary_supplier_id"])
+
+if actual == SUPPLIER_ID:
+    print(f"VERIFIED: primary_supplier_id = {actual}")
+else:
+    # Most likely cause: no inventory_supplier_x_loc row at this location.
+    # Add the location supplier row first, then set the flag again.
+    print(f"SILENT NO-OP: primary_supplier_id is {actual}, expected {SUPPLIER_ID}")
+```
+
+```csharp
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "password");
+
+const string ItemId = "WIDGET-001";
+const string LocationId = "10";
+const string SupplierId = "20000";
+
+JObject Element(string name, string type, string key, params (string Name, string Value)[] edits) =>
+    new JObject
+    {
+        ["Name"] = name, ["Type"] = type, ["Keys"] = new JArray(key),
+        ["Rows"] = new JArray(new JObject
+        {
+            ["Edits"] = new JArray(edits.Select(e =>
+                new JObject { ["Name"] = e.Name, ["Value"] = e.Value })),
+        }),
+    };
+
+var payload = new JObject
+{
+    ["Name"] = "Item",
+    ["UseCodeValues"] = false,
+    ["Transactions"] = new JArray(new JObject
+    {
+        ["Status"] = "New", // updates the keyed record; does not create a new item
+        ["DataElements"] = new JArray
+        {
+            Element("TABPAGE_1.tp_1_dw_1", "Form", "item_id", ("item_id", ItemId)),
+            Element("TABPAGE_17.invloclist", "List", "location_id", ("location_id", LocationId)),
+            Element("SUPPLIER_X_LOCATION.supplier_x_location", "List", "supplier_id",
+                ("supplier_id", SupplierId), ("primary_supplier", "ON")),
+        },
+    }),
+};
+
+var resp = await session.Http.PostAsync(
+    $"{session.UiServer}/api/v2/transaction",
+    new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+resp.EnsureSuccessStatusCode();
+var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+Console.WriteLine($"Succeeded: {result["Summary"]!["Succeeded"]}, " +
+                  $"Failed: {result["Summary"]!["Failed"]}");
+foreach (var msg in result["Messages"] as JArray ?? new JArray())
+    Console.WriteLine($"  {msg}"); // watch for 'Unexpected response window: Item Issues Detected'
+
+// MANDATORY verification — a silent no-op still reports Succeeded = 1.
+// Write target is the inventory_supplier_x_loc flag; READ inv_loc.primary_supplier_id.
+var mastResp = await session.Http.GetAsync(
+    "https://play.p21server.com/odataservice/odata/table/inv_mast" +
+    $"?$filter=item_id eq '{ItemId}'&$select=inv_mast_uid");
+mastResp.EnsureSuccessStatusCode();
+var invMastUid = (string)JObject.Parse(
+    await mastResp.Content.ReadAsStringAsync())["value"]![0]!["inv_mast_uid"]!;
+
+var locResp = await session.Http.GetAsync(
+    "https://play.p21server.com/odataservice/odata/table/inv_loc" +
+    $"?$filter=inv_mast_uid eq {invMastUid} and location_id eq {LocationId}" +
+    "&$select=primary_supplier_id");
+locResp.EnsureSuccessStatusCode();
+var actual = (string?)JObject.Parse(
+    await locResp.Content.ReadAsStringAsync())["value"]![0]!["primary_supplier_id"];
+
+if (actual == SupplierId)
+    Console.WriteLine($"VERIFIED: primary_supplier_id = {actual}");
+else
+    // Most likely cause: no inventory_supplier_x_loc row at this location.
+    // Add the location supplier row first, then set the flag again.
+    Console.WriteLine($"SILENT NO-OP: primary_supplier_id is {actual}, expected {SupplierId}");
+```
+<!-- /tabs -->
+
+## Gotchas
+
+- **Silent no-op — the big one.** The target supplier must already have a *location-level* row (`inventory_supplier_x_loc`) at that location. If it doesn't, the transaction still returns `Succeeded = 1` but **nothing flips** — there is no row to promote. (P21 allows cutting a PO to a supplier without location setup, so a supplier can appear in PO history yet be absent from the location's supplier list.) **Always verify `inv_loc.primary_supplier_id` after writing** — do not trust `Succeeded`. Fix: add the location supplier row first, then set the flag.
+- **Write the flag, read the id.** `primary_supplier` maps to `inventory_supplier_x_loc.primary_supplier` (Y/N), not `inv_loc.primary_supplier_id`; setting it `ON` auto-unsets the previous primary and updates `inv_loc.primary_supplier_id`. Verify against the id.
+- **"Item Issues Detected" popup.** Items with data problems return `Unexpected response window: Item Issues Detected` (`w_rule_callback_response`) in the response `Messages`. The Transaction API cannot get past this popup — it effectively answers "No" and discards the change. **Interactive fallback** ([worked example](../04-Interactive-API.md#worked-example-item-issues-detected-rule-callback)): start the session with `ResponseWindowHandlingEnabled: true`; open the `Item` window and set `item_id` on `TABPAGE_1.tp_1_dw_1` — **some items pop the dialog at retrieve time**, blocking the location list, so answer it immediately, not just at save; make your edits; `save()` — a blocked save returns Status 3 with a `windowopened` event carrying the popup's window ID; discover buttons via `GET /v2/tools?windowId={popupId}` (`cb_1` = **"Yes, Proceed Anyway"**, `cb_2` = "No, Cancel") and run `cb_1` via `POST /v2/tools`; the save then commits.
+- **Which items trip the rule differs per environment** — it fires on each item's data state. Don't hard-code a fallback list: run transaction-first, verify, and fall back to the Interactive API for whatever didn't stick.
+- **`SUPPLIER_X_LOCATION` keying is safe here** — it's keyed by `supplier_id` scoped to the selected location row in the Transaction API. The equivalent *interactive* flow must match rows on both `location_id` and `supplier_id`, because the grid holds every location's rows.
+- **Interactive fallback trap — never `select_row` on the detail form itself.** A single-row detail form (e.g. `inv_loc_detail`) is *bound* to the currently-selected parent list row. Sending `PUT /v2/row` against the **detail** datawindow re-selects the *parent* list (row N on the detail = row N on `invloclist`) and **silently flips which record the detail is bound to**, typically to the list's first row — the edit lands on the wrong location while every call reports success. Select only the parent list row, edit the detail directly, and assert the detail shows exactly the intended record before and after the change (abort without saving on mismatch). The Transaction API's nested pattern keys by `location_id` and has no such trap.
+- `Status: "New"` with populated `Keys` **updates** the existing keyed record — it does not create a new item.
+
+## Verify
+
+Not optional for the supplier write — the silent no-op makes read-back the only proof. Resolve `inv_mast_uid` from `item_id`, then read `inv_loc`:
+
+```http
+GET /odataservice/odata/table/inv_mast?$filter=item_id eq 'WIDGET-001'&$select=inv_mast_uid
+GET /odataservice/odata/table/inv_loc?$filter=inv_mast_uid eq {uid} and location_id eq 10&$select=primary_supplier_id
+```
+
+For the primary-bin variant, read back the bin field on the same `inv_loc` row.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — patterns and gotchas verified in production (July 2026).

--- a/docs/recipes/update-contract-lines.md
+++ b/docs/recipes/update-contract-lines.md
@@ -1,0 +1,320 @@
+# Update Contract Lines
+
+Update prices on existing `JobContractPricing` lines, insert new lines onto an existing contract (upsert), and set commission costs — all through the stateless Transaction API.
+
+**API:** Transaction (`POST {ui_server}/api/v2/transaction`) · **Service:** `JobContractPricing` · **Deep dive:** [JobContractPricing Service](../03-Transaction-API.md#jobcontractpricing-service) · [Updating an Existing Contract](../03-Transaction-API.md#updating-an-existing-contract) · [Upsert Semantics](../03-Transaction-API.md#upsert-semantics----keyed-rows-insert-when-absent) · [Commission Costs](../03-Transaction-API.md#commission-costs) · [Field Order Matters](../03-Transaction-API.md#field-order-matters) · [Known Limitations](../03-Transaction-API.md#known-limitations) · **Full schema:** [`definitions/JobContractPricing.json`](../../definitions/JobContractPricing.json)
+
+## Prerequisites
+
+- The contract already exists — know its `contract_no` and its `job_no`. Renewals can leave the same `contract_no` on two header rows; `job_no` is unique, so include it whenever it's known.
+- Look up the current header values (`company_id`, `job_no`, `end_date`) before writing — the header is re-validated on every save. Use `POST {ui_server}/api/v2/transaction/get`:
+
+  ```json
+  {
+    "ServiceName": "JobContractPricing",
+    "TransactionStates": [{
+      "DataElementName": "FORM.d_dw_job_price_hdr",
+      "Keys": [{"Name": "contract_no", "Value": "A120-12"}]
+    }]
+  }
+  ```
+- The contract's `end_date` must be **>= today** (or you must move it forward in the same call — a real side effect). Expired contracts cannot have their lines edited this way; use the Interactive API for those.
+- For **commission costs only**: the payload needs `IgnoreDisabled: true` at the top level — see [IgnoreDisabled](../03-Transaction-API.md#ignoredisabled).
+
+## Payload
+
+`Status` is `"New"` for both create and update — the API distinguishes them by whether the FORM key fields (`company_id`, `contract_no`, `job_no`) land on an existing record. The keyed `JOBPRICELINE` row is an **upsert**: matching `item_id` updates that line; no match inserts a new line.
+
+```jsonc
+{
+    "Name": "JobContractPricing",
+    "UseCodeValues": false,
+    "IgnoreDisabled": true,            // top level — only needed when writing commission costs
+    "Transactions": [{
+        "Status": "New",               // "New" for BOTH create and update — "Existing" returns HTTP 500
+        "DataElements": [
+            {
+                // Header: Keys stays EMPTY; the key fields go in Edits.
+                "Name": "FORM.d_dw_job_price_hdr",
+                "Type": "Form",
+                "Keys": [],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "company_id",  "Value": "ACME"},
+                        {"Name": "contract_no", "Value": "A120-12"},
+                        {"Name": "job_no",      "Value": "31"},        // unique across renewals
+                        {"Name": "end_date",    "Value": "2030-01-01"} // required on EVERY submit, must be >= today
+                    ],
+                    "RelativeDateEdits": []
+                }]
+            },
+            {
+                // Line: keyed by item_id — updates the row if it exists, inserts it if not
+                "Name": "JOBPRICELINE.jobpriceline",
+                "Type": "List",
+                "Keys": ["item_id"],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "item_id",        "Value": "WIDGET-001"},
+                        {"Name": "uom",            "Value": "EA"},
+                        {"Name": "pricing_method", "Value": "Price"},  // MUST come before price
+                        {"Name": "price",          "Value": "36.58"}
+                    ],
+                    "RelativeDateEdits": []
+                }]
+            },
+            {
+                // Optional: commission cost (requires IgnoreDisabled above)
+                "Name": "JOBPRICECOST.jobpricecost",
+                "Type": "Form",
+                "Keys": ["item_id"],
+                "Rows": [{
+                    "Edits": [
+                        {"Name": "item_id",                 "Value": "WIDGET-001"},
+                        {"Name": "commission_cost_type_cd", "Value": "Value"},   // type BEFORE value; labels: Order, Source, Value, None
+                        {"Name": "commission_cost_value",   "Value": "17.19"}
+                    ]
+                }]
+            }
+        ]
+    }]
+}
+```
+
+**Break-line variant:** for quantity-break lines set `pricing_method` to `"Source"`, `source_price` to `"Supplier List Price"` (or other source), and `multiplier` — do **not** send `price`. See [JobContractPricing Service](../03-Transaction-API.md#jobcontractpricing-service) for the VALUES break-tier structure.
+
+## Complete example
+
+<!-- tabs -->
+```python
+import httpx  # p21_auth() from recipes/README.md
+
+BASE_URL = "https://play.p21server.com"
+token, ui_server, headers = p21_auth(BASE_URL, "api_user", "api_pass")
+
+CONTRACT = {"company_id": "ACME", "contract_no": "A120-12",
+            "job_no": "31", "end_date": "2030-01-01"}
+
+
+def line_payload(contract: dict, item_id: str, uom: str, price: float,
+                 commission_cost: float | None = None) -> dict:
+    """Build a one-line upsert payload, optionally with a commission cost."""
+    elements = [
+        {"Name": "FORM.d_dw_job_price_hdr", "Type": "Form", "Keys": [],
+         "Rows": [{"Edits": [
+             {"Name": "company_id",  "Value": contract["company_id"]},
+             {"Name": "contract_no", "Value": contract["contract_no"]},
+             {"Name": "job_no",      "Value": contract["job_no"]},
+             {"Name": "end_date",    "Value": contract["end_date"]},
+         ], "RelativeDateEdits": []}]},
+        {"Name": "JOBPRICELINE.jobpriceline", "Type": "List", "Keys": ["item_id"],
+         "Rows": [{"Edits": [
+             {"Name": "item_id",        "Value": item_id},
+             {"Name": "uom",            "Value": uom},
+             {"Name": "pricing_method", "Value": "Price"},   # before price!
+             {"Name": "price",          "Value": str(price)},
+         ], "RelativeDateEdits": []}]},
+    ]
+    payload = {"Name": "JobContractPricing", "UseCodeValues": False,
+               "Transactions": [{"Status": "New", "DataElements": elements}]}
+    if commission_cost is not None:
+        payload["IgnoreDisabled"] = True  # top level, NOT inside the Transaction
+        elements.append(
+            {"Name": "JOBPRICECOST.jobpricecost", "Type": "Form", "Keys": ["item_id"],
+             "Rows": [{"Edits": [
+                 {"Name": "item_id",                 "Value": item_id},
+                 {"Name": "commission_cost_type_cd", "Value": "Value"},  # type before value
+                 {"Name": "commission_cost_value",   "Value": str(commission_cost)},
+             ]}]})
+    return payload
+
+
+def post_line(payload: dict) -> bool:
+    """POST one transaction; True only if the Summary says it landed."""
+    resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                      headers=headers, json=payload, verify=False, timeout=60)
+    resp.raise_for_status()  # HTTP 200 even when the transaction failed
+    result = resp.json()
+    summary = result["Summary"]
+    if summary["Failed"] or not summary["Succeeded"]:
+        for msg in result.get("Messages", []):
+            print(f"  FAILED: {msg}")
+        return False
+    return True
+
+
+# One POST per line: inserts re-save the shared header and collide when batched.
+lines = [
+    ("WIDGET-001", "EA", 36.58, 17.19),  # already on contract -> updated
+    ("WIDGET-002", "EA", 12.40, None),   # not on contract     -> inserted (upsert)
+]
+for item_id, uom, price, commission in lines:
+    ok = post_line(line_payload(CONTRACT, item_id, uom, price, commission))
+    print(f"{item_id}: {'OK' if ok else 'failed'}")
+
+# --- Verify via OData (no joins: chain the uid columns) ---
+def odata(table: str, filter_expr: str) -> list[dict]:
+    resp = httpx.get(f"{BASE_URL}/odataservice/odata/table/{table}",
+                     params={"$filter": filter_expr},
+                     headers=headers, verify=False)
+    resp.raise_for_status()
+    return resp.json()["value"]
+
+# Renewals can return two headers for one contract_no — match job_no too.
+hdr = odata("job_price_hdr", f"contract_no eq '{CONTRACT['contract_no']}'")[0]
+for item_id, _uom, price, _c in lines:
+    im_uid = odata("inv_mast", f"item_id eq '{item_id}'")[0]["inv_mast_uid"]
+    line = odata("job_price_line",
+                 f"job_price_hdr_uid eq {hdr['job_price_hdr_uid']} "
+                 f"and inv_mast_uid eq {im_uid}")[0]
+    match = "OK" if float(line["price"]) == price else "MISMATCH"
+    print(f"{item_id}: price={line['price']} expected={price} -> {match}")
+```
+
+```csharp
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+var session = await P21Session.CreateAsync(
+    "https://play.p21server.com", "api_user", "api_pass");
+const string BaseUrl = "https://play.p21server.com";
+
+var contract = new { CompanyId = "ACME", ContractNo = "A120-12",
+                     JobNo = "31", EndDate = "2030-01-01" };
+
+JObject Edit(string name, string value) =>
+    new JObject { ["Name"] = name, ["Value"] = value };
+
+JObject LinePayload(string itemId, string uom, decimal price, decimal? commissionCost)
+{
+    var elements = new JArray
+    {
+        new JObject
+        {
+            ["Name"] = "FORM.d_dw_job_price_hdr", ["Type"] = "Form",
+            ["Keys"] = new JArray(),
+            ["Rows"] = new JArray { new JObject {
+                ["Edits"] = new JArray {
+                    Edit("company_id",  contract.CompanyId),
+                    Edit("contract_no", contract.ContractNo),
+                    Edit("job_no",      contract.JobNo),
+                    Edit("end_date",    contract.EndDate),
+                },
+                ["RelativeDateEdits"] = new JArray() } }
+        },
+        new JObject
+        {
+            ["Name"] = "JOBPRICELINE.jobpriceline", ["Type"] = "List",
+            ["Keys"] = new JArray { "item_id" },
+            ["Rows"] = new JArray { new JObject {
+                ["Edits"] = new JArray {
+                    Edit("item_id",        itemId),
+                    Edit("uom",            uom),
+                    Edit("pricing_method", "Price"),          // before price!
+                    Edit("price",          price.ToString()),
+                },
+                ["RelativeDateEdits"] = new JArray() } }
+        },
+    };
+    var payload = new JObject
+    {
+        ["Name"] = "JobContractPricing", ["UseCodeValues"] = false,
+        ["Transactions"] = new JArray {
+            new JObject { ["Status"] = "New", ["DataElements"] = elements } }
+    };
+    if (commissionCost is not null)
+    {
+        payload["IgnoreDisabled"] = true;  // top level, NOT inside the Transaction
+        elements.Add(new JObject
+        {
+            ["Name"] = "JOBPRICECOST.jobpricecost", ["Type"] = "Form",
+            ["Keys"] = new JArray { "item_id" },
+            ["Rows"] = new JArray { new JObject { ["Edits"] = new JArray {
+                Edit("item_id",                 itemId),
+                Edit("commission_cost_type_cd", "Value"),     // type before value
+                Edit("commission_cost_value",   commissionCost.ToString()!),
+            } } }
+        });
+    }
+    return payload;
+}
+
+async Task<bool> PostLineAsync(JObject payload)
+{
+    var resp = await session.Http.PostAsync(
+        $"{session.UiServer}/api/v2/transaction",
+        new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+    resp.EnsureSuccessStatusCode();  // HTTP 200 even when the transaction failed
+    var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+    var summary = result["Summary"]!;
+    if ((int)summary["Failed"]! > 0 || (int)summary["Succeeded"]! == 0)
+    {
+        foreach (var msg in result["Messages"] as JArray ?? new JArray())
+            Console.WriteLine($"  FAILED: {msg}");
+        return false;
+    }
+    return true;
+}
+
+// One POST per line: inserts re-save the shared header and collide when batched.
+var lines = new (string ItemId, string Uom, decimal Price, decimal? Commission)[]
+{
+    ("WIDGET-001", "EA", 36.58m, 17.19m),  // already on contract -> updated
+    ("WIDGET-002", "EA", 12.40m, null),    // not on contract     -> inserted (upsert)
+};
+foreach (var l in lines)
+{
+    var ok = await PostLineAsync(LinePayload(l.ItemId, l.Uom, l.Price, l.Commission));
+    Console.WriteLine($"{l.ItemId}: {(ok ? "OK" : "failed")}");
+}
+
+// --- Verify via OData (no joins: chain the uid columns) ---
+async Task<JArray> ODataAsync(string table, string filter)
+{
+    var url = $"{BaseUrl}/odataservice/odata/table/{table}" +
+              $"?$filter={Uri.EscapeDataString(filter)}";
+    var resp = await session.Http.GetAsync(url);
+    resp.EnsureSuccessStatusCode();
+    return (JArray)JObject.Parse(await resp.Content.ReadAsStringAsync())["value"]!;
+}
+
+// Renewals can return two headers for one contract_no — match job_no too.
+var hdr = (JObject)(await ODataAsync("job_price_hdr",
+    $"contract_no eq '{contract.ContractNo}'"))[0];
+foreach (var l in lines)
+{
+    var imUid = (await ODataAsync("inv_mast", $"item_id eq '{l.ItemId}'"))[0]["inv_mast_uid"];
+    var line = (await ODataAsync("job_price_line",
+        $"job_price_hdr_uid eq {hdr["job_price_hdr_uid"]} and inv_mast_uid eq {imUid}"))[0];
+    var match = (decimal)line["price"]! == l.Price ? "OK" : "MISMATCH";
+    Console.WriteLine($"{l.ItemId}: price={line["price"]} expected={l.Price} -> {match}");
+}
+```
+<!-- /tabs -->
+
+## Gotchas
+
+- **`pricing_method` must precede `price` in the Edits.** Changing `pricing_method` clears the typed price, exactly as in the UI — reversed order writes the line with **price = $0** and the transaction still reports `Succeeded`. Verified live. Order the Edits `item_id`, `pricing_method`, `price`.
+- **One transaction per POST when inserting lines.** Every transaction re-saves the shared FORM header; batched inserts collide — all but one fail with an optimistic-concurrency error, and the ones that land can get **duplicate `line_no`** values. Edits to existing keyed rows batch fine.
+- **`Status: "Existing"` (or `"Update"`, `"Change"`) returns HTTP 500** (`NullReferenceException`). Use `"New"` for both create and update.
+- **`end_date` must be >= today** — the header is validated on every save, so you cannot edit lines on an expired contract without also moving its `end_date` forward. For expired contracts, use the Interactive API.
+- **Include `job_no` to disambiguate renewals** — the same `contract_no` can exist on two header rows; `job_no` is unique.
+- **`IgnoreDisabled: true` goes at the payload top level** (alongside `Name`/`Transactions`). Inside a Transaction object it is silently ignored and commission-cost writes fail with `Column is disabled: commission_cost_value`.
+- **Set `commission_cost_type_cd` before `commission_cost_value`.** Accepted display labels (with `UseCodeValues: false`): `Order`, `Source`, `Value`, `None`. Setting only the commission cost leaves `other_cost` untouched.
+- **Non-break vs break lines:** fixed price → `pricing_method: "Price"` + `price` (no `source_price`/`multiplier`); breaks → `pricing_method: "Source"` + `source_price` + `multiplier` (no `price`). Converting `"Source"` → `"Price"` works in one call; the old `source_price`/`multiplier` are not auto-cleared but become dormant.
+- **`corp_address_id` is read-only after the initial save** — it can only be set at creation.
+- **HTTP 200 is not success.** Check `Summary.Succeeded`/`Summary.Failed` and print `Messages`; transactions in a bulk POST pass/fail independently.
+- **Per-line latency ~0.8s.** For bulk updates, single-line POSTs are easier to retry than batches.
+
+## Verify
+
+Chain OData uid lookups (no joins): `job_price_hdr` by `contract_no` → `job_price_hdr_uid`; `inv_mast` by `item_id` → `inv_mast_uid`; then check the line:
+
+```http
+GET /odataservice/odata/table/job_price_line?$filter=job_price_hdr_uid eq {uid} and inv_mast_uid eq {im_uid}
+```
+
+Confirm `price` matches what you submitted (the complete example above does this for every line). Commission costs and `line_no` uniqueness can be confirmed the same way after inserts.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — verified the update path, the upsert/header-collision behavior, the `pricing_method` ordering cascade, and the `IgnoreDisabled` commission-cost write path.


### PR DESCRIPTION
## Summary
Adds `docs/recipes/` — the playbook layer modeled on Alex Westemeier's per-context README pattern. One task = one page, self-contained:

- the **complete working payload** (with the full field set linked from `definitions/`),
- a **full runnable example in Python and C#** — auth → call → `Summary` check → OData/`transaction/get` read-back,
- every **verified gotcha** for that task,
- deep-dive links into the manual.

Pages: update-contract-lines · edit-contract-bins · create-bins · create-sales-order · order-with-assembly · set-primary-bin-supplier · generate-pick-ticket-pdf · production-order-runbook · record-labor-time · inventory-adjustment, plus a conventions README (shared auth helper, placeholder data, verify-after-write rules).

`INDEX.md` now routes tasks to recipes first, manual second.

## Validation
Programmatic pass over all 11 files: zero forbidden-string hits, every `<!-- tabs -->` block is exactly one Python + one C# fence, all cross-doc links and anchors resolve, field names cross-checked against `definitions/*.json` by the drafting agents.

HTML site publishing for the recipes subfolder is tracked separately in #77.

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE