### PR TITLE
docs: end-to-end runnable example files for every recipe (Python + C#)

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -101,4 +101,6 @@ public sealed class P21Session
 
 **Full field lists.** Recipes show the fields that matter for the task. For *every* field a service accepts (names, types, keys, labels, payload template), load `definitions/{Service}.json` — see the [definitions README](../../definitions/README.md).
 
+**Snippets vs end-to-end files.** The tabs on each page are self-contained snippets (portable — paste anywhere). Each recipe also links **complete runnable files** under [`scripts/recipes/`](../../scripts/recipes/README.md) (Python) and [`examples/csharp/Recipes/`](../../examples/csharp/Recipes/) (C#): they use the repo's shared config/auth helpers, run against your `.env`, **dry-run by default** (print the payload; `--execute` / typing `EXECUTE` posts), and end with the verify read-back.
+
 > **Credit:** the cookbook pattern and much of the verified content come from [Alex Westemeier](https://github.com/AWestemeier)'s process playbook.

--- a/docs/recipes/create-bins.md
+++ b/docs/recipes/create-bins.md
@@ -221,6 +221,8 @@ foreach (var batch in toCreate.Chunk(BatchSize))
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/create_bins.py`](../../scripts/recipes/create_bins.py) · [`examples/csharp/Recipes/CreateBins.cs`](../../examples/csharp/Recipes/CreateBins.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 - **`IgnoreDisabled: true` is mandatory — and it must be at the payload top level**, alongside `Name` and `Transactions`. `frozen_flag` and other system columns are disabled on the bin form; without the flag every transaction fails with `General Exception: Column is disabled: frozen_flag`. Placed inside a Transaction object instead of the top level, the flag is **silently ignored** and you get the same failure. See [IgnoreDisabled](../03-Transaction-API.md#ignoredisabled).

--- a/docs/recipes/create-sales-order.md
+++ b/docs/recipes/create-sales-order.md
@@ -239,6 +239,8 @@ Console.WriteLine($"Created order_no: {orderNo}");
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/create_sales_order.py`](../../scripts/recipes/create_sales_order.py) · [`examples/csharp/Recipes/CreateSalesOrder.cs`](../../examples/csharp/Recipes/CreateSalesOrder.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 All verified live — details in [Order Service Gotchas](../03-Transaction-API.md#order-service-gotchas):

--- a/docs/recipes/edit-contract-bins.md
+++ b/docs/recipes/edit-contract-bins.md
@@ -256,6 +256,8 @@ foreach (var e in binEdits)
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/edit_contract_bins.py`](../../scripts/recipes/edit_contract_bins.py) · [`examples/csharp/Recipes/EditContractBins.cs`](../../examples/csharp/Recipes/EditContractBins.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 All verified live:

--- a/docs/recipes/generate-pick-ticket-pdf.md
+++ b/docs/recipes/generate-pick-ticket-pdf.md
@@ -199,6 +199,8 @@ foreach (var doc in documents.OfType<JObject>())
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/generate_pick_ticket_pdf.py`](../../scripts/recipes/generate_pick_ticket_pdf.py) · [`examples/csharp/Recipes/GeneratePickTicketPdf.cs`](../../examples/csharp/Recipes/GeneratePickTicketPdf.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 All verified live — details in [PDF Report Generation](../03-Transaction-API.md#pdf-report-generation):

--- a/docs/recipes/inventory-adjustment.md
+++ b/docs/recipes/inventory-adjustment.md
@@ -251,6 +251,8 @@ foreach (var edit in row["Edits"] as JArray ?? new JArray())
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/inventory_adjustment.py`](../../scripts/recipes/inventory_adjustment.py) · [`examples/csharp/Recipes/InventoryAdjustment.cs`](../../examples/csharp/Recipes/InventoryAdjustment.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 - **`reason_id` takes the display text** of the reason — not its code — with `UseCodeValues: false`.

--- a/docs/recipes/order-with-assembly.md
+++ b/docs/recipes/order-with-assembly.md
@@ -363,6 +363,8 @@ finally
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/order_with_assembly.py`](../../scripts/recipes/order_with_assembly.py) · [`examples/csharp/Recipes/OrderWithAssembly.cs`](../../examples/csharp/Recipes/OrderWithAssembly.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 All verified end-to-end — details in [Sales Order Entry with Assembly Lines](../04-Interactive-API.md#sales-order-entry-with-assembly-lines) and [Response Windows](../04-Interactive-API.md#response-windows):

--- a/docs/recipes/production-order-runbook.md
+++ b/docs/recipes/production-order-runbook.md
@@ -265,6 +265,8 @@ foreach (var row in de["Rows"] as JArray ?? new JArray())
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/production_order_runbook.py`](../../scripts/recipes/production_order_runbook.py) · [`examples/csharp/Recipes/ProductionOrderRunbook.cs`](../../examples/csharp/Recipes/ProductionOrderRunbook.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 - **Shell confirm (the big one).** Confirming a pick with a bare Transaction API POST flips the status to `1962` and stamps `qty_confirmed`, but leaves **`qty_applied = 0` and moves no stock** — confirm through the Interactive API `ProductionOrderPicking` window (Stage 4).

--- a/docs/recipes/record-labor-time.md
+++ b/docs/recipes/record-labor-time.md
@@ -242,6 +242,8 @@ foreach (var row in de["Rows"] as JArray ?? new JArray())
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/record_labor_time.py`](../../scripts/recipes/record_labor_time.py) · [`examples/csharp/Recipes/RecordLaborTime.cs`](../../examples/csharp/Recipes/RecordLaborTime.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 - **Strict field order** on the labor grid: `prod_order_number` → `item_id` → `component_labor_id` → `start_time` → `end_time`. Out of order, the downstream fields stay disabled and the values don't land.

--- a/docs/recipes/set-primary-bin-supplier.md
+++ b/docs/recipes/set-primary-bin-supplier.md
@@ -195,6 +195,8 @@ else
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/set_primary_bin_supplier.py`](../../scripts/recipes/set_primary_bin_supplier.py) · [`examples/csharp/Recipes/SetPrimaryBinSupplier.cs`](../../examples/csharp/Recipes/SetPrimaryBinSupplier.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 - **Silent no-op — the big one.** The target supplier must already have a *location-level* row (`inventory_supplier_x_loc`) at that location. If it doesn't, the transaction still returns `Succeeded = 1` but **nothing flips** — there is no row to promote. (P21 allows cutting a PO to a supplier without location setup, so a supplier can appear in PO history yet be absent from the location's supplier list.) **Always verify `inv_loc.primary_supplier_id` after writing** — do not trust `Succeeded`. Fix: add the location supplier row first, then set the flag.

--- a/docs/recipes/update-contract-lines.md
+++ b/docs/recipes/update-contract-lines.md
@@ -293,6 +293,8 @@ foreach (var l in lines)
 ```
 <!-- /tabs -->
 
+> **End-to-end files** (runnable from the repo with a `.env`, dry-run by default): [`scripts/recipes/update_contract_lines.py`](../../scripts/recipes/update_contract_lines.py) · [`examples/csharp/Recipes/UpdateContractLines.cs`](../../examples/csharp/Recipes/UpdateContractLines.cs). The snippet above is self-contained; the files use the repo's shared `common` / `P21Examples.Common` helpers like every other example.
+
 ## Gotchas
 
 - **`pricing_method` must precede `price` in the Edits.** Changing `pricing_method` clears the typed price, exactly as in the UI — reversed order writes the line with **price = $0** and the transaction still reports `Succeeded`. Verified live. Order the Edits `item_id`, `pricing_method`, `price`.

--- a/examples/csharp/P21Examples.sln
+++ b/examples/csharp/P21Examples.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "P21Examples.Entity", "Entit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "P21Examples.Production", "Production\P21Examples.Production.csproj", "{A1B2C3D4-1111-2222-3333-44445555BBBB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "P21Examples.Recipes", "Recipes\P21Examples.Recipes.csproj", "{A1B2C3D4-1111-2222-3333-44445555CCCC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,5 +47,9 @@ Global
 		{A1B2C3D4-1111-2222-3333-44445555BBBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-1111-2222-3333-44445555BBBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-1111-2222-3333-44445555BBBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-44445555CCCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-44445555CCCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-44445555CCCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-44445555CCCC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/examples/csharp/Recipes/CreateBins.cs
+++ b/examples/csharp/Recipes/CreateBins.cs
@@ -1,0 +1,151 @@
+// Recipe: Create Bins (Bulk)
+// Docs:   docs/recipes/create-bins.md
+//
+// Bulk-create warehouse bins with the BinLocation service — one transaction
+// per bin, tens per POST, verified in production at hundreds of bins per run.
+//
+// Key rules (all verified live — see the recipe page):
+//   - IgnoreDisabled: true is mandatory and must be at the payload top level;
+//     inside a Transaction it is silently ignored (frozen_flag is disabled).
+//   - Pass codes, not uids (bin_type "SHELF", zone "ZONE-A").
+//   - Flags are ON/OFF on the form but stored Y/N in dbo.bin — convert when
+//     cloning constants from a "twin" bin.
+//   - Don't send master_bin_flag — P21 auto-sets it.
+//   - Re-running is safe if you skip (bin_id, location_id) pairs that exist.
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class CreateBins
+{
+    private const string CompanyId = "ACME";
+    private const string LocationId = "10";
+    private const int BatchSize = 20;  // tens of transactions per POST is fine and fast
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Create Bins Bulk (BinLocation)");
+        Console.WriteLine(new string('=', 60));
+
+        using var client = await P21Client.CreateAsync();
+
+        var newBinIds = new[] { "A01-02-01", "A01-02-02", "A01-02-03", "A01-02-04" };
+
+        // Constants cloned from a "twin" bin of the same bin_type at this location.
+        // Flags come back Y/N from the database — convert to ON/OFF for the form.
+        var twin = new (string Name, string Value)[]
+        {
+            ("bin_type", "SHELF"),
+            ("putaway_zone_id", "ZONE-A"), ("pick_zone_id", "ZONE-A"),
+            ("bin_length", "10"), ("bin_width", "10"), ("bin_height", "11"),
+            ("warehouse_sequence", "1"), ("putaway_zone_sequence", "1"), ("pick_zone_sequence", "1"),
+            ("max_unique_items", "0"),
+            ("pick_locked_flag", "OFF"), ("put_locked_flag", "OFF"),
+            ("full_flag", "OFF"), ("frozen_flag", "OFF"),
+            ("consolidation_bin_flag", "OFF"), ("stage_bin_flag", "OFF"), ("door_bin_flag", "OFF"),
+        };
+
+        // ------------------------------------------------------------------
+        // Read-only: skip-existing check via the p21_view_bin view
+        // (the raw bin table isn't always exposed via OData)
+        // ------------------------------------------------------------------
+        var existingRows = (JArray)(await client.OData.QueryViewAsync(
+            "p21_view_bin",
+            select: "bin_id",
+            filter: $"location_id eq {LocationId}"))["value"]!;
+        var existing = existingRows.Select(r => (string)r["bin_id"]!).ToHashSet();
+
+        var toCreate = newBinIds.Where(b => !existing.Contains(b)).ToList();
+        Console.WriteLine(
+            $"\n{newBinIds.Length - toCreate.Count} already exist, creating {toCreate.Count}");
+        if (toCreate.Count == 0)
+            return;
+
+        var batches = toCreate.Chunk(BatchSize).ToList();
+        foreach (var batch in batches)
+        {
+            var preview = BuildBatchPayload(batch, twin);
+            PrintPayload($"Batch payload ({batch.Length} bin(s))", preview);
+        }
+
+        if (!ConfirmExecute())
+            return;
+
+        // ------------------------------------------------------------------
+        // Write: one POST per batch, per-transaction result checks
+        // ------------------------------------------------------------------
+        foreach (var batch in batches)
+        {
+            var payload = BuildBatchPayload(batch, twin);
+            var result = await client.Transaction.CreateAsync(payload);
+            Console.WriteLine();
+            CheckResult(result);
+
+            // Transactions pass/fail independently — check each one
+            var txns = result.Raw?["Results"]?["Transactions"] as JArray ?? new JArray();
+            foreach (var (binId, txn) in batch.Zip(txns))
+                if ((string?)txn["Status"] != "Passed")
+                    Console.WriteLine($"  FAILED: {binId}");
+        }
+
+        // ------------------------------------------------------------------
+        // Verify: read the new bins back through p21_view_bin
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nVerify via p21_view_bin:");
+        Console.WriteLine(new string('-', 50));
+        foreach (var binId in toCreate)
+        {
+            var rows = (JArray)(await client.OData.QueryViewAsync(
+                "p21_view_bin",
+                filter: $"location_id eq {LocationId} and bin_id eq '{binId}'"))["value"]!;
+            Console.WriteLine(rows.Count > 0
+                ? $"  {binId}: exists (bin_type={rows[0]["bin_type"]})"
+                : $"  {binId}: NOT FOUND");
+        }
+        Console.WriteLine(
+            "\n  Compare field-for-field against the twin after the first run" +
+            " (remember the Y/N <-> ON/OFF flag mapping).");
+    }
+
+    private static JObject BuildBatchPayload(
+        string[] batch, (string Name, string Value)[] twin)
+    {
+        return new JObject
+        {
+            ["Name"] = "BinLocation",
+            ["UseCodeValues"] = false,
+            ["IgnoreDisabled"] = true, // TOP LEVEL — inside a Transaction it is silently ignored
+            ["Transactions"] = new JArray(batch.Select(b => BuildBinTransaction(b, twin))),
+        };
+    }
+
+    /// <summary>One Transaction object per bin (keys first, then the twin's constants).</summary>
+    private static JObject BuildBinTransaction(string binId, (string Name, string Value)[] twin)
+    {
+        var edits = new JArray
+        {
+            Edit("company_id", CompanyId),
+            Edit("location_id", LocationId),
+            Edit("bin_id", binId),
+        };
+        foreach (var (name, value) in twin)
+            edits.Add(Edit(name, value));
+
+        return new JObject
+        {
+            ["Status"] = "New",
+            ["DataElements"] = new JArray
+            {
+                new JObject
+                {
+                    ["Name"] = "FORM.form", ["Type"] = "Form",
+                    ["Keys"] = new JArray("company_id", "location_id", "bin_id"),
+                    ["Rows"] = new JArray(new JObject { ["Edits"] = edits }),
+                }
+            },
+        };
+    }
+}

--- a/examples/csharp/Recipes/CreateSalesOrder.cs
+++ b/examples/csharp/Recipes/CreateSalesOrder.cs
@@ -1,0 +1,138 @@
+// Recipe: Create a Sales Order
+// Docs:   docs/recipes/create-sales-order.md
+//
+// Create a sales order — header plus line items — in one stateless
+// Transaction API call (service: Order).
+//
+// Key rules (all verified live — see the recipe page):
+//   - source_loc_id is effectively required; omitting it fails with a
+//     "Jurisdiction ID for Order Header Tax" error.
+//   - requested_date must be AFTER order_date (same date trips a prompt).
+//   - Do NOT send company_id — it is a disabled column on the Order window.
+//   - No assembly lines here — the Transaction API auto-answers the
+//     "add as assembly?" prompt No. Use the OrderWithAssembly recipe instead.
+//   - HTTP 200 is not success; the generated order_no comes back in the
+//     result rows of TABPAGE_1.order.
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class CreateSalesOrder
+{
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Create a Sales Order (Order)");
+        Console.WriteLine(new string('=', 60));
+
+        using var client = await P21Client.CreateAsync();
+
+        var payload = BuildOrderPayload();
+        PrintPayload("Order payload", payload);
+
+        if (!ConfirmExecute())
+            return;
+
+        // ------------------------------------------------------------------
+        // Write
+        // ------------------------------------------------------------------
+        var result = await client.Transaction.CreateAsync(payload);
+        if (!CheckResult(result))
+            return;
+
+        // The generated order_no comes back in the result rows of TABPAGE_1.order
+        var orderNo = (result.Raw?.SelectTokens(
+                "$.Results.Transactions[?(@.Status == 'Passed')]" +
+                ".DataElements[?(@.Name == 'TABPAGE_1.order')]" +
+                ".Rows[*].Edits[?(@.Name == 'order_no')].Value")
+            ?? Enumerable.Empty<JToken>()).FirstOrDefault()?.ToString();
+
+        Console.WriteLine($"\nCreated order_no: {orderNo}");
+        if (string.IsNullOrEmpty(orderNo))
+            return;
+
+        // ------------------------------------------------------------------
+        // Verify: read the order back — Succeeded is not proof every value
+        // landed (a DynaChange auto-answer can silently drop a line).
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nVerify via OData:");
+        Console.WriteLine(new string('-', 50));
+
+        var hdrRows = (JArray)(await client.OData.QueryAsync(
+            "oe_hdr", filter: $"order_no eq '{orderNo}'"))["value"]!;
+        if (hdrRows.Count > 0)
+        {
+            var hdr = hdrRows[0];
+            Console.WriteLine($"  Header: taker={hdr["taker"]} po_no={hdr["po_no"]} " +
+                              $"order_date={hdr["order_date"]}");
+        }
+        else
+        {
+            Console.WriteLine("  Header NOT FOUND");
+        }
+
+        var lineRows = (JArray)(await client.OData.QueryAsync(
+            "oe_line", filter: $"order_no eq '{orderNo}'"))["value"]!;
+        Console.WriteLine($"  Lines: {lineRows.Count} (expected 2 — a dropped line means " +
+                          "a DynaChange prompt was auto-answered)");
+        foreach (var line in lineRows)
+            Console.WriteLine($"    line {line["line_no"]}: " +
+                              $"qty_ordered={line["qty_ordered"]}");
+    }
+
+    private static JObject BuildOrderPayload()
+    {
+        JObject Row(params (string Name, string Value)[] edits) => new JObject
+        {
+            ["Edits"] = new JArray(edits.Select(e => Edit(e.Name, e.Value))),
+            ["RelativeDateEdits"] = new JArray(),
+        };
+
+        return new JObject
+        {
+            ["Name"] = "Order",
+            ["UseCodeValues"] = false,
+            ["Transactions"] = new JArray
+            {
+                new JObject
+                {
+                    ["Status"] = "New",
+                    ["DataElements"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Name"] = "TABPAGE_1.order",
+                            ["Type"] = "Form",
+                            ["Keys"] = new JArray(),
+                            ["Rows"] = new JArray
+                            {
+                                Row(("customer_id", "100198"),
+                                    ("sales_loc_id", "10"),
+                                    ("source_loc_id", "10"),          // required in practice
+                                    ("order_date", "2030-01-05"),
+                                    ("requested_date", "2030-01-06"), // must be AFTER order_date
+                                    ("po_no", "PO-TEST-001"),
+                                    ("taker", "JSMITH"),
+                                    ("ship_to_id", "200"),
+                                    ("contact_id", "300")),
+                            },
+                        },
+                        new JObject
+                        {
+                            ["Name"] = "TP_ITEMS.items",
+                            ["Type"] = "List",
+                            ["Keys"] = new JArray(),
+                            ["Rows"] = new JArray
+                            {
+                                Row(("oe_order_item_id", "WIDGET-001"), ("unit_quantity", "5")),
+                                Row(("oe_order_item_id", "WIDGET-002"), ("unit_quantity", "2")),
+                            },
+                        },
+                    },
+                },
+            },
+        };
+    }
+}

--- a/examples/csharp/Recipes/EditContractBins.cs
+++ b/examples/csharp/Recipes/EditContractBins.cs
@@ -1,0 +1,156 @@
+// Recipe: Edit Contract Bin Quantities
+// Docs:   docs/recipes/edit-contract-bins.md
+//
+// Change min_qty, max_qty, reorder_qty, and capacity on the bins of an
+// existing job contract via the Transaction API with IgnoreDisabled: true.
+//
+// Key rules (all verified live — see the recipe page):
+//   - IgnoreDisabled: true is MANDATORY and goes at the payload top level;
+//     inside a Transaction it is silently ignored ("Column is disabled: ...").
+//   - Select the line by item_id (the JOBPRICELINE key), not line_no.
+//   - Batching is fine here — repeat the JOBPRICELINE + BINS.bins pair per bin.
+//   - No end_date required; works on expired contracts too.
+//   - Status "New" even for an existing contract ("Existing" returns HTTP 500).
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class EditContractBins
+{
+    private const string ContractNo = "A120-12";
+    private const string JobNo = "31";
+    private const string CustomerId = "100198";
+    private const string ShipToId = "200";
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Edit Contract Bin Quantities (JobContractPricing)");
+        Console.WriteLine(new string('=', 60));
+
+        using var client = await P21Client.CreateAsync();
+
+        // Per bin: the line's item_id, the bin id, and the new quantities.
+        var binEdits = new (string ItemId, string BinId, int Min, int Max, int Reorder, int Capacity)[]
+        {
+            ("WIDGET-001", "A01-02", 30, 100, 40, 100),
+            ("WIDGET-002", "A01-02", 5, 50, 10, 50),
+        };
+
+        var payload = BuildBinPayload(binEdits);
+        PrintPayload("Bin edit payload (one POST, batched)", payload);
+
+        if (!ConfirmExecute())
+            return;
+
+        // ------------------------------------------------------------------
+        // Write: one POST covers every bin
+        // ------------------------------------------------------------------
+        var result = await client.Transaction.CreateAsync(payload);
+        if (!CheckResult(result))
+            return;
+
+        // ------------------------------------------------------------------
+        // Verify via OData (no joins: chain the uid columns)
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nVerify via OData:");
+        Console.WriteLine(new string('-', 50));
+
+        var hdrRows = (JArray)(await client.OData.QueryAsync(
+            "job_price_hdr", filter: $"contract_no eq '{ContractNo}'"))["value"]!;
+        if (hdrRows.Count == 0)
+        {
+            Console.WriteLine($"  Contract {ContractNo} not found");
+            return;
+        }
+        var hdrUid = hdrRows[0]["job_price_hdr_uid"];
+
+        foreach (var e in binEdits)
+        {
+            var imRows = (JArray)(await client.OData.QueryAsync(
+                "inv_mast", filter: $"item_id eq '{e.ItemId}'"))["value"]!;
+            if (imRows.Count == 0)
+            {
+                Console.WriteLine($"  {e.ItemId}: item not found in inv_mast");
+                continue;
+            }
+            var imUid = imRows[0]["inv_mast_uid"];
+
+            var lineRows = (JArray)(await client.OData.QueryAsync(
+                "job_price_line",
+                filter: $"job_price_hdr_uid eq {hdrUid} and inv_mast_uid eq {imUid}"))["value"]!;
+            if (lineRows.Count == 0)
+            {
+                Console.WriteLine($"  {e.ItemId}: no contract line found");
+                continue;
+            }
+
+            var binRows = (JArray)(await client.OData.QueryAsync(
+                "job_price_bin",
+                filter: $"job_price_line_uid eq {lineRows[0]["job_price_line_uid"]}"))["value"]!;
+            foreach (var binRow in binRows)
+            {
+                Console.WriteLine(
+                    $"  {e.ItemId}: min={binRow["min_qty"]} max={binRow["max_qty"]} " +
+                    $"reorder={binRow["reorder_qty"]} " +
+                    $"(expected {e.Min}/{e.Max}/{e.Reorder})");
+            }
+        }
+    }
+
+    private static JObject BuildBinPayload(
+        (string ItemId, string BinId, int Min, int Max, int Reorder, int Capacity)[] binEdits)
+    {
+        var elements = new JArray
+        {
+            new JObject
+            {
+                // Load the contract header. job_no is unique across renewals.
+                ["Name"] = "FORM.d_dw_job_price_hdr", ["Type"] = "Form",
+                ["Keys"] = new JArray(),
+                ["Rows"] = new JArray { new JObject { ["Edits"] = new JArray {
+                    Edit("job_no",      JobNo),
+                    Edit("customer_id", CustomerId),
+                    Edit("ship_to_id",  ShipToId),
+                } } }
+            }
+        };
+
+        foreach (var e in binEdits)
+        {
+            elements.Add(new JObject
+            {
+                // Select the line by item_id (NOT line_no).
+                ["Name"] = "JOBPRICELINE.jobpriceline", ["Type"] = "List",
+                ["Keys"] = new JArray { "item_id" },
+                ["Rows"] = new JArray { new JObject {
+                    ["Edits"] = new JArray { Edit("item_id", e.ItemId) } } }
+            });
+            elements.Add(new JObject
+            {
+                // Edit the bin quantities.
+                ["Name"] = "BINS.bins", ["Type"] = "List",
+                ["Keys"] = new JArray { "contract_bin_id", "customer_id", "ship_to_id" },
+                ["Rows"] = new JArray { new JObject { ["Edits"] = new JArray {
+                    Edit("contract_bin_id", e.BinId),
+                    Edit("customer_id",     CustomerId),
+                    Edit("ship_to_id",      ShipToId),
+                    Edit("min_qty",         e.Min.ToString()),
+                    Edit("max_qty",         e.Max.ToString()),
+                    Edit("reorder_qty",     e.Reorder.ToString()),
+                    Edit("capacity",        e.Capacity.ToString()),
+                } } }
+            });
+        }
+
+        return new JObject
+        {
+            ["Name"] = "JobContractPricing", ["UseCodeValues"] = false,
+            ["IgnoreDisabled"] = true,  // top level — mandatory for the BINS sub-tab
+            ["Transactions"] = new JArray {
+                new JObject { ["Status"] = "New", ["DataElements"] = elements } }
+        };
+    }
+}

--- a/examples/csharp/Recipes/GeneratePickTicketPdf.cs
+++ b/examples/csharp/Recipes/GeneratePickTicketPdf.cs
@@ -1,0 +1,152 @@
+// Recipe: Generate Pick Ticket and PO PDFs
+// Docs:   docs/recipes/generate-pick-ticket-pdf.md
+//
+// Generate a production-order pick ticket as a base64-encoded PDF via the
+// dedicated report endpoint POST /api/v2/process/pdfreport (service
+// m_picktickets). NOTE: m_picktickets is a WRITE — it creates the
+// pick-ticket record at location_id AND returns its PDF in one call.
+//
+// Key rules (all verified live — see the recipe page):
+//   - Wrong-endpoint trap: POST /api/v2/transaction accepts an m_* payload
+//     and returns Succeeded but emits NOTHING. Reports go to
+//     /api/v2/process/pdfreport.
+//   - m_picktickets REQUIRES UseCodeValues: true and the code "P"
+//     (Production Order); UseCodeValues: false returns HTTP 500.
+//   - Status and Type are numeric 0 with Keys: [] — not the "New" shape.
+//   - Prerequisite: prod_order_hdr.printed = 'Y' (run a ProductionOrder
+//     transaction with print_form = ON first).
+//   - Success is a JSON ARRAY; errors use the P21 error envelope
+//     (ErrorType/ErrorMessage), not Summary/Messages.
+//
+// The pdfreport endpoint is not wrapped by P21Client, so this uses a raw
+// HttpClient authenticated through the Common project's P21Config/P21Auth
+// helpers (RecipeHelpers.CreateRawClientAsync).
+
+using System.Text;
+using Newtonsoft.Json.Linq;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class GeneratePickTicketPdf
+{
+    private const string ProdOrder = "1000123";  // production order number
+    private const string LocationId = "10";      // location whose inventory the components pick from
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Generate Pick Ticket PDF (m_picktickets)");
+        Console.WriteLine(new string('=', 60));
+
+        var payload = new JObject
+        {
+            ["Name"] = "m_picktickets",
+            ["UseCodeValues"] = true,   // required here -- false returns HTTP 500
+            ["Transactions"] = new JArray
+            {
+                new JObject
+                {
+                    ["Status"] = 0,     // numeric 0 for report payloads
+                    ["DataElements"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Keys"] = new JArray(),  // always empty for reports
+                            ["Type"] = 0,             // numeric 0 for report payloads
+                            ["Name"] = "TABPAGE_1.tp_1_dw_1",
+                            ["Rows"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["Edits"] = new JArray
+                                    {
+                                        // code "P" = Production Order (label is rejected)
+                                        Edit("create_pick_ticket_type", "P"),
+                                        Edit("beg_prod_order", ProdOrder),
+                                        Edit("end_prod_order", ProdOrder),
+                                        Edit("location_id", LocationId),
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        PrintPayload("m_picktickets payload (POST /api/v2/process/pdfreport)", payload);
+        Console.WriteLine(
+            "\nNOTE: this WRITES — it creates the pick-ticket record at the location" +
+            " in addition to returning the PDF.");
+
+        if (!ConfirmExecute())
+            return;
+
+        var (rawHttp, uiServer, _) = await CreateRawClientAsync();
+        using var http = rawHttp;
+
+        // ------------------------------------------------------------------
+        // Write: generate the report (creates the ticket + returns the PDF)
+        // ------------------------------------------------------------------
+        var response = await http.PostAsync(
+            $"{uiServer}/api/v2/process/pdfreport",  // NOT /api/v2/transaction
+            new StringContent(payload.ToString(), Encoding.UTF8, "application/json"));
+        var bodyText = await response.Content.ReadAsStringAsync();
+
+        // Errors come back as the standard P21 error envelope (ErrorType/ErrorMessage),
+        // NOT the Summary/Messages format used by /transaction.
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.WriteLine($"HTTP {(int)response.StatusCode}: {bodyText}");
+            return;
+        }
+
+        var parsed = JToken.Parse(bodyText);
+        if (parsed is JObject envelope && envelope["ErrorMessage"] != null)
+        {
+            Console.WriteLine($"{envelope["ErrorType"]}: {envelope["ErrorMessage"]}");
+            return;
+        }
+
+        // Success is a JSON ARRAY -- even for a single document
+        if (parsed is not JArray documents || documents.Count == 0)
+        {
+            Console.WriteLine($"No documents returned: {parsed}");
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // Save + verify each document
+        // ------------------------------------------------------------------
+        foreach (var doc in documents.OfType<JObject>())
+        {
+            var status = doc["ResponseStatus"]?["StatusCode"]?.ToString();
+            var documentData = doc["DocumentData"]?.ToString();
+            if (status != "Success" || string.IsNullOrEmpty(documentData))
+            {
+                var msg = doc["ResponseStatus"]?["Message"]?.ToString() ?? "Unknown error";
+                Console.WriteLine($"Document failed: {msg}");
+                continue;
+            }
+
+            var pdfBytes = Convert.FromBase64String(documentData);
+            // FileName includes .pdf, e.g. "PPT<nnn> PRODUCTION_PICK_TICKET.pdf"
+            var filename = doc["FileName"]?.ToString() ?? "pick_ticket.pdf";
+            await File.WriteAllBytesAsync(filename, pdfBytes);
+            Console.WriteLine($"Saved {filename} ({pdfBytes.Length} bytes)");
+
+            // Verify: decoded bytes start with %PDF and content type is PDF
+            var isPdf = pdfBytes.Length > 4 &&
+                        pdfBytes[0] == (byte)'%' && pdfBytes[1] == (byte)'P' &&
+                        pdfBytes[2] == (byte)'D' && pdfBytes[3] == (byte)'F';
+            Console.WriteLine($"  Starts with %PDF: {(isPdf ? "yes" : "NO")}");
+            Console.WriteLine($"  DocumentContentType: {doc["DocumentContentType"]}");
+            Console.WriteLine($"  ResponseStatus.Message: {doc["ResponseStatus"]?["Message"]}");
+        }
+
+        Console.WriteLine(
+            "\nTo prove the pick-ticket row landed, reprint it: run" +
+            " m_reprintpicktickets with beg_prod_pick_ticket_no/end_prod_pick_ticket_no" +
+            " set to the number from the FileName — a second PDF confirms the record.");
+    }
+}

--- a/examples/csharp/Recipes/InventoryAdjustment.cs
+++ b/examples/csharp/Recipes/InventoryAdjustment.cs
@@ -1,0 +1,151 @@
+// Recipe: Adjust On-Hand Quantity (Write-Off)
+// Docs:   docs/recipes/inventory-adjustment.md
+//
+// Post an inventory adjustment — a signed on-hand quantity change with no
+// invoice — via the InventoryAdjustment service, then read it back by its
+// server-generated adjustment_number.
+//
+// Key rules (all verified live — see the recipe page):
+//   - reason_id takes the reason's DISPLAY TEXT (with UseCodeValues: false),
+//     not its code.
+//   - unit_quantity is the SIGNED DELTA, not the new on-hand: -5 removes
+//     5 units; to zero an item out, post the negative of its on-hand.
+//   - The save POSTS the adjustment immediately — there is no draft state.
+//   - HTTP 200 is not success — check Summary.Succeeded / Failed.
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class InventoryAdjustment
+{
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Inventory Adjustment / Write-Off (InventoryAdjustment)");
+        Console.WriteLine(new string('=', 60));
+
+        using var client = await P21Client.CreateAsync();
+
+        var payload = new JObject
+        {
+            ["Name"] = "InventoryAdjustment",
+            ["UseCodeValues"] = false,  // reason_id is the display text, not the code
+            ["Transactions"] = new JArray
+            {
+                new JObject
+                {
+                    ["Status"] = "New",
+                    ["DataElements"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Name"] = "TABPAGE_1.tp_1_dw_1",
+                            ["Type"] = "Form",
+                            ["Keys"] = new JArray(),
+                            ["Rows"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["Edits"] = new JArray
+                                    {
+                                        Edit("company_id", "ACME"),
+                                        Edit("location_id", "10"),
+                                        Edit("reason_id", "ADJUST"),  // display text
+                                        Edit("inv_adj_description", "Cycle count write-off"),
+                                    },
+                                    ["RelativeDateEdits"] = new JArray()
+                                }
+                            }
+                        },
+                        new JObject
+                        {
+                            ["Name"] = "TABPAGE_17.tp_17_dw_17",
+                            ["Type"] = "List",
+                            ["Keys"] = new JArray(),
+                            ["Rows"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["Edits"] = new JArray
+                                    {
+                                        Edit("item_id", "WIDGET-001"),
+                                        // signed delta, NOT new on-hand
+                                        Edit("unit_quantity", "-5"),
+                                    },
+                                    ["RelativeDateEdits"] = new JArray()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        PrintPayload("InventoryAdjustment payload (write off 5 units)", payload);
+        Console.WriteLine("\nNOTE: the save POSTS the adjustment immediately — no draft state.");
+
+        if (!ConfirmExecute())
+            return;
+
+        // ------------------------------------------------------------------
+        // Write
+        // ------------------------------------------------------------------
+        var result = await client.Transaction.CreateAsync(payload);
+        if (!CheckResult(result))
+            return;
+
+        // Pull the server-generated adjustment_number out of the echoed DataElements
+        string? adjustmentNumber = null;
+        foreach (var txn in result.Raw?["Results"]?["Transactions"] as JArray ?? new JArray())
+        foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+        {
+            if (de["Name"]?.ToString() != "TABPAGE_1.tp_1_dw_1") continue;
+            foreach (var row in de["Rows"] as JArray ?? new JArray())
+            foreach (var edit in row["Edits"] as JArray ?? new JArray())
+                if (edit["Name"]?.ToString() == "adjustment_number" &&
+                    !string.IsNullOrEmpty(edit["Value"]?.ToString()))
+                    adjustmentNumber = edit["Value"]!.ToString();
+        }
+        Console.WriteLine($"\nAdjustment number: {adjustmentNumber}");
+        if (string.IsNullOrEmpty(adjustmentNumber))
+            return;
+
+        // ------------------------------------------------------------------
+        // Verify: read the adjustment back by its key
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nVerify via /transaction/get:");
+        Console.WriteLine(new string('-', 50));
+
+        var getPayload = new JObject
+        {
+            ["ServiceName"] = "InventoryAdjustment",
+            ["TransactionStates"] = new JArray
+            {
+                new JObject
+                {
+                    ["DataElementName"] = "TABPAGE_1.tp_1_dw_1",
+                    ["Keys"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Name"] = "adjustment_number",
+                            ["Value"] = adjustmentNumber
+                        }
+                    }
+                }
+            }
+        };
+        var getResult = await client.Transaction.GetRecordsAsync(getPayload);
+
+        var wanted = new[] { "adjustment_number", "location_id", "reason_id",
+                             "item_id", "unit_quantity", "new_qoh" };
+        foreach (var txn in getResult["Transactions"] as JArray ?? new JArray())
+        foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+        foreach (var row in de["Rows"] as JArray ?? new JArray())
+        foreach (var edit in row["Edits"] as JArray ?? new JArray())
+            if (wanted.Contains(edit["Name"]?.ToString()))
+                Console.WriteLine($"  {edit["Name"]}: {edit["Value"]}");
+    }
+}

--- a/examples/csharp/Recipes/OrderWithAssembly.cs
+++ b/examples/csharp/Recipes/OrderWithAssembly.cs
@@ -1,0 +1,245 @@
+// Recipe: Order with an Assembly Line
+// Docs:   docs/recipes/order-with-assembly.md
+//
+// Enter a sales order interactively when a line is an assembly that must
+// explode into components and/or spawn a production order. The Transaction
+// API auto-answers the "add as assembly?" prompt No (killing the explode),
+// so this flow uses the Interactive API with response-window handling ON
+// and answers the prompts itself.
+//
+// Key rules (all verified end-to-end — see the recipe page):
+//   - Session must start with ResponseWindowHandlingEnabled: true.
+//   - Date fields fire the w_response_common date-cascade prompt even on a
+//     brand-new order — answer cb_ok against the POPUP's window ID.
+//   - Assembly prompt buttons: cb_1 = Yes (explode) / cb_2 = No / cb_3 = Cancel.
+//   - Set the first line on the EXISTING items row (no /v2/row add for it).
+//   - PUT /v2/data takes the bare window-ID string as the JSON body.
+//   - /v2/window and /v2/data take ?id=; /v2/tools takes ?windowId=.
+//   - Status may be an integer or a string (3 or "Blocked") — handle both.
+//   - DatawindowName is required in v2 change requests on P21 25.2+.
+//
+// This recipe drives popup windows directly, which P21Client's typed helpers
+// don't cover — it uses a raw HttpClient authenticated through the Common
+// project's P21Config/P21Auth helpers (RecipeHelpers.CreateRawClientAsync).
+
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class OrderWithAssembly
+{
+    private const string CustomerId = "100198";
+    private const string AssemblyItemId = "WIDGET-001";
+    private const string Quantity = "5";
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Order with an Assembly Line (Interactive API)");
+        Console.WriteLine(new string('=', 60));
+
+        // Dry run = print the planned call sequence; EXECUTE = run it.
+        Console.WriteLine(@"
+Planned call sequence:
+  1. POST /api/ui/interactive/sessions   {ResponseWindowHandlingEnabled: true}
+  2. POST /api/ui/interactive/v2/window  {ServiceName: ""Order""}
+  3. PUT  /v2/change TABPAGE_1/order: quote=OFF, sales_loc_id=10,
+          source_loc_id=10, customer_id=" + CustomerId + @", ship_to_id=200,
+          contact_id=300, order_date=2030-01-05 (answer cb_ok),
+          requested_date=2030-01-06 (answer cb_ok), po_no=PO-TEST-001,
+          taker=JSMITH
+  4. PUT  /v2/tab  -> TP_ITEMS
+  5. PUT  /v2/change TP_ITEMS/items: oe_order_item_id=" + AssemblyItemId + @"
+          (assembly prompt -> answer cb_1 = Yes, explode / link prod order)
+  6. PUT  /v2/change TP_ITEMS/items: unit_quantity=" + Quantity + @"
+  7. PUT  /v2/data (bare window-ID string body) -> answer follow-on prompts
+  8. PUT  /v2/tab -> TABPAGE_1, GET /v2/data?id={windowId} -> read order_no
+  9. DELETE /v2/window?id={windowId}, DELETE /sessions
+Verify: OData oe_line for the new order_no -> assembly codes
+        (B kit parent, N component, P production-order line, S build-to-stock)");
+
+        if (!ConfirmExecute())
+            return;
+
+        var (rawHttp, uiServer, baseUrl) = await CreateRawClientAsync();
+        using var http = rawHttp;
+        var iapi = $"{uiServer}/api/ui/interactive";
+
+        // 1. Session with response-window handling ON
+        var sessBody = new JObject { ["ResponseWindowHandlingEnabled"] = true };
+        (await http.PostAsync($"{iapi}/sessions",
+            new StringContent(sessBody.ToString(), Encoding.UTF8, "application/json")))
+            .EnsureSuccessStatusCode();
+        Console.WriteLine("\nSession started (ResponseWindowHandlingEnabled: true)");
+
+        // 2. Open the Order window
+        var winBody = new JObject { ["ServiceName"] = "Order" };
+        var winResp = await http.PostAsync($"{iapi}/v2/window",
+            new StringContent(winBody.ToString(), Encoding.UTF8, "application/json"));
+        winResp.EnsureSuccessStatusCode();
+        var windowId = JObject.Parse(
+            await winResp.Content.ReadAsStringAsync())["WindowId"]!.ToString();
+        Console.WriteLine($"Order window opened: {windowId}");
+
+        try
+        {
+            // 3. Header -- TABPAGE_1 / datawindow "order". quote OFF = real order.
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "quote", "OFF");
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "sales_loc_id", "10");
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "source_loc_id", "10");
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "customer_id", CustomerId);
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "ship_to_id", "200");
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "contact_id", "300");
+            // Dates fire the w_response_common date-cascade prompt even on a NEW order
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "order_date", "2030-01-05", "cb_ok");
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "requested_date", "2030-01-06", "cb_ok");
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "po_no", "PO-TEST-001");
+            await ChangeAsync(http, iapi, windowId, "TABPAGE_1", "order", "taker", "JSMITH"); // else = API user
+            Console.WriteLine("Header fields set");
+
+            // 4. Lines tab
+            var tabBody = new JObject { ["WindowId"] = windowId, ["PageName"] = "TP_ITEMS" };
+            (await http.PutAsync($"{iapi}/v2/tab",
+                new StringContent(tabBody.ToString(), Encoding.UTF8, "application/json")))
+                .EnsureSuccessStatusCode();
+
+            // 5. Item on the EXISTING items row; assembly prompt: cb_1 = Yes (explode)
+            await ChangeAsync(http, iapi, windowId, "TP_ITEMS", "items",
+                "oe_order_item_id", AssemblyItemId, "cb_1");
+            // 6. Quantity
+            await ChangeAsync(http, iapi, windowId, "TP_ITEMS", "items",
+                "unit_quantity", Quantity);
+            Console.WriteLine($"Line entered: {AssemblyItemId} x {Quantity}");
+
+            // 7. Save -- v2 body is the bare window-ID JSON string (an object => 422)
+            var saveResp = await http.PutAsync($"{iapi}/v2/data",
+                new StringContent(JsonConvert.SerializeObject(windowId),
+                    Encoding.UTF8, "application/json"));
+            saveResp.EnsureSuccessStatusCode();
+            var result = JObject.Parse(await saveResp.Content.ReadAsStringAsync());
+            while (IsBlocked(result))  // follow-on prompts: answer with proceed button
+                result = await AnswerResponseWindowsAsync(http, iapi, result);
+            if (result["Status"]?.ToString() is "2" or "Failure")
+                throw new InvalidOperationException($"Save failed: {result["Messages"]}");
+            Console.WriteLine("Order saved");
+
+            // 8. Read order_no back -- /v2/data returns the ACTIVE surface, so
+            //    switch back to the header tab first.
+            var backBody = new JObject { ["WindowId"] = windowId, ["PageName"] = "TABPAGE_1" };
+            (await http.PutAsync($"{iapi}/v2/tab",
+                new StringContent(backBody.ToString(), Encoding.UTF8, "application/json")))
+                .EnsureSuccessStatusCode();
+            var dataResp = await http.GetAsync($"{iapi}/v2/data?id={windowId}");
+            dataResp.EnsureSuccessStatusCode();
+
+            string? orderNo = null;
+            foreach (var dw in JArray.Parse(await dataResp.Content.ReadAsStringAsync()))
+            {
+                if (dw["Name"]?.ToString() != "order") continue;
+                var columns = (dw["Columns"] as JArray)!.Select(c => c.ToString()).ToList();
+                var row = (dw["Data"] as JArray)![(int?)dw["ActiveRow"] ?? 0];
+                orderNo = row[columns.IndexOf("order_no")]?.ToString();
+                Console.WriteLine($"Created order_no: {orderNo}");
+            }
+
+            // Verify: assembly codes on the saved lines
+            // (B kit parent, N component, P production-order line, S build-to-stock)
+            if (!string.IsNullOrEmpty(orderNo))
+            {
+                Console.WriteLine("\nVerify via OData (oe_line assembly codes):");
+                Console.WriteLine(new string('-', 50));
+                var filter = Uri.EscapeDataString($"order_no eq '{orderNo}'");
+                var lineResp = await http.GetAsync(
+                    $"{baseUrl}/odataservice/odata/table/oe_line?$filter={filter}");
+                lineResp.EnsureSuccessStatusCode();
+                var lines = (JArray)JObject.Parse(
+                    await lineResp.Content.ReadAsStringAsync())["value"]!;
+                foreach (var line in lines)
+                    Console.WriteLine($"  line {line["line_no"]}: assembly={line["assembly"]} " +
+                                      $"qty_ordered={line["qty_ordered"]}");
+                Console.WriteLine("  For auto_create_prod_order items, also check " +
+                                  "prod_order_line_link (trans_type 'O').");
+            }
+        }
+        finally
+        {
+            // 9. Clean up (window uses ?id=; sessions endpoint takes no parameter)
+            await http.DeleteAsync($"{iapi}/v2/window?id={windowId}");
+            await http.DeleteAsync($"{iapi}/sessions");
+            Console.WriteLine("\nWindow closed, session ended");
+        }
+    }
+
+    /// <summary>Status may be an integer or a string form — handle both.</summary>
+    private static bool IsBlocked(JObject r) =>
+        r["Status"]?.ToString() is "3" or "Blocked";
+
+    /// <summary>Window IDs of popups opened by the last action.
+    /// Events[].Data is a key-value list: [{"Key": "windowid", "Value": "..."}].</summary>
+    private static List<string> PopupIds(JObject r) =>
+        (r["Events"] as JArray ?? new JArray())
+            .Where(e => e["Name"]?.ToString() == "windowopened")
+            .SelectMany(e => e["Data"] as JArray ?? new JArray())
+            .Where(kv => kv["Key"]?.ToString() == "windowid")
+            .Select(kv => kv["Value"]!.ToString())
+            .ToList();
+
+    /// <summary>
+    /// Answer every popup the last action opened, then return the last result.
+    /// Discovers buttons via GET /v2/tools?windowId= (the tools endpoint takes
+    /// ?windowId=, NOT ?id=), then clicks via POST /v2/tools with the POPUP's
+    /// window ID. If button is null, picks the first proceed-style button.
+    /// </summary>
+    private static async Task<JObject> AnswerResponseWindowsAsync(
+        HttpClient http, string iapi, JObject result, string? button = null)
+    {
+        foreach (var popupId in PopupIds(result))
+        {
+            var toolsResp = await http.GetAsync($"{iapi}/v2/tools?windowId={popupId}");
+            toolsResp.EnsureSuccessStatusCode();
+            var available = JArray.Parse(await toolsResp.Content.ReadAsStringAsync())
+                .Select(t => (t["Name"] ?? t["ToolName"])?.ToString()).ToList();
+            var pick = button
+                ?? new[] { "cb_ok", "cb_1", "cb_yes" }.FirstOrDefault(available.Contains)
+                ?? throw new InvalidOperationException(
+                    $"Popup {popupId}: buttons [{string.Join(", ", available)}]");
+            Console.WriteLine($"  Popup {popupId}: answering {pick}");
+
+            var clickBody = new JObject { ["WindowId"] = popupId, ["ToolName"] = pick };
+            var clickResp = await http.PostAsync($"{iapi}/v2/tools",
+                new StringContent(clickBody.ToString(), Encoding.UTF8, "application/json"));
+            clickResp.EnsureSuccessStatusCode();
+            result = JObject.Parse(await clickResp.Content.ReadAsStringAsync());
+        }
+        return result;
+    }
+
+    /// <summary>Change one field; answer the popup it triggers (if any) with answer.</summary>
+    private static async Task<JObject> ChangeAsync(
+        HttpClient http, string iapi, string windowId, string tab, string dw,
+        string field, string value, string? answer = null)
+    {
+        var body = new JObject
+        {
+            ["WindowId"] = windowId,
+            ["List"] = new JArray { new JObject
+            {
+                ["TabName"] = tab,
+                ["DatawindowName"] = dw,   // required on 25.2+
+                ["FieldName"] = field,
+                ["Value"] = value,
+            }},
+        };
+        var resp = await http.PutAsync($"{iapi}/v2/change",
+            new StringContent(body.ToString(), Encoding.UTF8, "application/json"));
+        resp.EnsureSuccessStatusCode();
+        var result = JObject.Parse(await resp.Content.ReadAsStringAsync());
+        if (result["Status"]?.ToString() is "2" or "Failure")
+            throw new InvalidOperationException($"{field}: {result["Messages"]}");
+        return IsBlocked(result)
+            ? await AnswerResponseWindowsAsync(http, iapi, result, answer)
+            : result;
+    }
+}

--- a/examples/csharp/Recipes/P21Examples.Recipes.csproj
+++ b/examples/csharp/Recipes/P21Examples.Recipes.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>P21Examples.Recipes</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\P21Examples.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/csharp/Recipes/ProductionOrderRunbook.cs
+++ b/examples/csharp/Recipes/ProductionOrderRunbook.cs
@@ -1,0 +1,229 @@
+// Recipe: Production Order Runbook — Create to Invoice
+// Docs:   docs/recipes/production-order-runbook.md
+//
+// The recipe page is a CHECKLIST, not a script: create the production order,
+// log labor, print the pick ticket(s), confirm the pick, complete (receive)
+// the order, and ship + invoice the linked sales order. This example prints
+// that checklist as guidance and automates the one stage most people script
+// first: generating the pick ticket with m_picktickets and reading the new
+// ticket's status back via POST /api/v2/transaction/get.
+//
+// Key traps (all verified live — see the recipe page):
+//   - Shell confirm: confirming a pick via a bare Transaction POST flips the
+//     status to 1962 but qty_applied stays 0 and NO stock moves — confirm
+//     through the Interactive API ProductionOrderPicking window.
+//   - Labor must land on a pick ticket before completion.
+//   - bin_cd and unit_quantity are two SEPARATE change calls at completion.
+//   - Reports go to /api/v2/process/pdfreport, never /api/v2/transaction.
+//
+// Uses a raw HttpClient (Common P21Config/P21Auth) because pdfreport is not
+// wrapped by P21Client.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class ProductionOrderRunbook
+{
+    private const string ProdOrder = "1000123";     // production order number
+    private const string StockLocation = "10";      // where the components stock (NOT necessarily the make location)
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Production Order Runbook (Create to Invoice)");
+        Console.WriteLine(new string('=', 60));
+
+        PrintChecklist();
+
+        // ------------------------------------------------------------------
+        // Automated stage: print the pick ticket and read back its status
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nAutomated stage — Stage 3: generate the production pick ticket");
+        Console.WriteLine(new string('-', 60));
+
+        var report = new JObject
+        {
+            ["Name"] = "m_picktickets",
+            ["UseCodeValues"] = true,  // m_picktickets REQUIRES code values; false returns HTTP 500
+            ["Transactions"] = new JArray
+            {
+                new JObject
+                {
+                    ["Status"] = 0,    // reports use numeric 0, not "New"
+                    ["DataElements"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Keys"] = new JArray(),
+                            ["Type"] = 0,
+                            ["Name"] = "TABPAGE_1.tp_1_dw_1",
+                            ["Rows"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["Edits"] = new JArray
+                                    {
+                                        Edit("create_pick_ticket_type", "P"), // code "P" = Production Order
+                                        Edit("beg_prod_order", ProdOrder),
+                                        Edit("end_prod_order", ProdOrder),
+                                        Edit("location_id", StockLocation),
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        PrintPayload("m_picktickets payload (POST /api/v2/process/pdfreport)", report);
+        Console.WriteLine(
+            "\nNOTE: this WRITES — it creates the pick-ticket record at the stock" +
+            " location in addition to returning the PDF.\n" +
+            "Prerequisite: prod_order_hdr.printed = 'Y' (ProductionOrder transaction" +
+            " with print_form = ON).");
+
+        if (!ConfirmExecute())
+            return;
+
+        var (rawHttp, uiServer, _) = await CreateRawClientAsync();
+        using var http = rawHttp;
+
+        // --- 1. Generate the pick ticket (creates the record + returns the PDF) ---
+        // NOT /api/v2/transaction (silent no-op there)
+        var reportResp = await http.PostAsync(
+            $"{uiServer}/api/v2/process/pdfreport",
+            new StringContent(report.ToString(), Encoding.UTF8, "application/json"));
+        var reportText = await reportResp.Content.ReadAsStringAsync();
+        if (!reportResp.IsSuccessStatusCode)
+        {
+            Console.WriteLine($"HTTP {(int)reportResp.StatusCode}: {reportText}");
+            return;
+        }
+
+        var reportBody = JToken.Parse(reportText);
+        if (reportBody.Type != JTokenType.Array)  // errors come back as an envelope, not an array
+        {
+            Console.WriteLine($"Report failed: {reportBody["ErrorMessage"]}");
+            return;
+        }
+
+        var doc = (JObject)((JArray)reportBody)[0];
+        if (doc["ResponseStatus"]?["StatusCode"]?.ToString() != "Success" ||
+            string.IsNullOrEmpty(doc["DocumentData"]?.ToString()))
+        {
+            Console.WriteLine($"Report failed: {doc["ResponseStatus"]?["Message"]}");
+            return;
+        }
+
+        var fileName = doc["FileName"]!.ToString(); // e.g. "PPT123456 PRODUCTION_PICK_TICKET.pdf"
+        await File.WriteAllBytesAsync(
+            fileName, Convert.FromBase64String(doc["DocumentData"]!.ToString()));
+        Console.WriteLine($"Saved {fileName}");
+
+        // --- 2. Verify: read the new ticket back (number comes from the FileName) ---
+        var match = Regex.Match(fileName, @"PPT(\d+)");
+        if (!match.Success)
+        {
+            Console.WriteLine($"Could not parse a ticket number from '{fileName}'");
+            return;
+        }
+        var ticketNo = match.Groups[1].Value;
+
+        Console.WriteLine($"\nVerify: reading ticket {ticketNo} back via /transaction/get:");
+        Console.WriteLine(new string('-', 50));
+
+        var getPayload = new JObject
+        {
+            ["ServiceName"] = "ProductionOrderPicking",
+            ["TransactionStates"] = new JArray
+            {
+                new JObject
+                {
+                    ["DataElementName"] = "TP_PRODPICKTICKETCONF.tp_prodpickticketconf",
+                    ["Keys"] = new JArray
+                    {
+                        new JObject { ["Name"] = "prod_pick_ticket_number", ["Value"] = ticketNo }
+                    }
+                }
+            }
+        };
+
+        var getResp = await http.PostAsync(
+            $"{uiServer}/api/v2/transaction/get",
+            new StringContent(getPayload.ToString(), Encoding.UTF8, "application/json"));
+        getResp.EnsureSuccessStatusCode();
+        var getResult = JObject.Parse(await getResp.Content.ReadAsStringAsync());
+
+        foreach (var txn in getResult["Transactions"] as JArray ?? new JArray())
+        foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+        foreach (var row in de["Rows"] as JArray ?? new JArray())
+        {
+            var fields = new Dictionary<string, string>();
+            foreach (var edit in row["Edits"] as JArray ?? new JArray())
+                fields[edit["Name"]!.ToString()] = edit["Value"]?.ToString() ?? "";
+            if (fields.ContainsKey("row_status_flag"))
+                // 702 = Open, 1962 = Confirmed, 1268 = Completed
+                Console.WriteLine(
+                    $"  Ticket {fields.GetValueOrDefault("prod_pick_ticket_number")} " +
+                    $"for prod order {fields.GetValueOrDefault("prod_order_number")}: " +
+                    $"status {fields.GetValueOrDefault("row_status_flag")} " +
+                    "(702 Open / 1962 Confirmed / 1268 Completed)");
+        }
+    }
+
+    private static void PrintChecklist()
+    {
+        Console.WriteLine(@"
+Runbook checklist (each stage links to a deep dive in the recipe page):
+
+  Stage 1 - Create the production order
+    Path A: sales order auto-create (Interactive API when the line must
+            explode — see OrderWithAssembly). Auto-create NETS against
+            stock: on-hand means no production order spawns.
+    Path B: direct build-to-stock via the ProductionOrder window
+            (header source_loc_id; TABPAGE_17.tp_17_dw_17
+            assembly_item_id + qty_to_make).
+    Traps:  salesrep must be valid at the sales location; order date
+            must differ from required date.
+
+  Stage 2 - Log labor BEFORE printing (see RecordLaborTime)
+    Trap:   labor added after printing (no reprint) sits at
+            qty_on_pick_tickets = 0 and completion fails with
+            ""components have a quantity used of 0"".
+
+  Stage 3 - Print the pick ticket and form  [AUTOMATED BELOW]
+    ProductionOrder transaction (print_pick_ticket/print_form = ON) or
+    m_picktickets at POST /api/v2/process/pdfreport.
+    Traps:  print_pick_ticket emits only at the MAKE location; never
+            post m_* reports to /api/v2/transaction (silent no-op).
+
+  Stage 4 - Confirm the pick (Interactive API ONLY)
+    ProductionOrderPicking window, header key prod_pick_ticket_number,
+    set row_status_flag = ""Confirm"", save. Confirm EVERY ticket.
+    Trap:   a bare Transaction POST produces a SHELL confirm — status
+            1962 but qty_applied = 0 and no stock moves.
+
+  Stage 5 - Complete the order (production receipt)
+    ProductionOrderProcessing window: qty_to_complete on the line, then
+    bin_cd and unit_quantity on TABPAGE_ASSEMBLY_BIN as TWO SEPARATE
+    change calls; optional new_cost per component; save (inv_tran PROP).
+    Trap:   combining bin_cd and unit_quantity in one call drops the
+            quantity.
+
+  Stage 6 - Ship + invoice the linked sales order
+    Order transaction with print_tix = ON (creates oe_pick_ticket), then
+    the Shipping service keyed by pick_ticket_no — retrieve and save
+    (create_invoice defaults ON, so the save ships AND invoices).
+    Traps:  the item needs a packaging code; leave unit_price unset for
+            contract pricing.
+
+  Stage 7 - Fix quantity fallout (see InventoryAdjustment)
+
+  Cost model: PROP receipt cost = components + labor posted BEFORE
+  completion; shipment COGS is the moving average at ship time.");
+    }
+}

--- a/examples/csharp/Recipes/Program.cs
+++ b/examples/csharp/Recipes/Program.cs
@@ -1,0 +1,117 @@
+// P21 Cookbook Recipes - C#
+//
+// Menu-driven runner for the docs/recipes/ cookbook — one end-to-end class
+// per recipe page. Each example is a static class with an async RunAsync()
+// method.
+//
+// WRITE SAFETY: every recipe prints its payload and asks for console
+// confirmation (Type EXECUTE to post, anything else = dry run) before any
+// POST that writes; read-only lookups run freely.
+//
+// Prerequisites:
+//   - .env file with P21_BASE_URL, P21_USERNAME, P21_PASSWORD
+//   - Network access to the P21 server
+//   - Always run against a test/play environment first
+//
+// Usage:
+//   dotnet run --project examples/csharp/Recipes
+//
+// Or from Visual Studio, set Recipes as the startup project.
+
+using P21Examples.Recipes;
+
+Console.WriteLine("P21 Cookbook Recipes (C#)");
+Console.WriteLine(new string('=', 50));
+Console.WriteLine();
+
+while (true)
+{
+    Console.WriteLine("Select a recipe to run:");
+    Console.WriteLine();
+    Console.WriteLine("   1. Update Contract Lines      - JobContractPricing line/price upsert");
+    Console.WriteLine("   2. Edit Contract Bins         - Bin min/max/reorder via IgnoreDisabled");
+    Console.WriteLine("   3. Create Bins (Bulk)         - BinLocation twin-clone batch create");
+    Console.WriteLine("   4. Create Sales Order         - Order header + lines in one POST");
+    Console.WriteLine("   5. Order with Assembly        - Interactive flow with response windows");
+    Console.WriteLine("   6. Set Primary Bin/Supplier   - Item nested edit + mandatory read-back");
+    Console.WriteLine("   7. Generate Pick Ticket PDF   - m_picktickets via /process/pdfreport");
+    Console.WriteLine("   8. Production Order Runbook   - Checklist + pick-ticket stage");
+    Console.WriteLine("   9. Record Labor Time          - TimeEntry labor hours");
+    Console.WriteLine("  10. Inventory Adjustment       - Signed on-hand delta write-off");
+    Console.WriteLine();
+    Console.WriteLine("  Q. Quit");
+    Console.WriteLine();
+    Console.Write("Choice: ");
+
+    var choice = Console.ReadLine()?.Trim().ToUpper();
+    Console.WriteLine();
+
+    try
+    {
+        switch (choice)
+        {
+            case "1":
+                await UpdateContractLines.RunAsync();
+                break;
+
+            case "2":
+                await EditContractBins.RunAsync();
+                break;
+
+            case "3":
+                await CreateBins.RunAsync();
+                break;
+
+            case "4":
+                await CreateSalesOrder.RunAsync();
+                break;
+
+            case "5":
+                await OrderWithAssembly.RunAsync();
+                break;
+
+            case "6":
+                await SetPrimaryBinSupplier.RunAsync();
+                break;
+
+            case "7":
+                await GeneratePickTicketPdf.RunAsync();
+                break;
+
+            case "8":
+                await ProductionOrderRunbook.RunAsync();
+                break;
+
+            case "9":
+                await RecordLaborTime.RunAsync();
+                break;
+
+            case "10":
+                await InventoryAdjustment.RunAsync();
+                break;
+
+            case "Q":
+            case null:
+                Console.WriteLine("Goodbye!");
+                return;
+
+            default:
+                Console.WriteLine($"Unknown choice: {choice}");
+                break;
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"\nUnhandled error: {ex.GetType().Name}");
+        Console.WriteLine($"  {ex.Message}");
+
+        if (ex.InnerException != null)
+        {
+            Console.WriteLine($"  Inner: {ex.InnerException.Message}");
+        }
+    }
+
+    Console.WriteLine();
+    Console.WriteLine(new string('-', 50));
+    Console.WriteLine();
+}

--- a/examples/csharp/Recipes/RecipeHelpers.cs
+++ b/examples/csharp/Recipes/RecipeHelpers.cs
@@ -1,0 +1,81 @@
+// Shared helpers for the recipe examples.
+//
+// - Write-safety gate: every recipe prints its payload and asks for console
+//   confirmation before any POST that writes. Anything other than EXECUTE
+//   is a dry run; read-only lookups always run.
+// - Auth/config comes from the Common project (P21Client / P21Config /
+//   P21Auth), not the recipes' inline P21Session helper.
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using P21Examples.Common.Models;
+
+namespace P21Examples.Recipes;
+
+internal static class RecipeHelpers
+{
+    /// <summary>Build a Transaction API edit: {"Name": ..., "Value": ...}.</summary>
+    public static JObject Edit(string name, string value) =>
+        new JObject { ["Name"] = name, ["Value"] = value };
+
+    /// <summary>Print a payload before asking for write confirmation.</summary>
+    public static void PrintPayload(string title, JToken payload)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"{title}:");
+        Console.WriteLine(new string('-', 50));
+        Console.WriteLine(payload.ToString());
+    }
+
+    /// <summary>
+    /// WRITE SAFETY gate. Returns true only when the user types EXECUTE;
+    /// anything else means dry run (nothing is posted).
+    /// </summary>
+    public static bool ConfirmExecute()
+    {
+        Console.WriteLine();
+        Console.Write("Type EXECUTE to post, anything else = dry run: ");
+        var answer = Console.ReadLine()?.Trim();
+        if (answer == "EXECUTE")
+            return true;
+
+        Console.WriteLine("Dry run - nothing was posted.");
+        return false;
+    }
+
+    /// <summary>
+    /// Print Summary.Succeeded / Summary.Failed and every message.
+    /// HTTP 200 is NOT success on the Transaction API — only the Summary is.
+    /// </summary>
+    public static bool CheckResult(TransactionResult result)
+    {
+        Console.WriteLine($"  Succeeded: {result.Succeeded}, Failed: {result.Failed}");
+        foreach (var msg in result.Messages)
+            Console.WriteLine($"  {msg}");
+        return result.Failed == 0 && result.Succeeded > 0;
+    }
+
+    /// <summary>
+    /// Authenticated raw HttpClient + UI server URL for endpoints P21Client
+    /// does not wrap (POST /api/v2/process/pdfreport, popup /v2/tools calls).
+    /// Built from the Common project's config/auth helpers. Caller disposes Http.
+    /// </summary>
+    public static async Task<(HttpClient Http, string UiServer, string BaseUrl)> CreateRawClientAsync()
+    {
+        var config = P21Config.FromEnvironment();
+
+        var handler = new HttpClientHandler();
+        if (!config.VerifySsl)
+        {
+            handler.ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+        }
+
+        var http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(120) };
+        var token = await P21Auth.GetTokenAsync(http, config);
+        P21Auth.SetAuthHeaders(http, token.AccessToken);
+        var uiServer = await P21Auth.GetUiServerUrlAsync(http, config.BaseUrl);
+
+        return (http, uiServer, config.BaseUrl);
+    }
+}

--- a/examples/csharp/Recipes/RecordLaborTime.cs
+++ b/examples/csharp/Recipes/RecordLaborTime.cs
@@ -1,0 +1,143 @@
+// Recipe: Record Labor Time on a Production Order
+// Docs:   docs/recipes/record-labor-time.md
+//
+// Post a technician's labor hours to a production order with the TimeEntry
+// service, then read the labor grid back.
+//
+// Key rules (all verified live — see the recipe page):
+//   - Strict field order on the labor grid: prod_order_number -> item_id ->
+//     component_labor_id -> start_time -> end_time. Out of order, the
+//     downstream fields stay disabled and the values don't land.
+//   - technician_id is a CONTACT ID, not a P21 user ID.
+//   - The accounting period for entry_date must be open.
+//   - Time ACCUMULATES: re-posting the same entry doubles the labor.
+//   - Log labor before printing the pick ticket (or reprint after).
+//   - labor_type_cd is required — Rate, OT Rate, Prem Rate.
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class RecordLaborTime
+{
+    private const string ProdOrder = "1000123";
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Record Labor Time (TimeEntry)");
+        Console.WriteLine(new string('=', 60));
+
+        using var client = await P21Client.CreateAsync();
+
+        var payload = new JObject
+        {
+            ["Name"] = "TimeEntry",
+            ["UseCodeValues"] = false,
+            ["Transactions"] = new JArray
+            {
+                new JObject
+                {
+                    ["Status"] = "New",
+                    ["DataElements"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["Name"] = "TP_TECHNICIAN.tp_technician",
+                            ["Type"] = "Form",
+                            ["Keys"] = new JArray(),
+                            ["Rows"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["Edits"] = new JArray
+                                    {
+                                        Edit("company_id", "ACME"),
+                                        Edit("technician_id", "300"),  // CONTACT id, not a user id
+                                        Edit("entry_date", "2030-01-05"),
+                                    },
+                                    ["RelativeDateEdits"] = new JArray()
+                                }
+                            }
+                        },
+                        new JObject
+                        {
+                            ["Name"] = "TP_LABORRECORDING.prod_order_line_comp_labor",
+                            ["Type"] = "List",
+                            ["Keys"] = new JArray { "prod_order_number" },
+                            ["Rows"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    // Strict order: prod_order_number -> item_id ->
+                                    // component_labor_id -> start_time -> end_time
+                                    ["Edits"] = new JArray
+                                    {
+                                        Edit("prod_order_number", ProdOrder),
+                                        Edit("item_id", "ASSY-100"),          // the assembly LINE's item
+                                        Edit("component_labor_id", "LABOR-SHOP"),
+                                        Edit("start_time", "2030-01-05T08:00:00"),
+                                        Edit("end_time", "2030-01-05T12:00:00"),
+                                        Edit("labor_type_cd", "Rate"),        // required
+                                    },
+                                    ["RelativeDateEdits"] = new JArray()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        PrintPayload("TimeEntry payload (4 hours)", payload);
+        Console.WriteLine("\nNOTE: time ACCUMULATES — re-posting the same entry doubles the labor.");
+
+        if (!ConfirmExecute())
+            return;
+
+        // ------------------------------------------------------------------
+        // Write
+        // ------------------------------------------------------------------
+        var result = await client.Transaction.CreateAsync(payload);
+        if (!CheckResult(result))
+            return;
+
+        // ------------------------------------------------------------------
+        // Verify: read the labor grid back — time_worked should reflect the
+        // ACCUMULATED total, not just this entry.
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nVerify: labor grid via /transaction/get:");
+        Console.WriteLine(new string('-', 50));
+
+        var getPayload = new JObject
+        {
+            ["ServiceName"] = "TimeEntry",
+            ["TransactionStates"] = new JArray
+            {
+                new JObject
+                {
+                    ["DataElementName"] = "TP_LABORRECORDING.prod_order_line_comp_labor",
+                    ["Keys"] = new JArray
+                    {
+                        new JObject { ["Name"] = "prod_order_number", ["Value"] = ProdOrder }
+                    }
+                }
+            }
+        };
+        var getResult = await client.Transaction.GetRecordsAsync(getPayload);
+
+        foreach (var txn in getResult["Transactions"] as JArray ?? new JArray())
+        foreach (var de in txn["DataElements"] as JArray ?? new JArray())
+        foreach (var row in de["Rows"] as JArray ?? new JArray())
+        {
+            var fields = new Dictionary<string, string>();
+            foreach (var edit in row["Edits"] as JArray ?? new JArray())
+                fields[edit["Name"]!.ToString()] = edit["Value"]?.ToString() ?? "";
+            if (!string.IsNullOrEmpty(fields.GetValueOrDefault("prod_order_number")))
+                Console.WriteLine(
+                    $"  {fields.GetValueOrDefault("component_labor_id")}: " +
+                    $"time_worked={fields.GetValueOrDefault("time_worked")}");
+        }
+    }
+}

--- a/examples/csharp/Recipes/SetPrimaryBinSupplier.cs
+++ b/examples/csharp/Recipes/SetPrimaryBinSupplier.cs
@@ -1,0 +1,120 @@
+// Recipe: Set an Item's Primary Bin or Primary Supplier at a Location
+// Docs:   docs/recipes/set-primary-bin-supplier.md
+//
+// Update an item's primary supplier (or primary bin) for one stocking
+// location via the Item service's nested Form -> List -> detail pattern —
+// with a MANDATORY read-back, because the primary-supplier write can
+// silently no-op.
+//
+// Key rules (all verified live — see the recipe page):
+//   - Silent no-op: the target supplier must already have a location-level
+//     row (inventory_supplier_x_loc) at that location, or the transaction
+//     returns Succeeded = 1 and nothing flips. Always verify.
+//   - Write the flag, read the id: primary_supplier maps to
+//     inventory_supplier_x_loc.primary_supplier; verify against
+//     inv_loc.primary_supplier_id.
+//   - Status "New" with populated Keys updates the existing keyed record.
+//   - "Item Issues Detected" popups need the Interactive API fallback.
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class SetPrimaryBinSupplier
+{
+    private const string ItemId = "WIDGET-001";
+    private const string LocationId = "10";
+    private const string SupplierId = "20000";
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Set Primary Bin / Primary Supplier (Item)");
+        Console.WriteLine(new string('=', 60));
+
+        using var client = await P21Client.CreateAsync();
+
+        JObject Element(string name, string type, string key,
+            params (string Name, string Value)[] edits) => new JObject
+        {
+            ["Name"] = name, ["Type"] = type, ["Keys"] = new JArray(key),
+            ["Rows"] = new JArray(new JObject
+            {
+                ["Edits"] = new JArray(edits.Select(e => Edit(e.Name, e.Value))),
+            }),
+        };
+
+        // Primary supplier: Form -> List -> List.
+        var payload = new JObject
+        {
+            ["Name"] = "Item",
+            ["UseCodeValues"] = false,
+            ["Transactions"] = new JArray(new JObject
+            {
+                ["Status"] = "New", // updates the keyed record; does not create a new item
+                ["DataElements"] = new JArray
+                {
+                    Element("TABPAGE_1.tp_1_dw_1", "Form", "item_id", ("item_id", ItemId)),
+                    Element("TABPAGE_17.invloclist", "List", "location_id",
+                        ("location_id", LocationId)),
+                    Element("SUPPLIER_X_LOCATION.supplier_x_location", "List", "supplier_id",
+                        ("supplier_id", SupplierId), ("primary_supplier", "ON")),
+                },
+            }),
+        };
+
+        PrintPayload("Primary-supplier payload", payload);
+        Console.WriteLine(
+            "\nPrimary-BIN variant: swap the third element for\n" +
+            "  TABPAGE_18.inv_loc_detail (Form, key location_id) with edits\n" +
+            "  location_id + bin, then verify inv_loc.primary_bin the same way.");
+
+        if (!ConfirmExecute())
+            return;
+
+        // ------------------------------------------------------------------
+        // Write
+        // ------------------------------------------------------------------
+        var result = await client.Transaction.CreateAsync(payload);
+        CheckResult(result); // watch for 'Unexpected response window: Item Issues Detected'
+
+        // ------------------------------------------------------------------
+        // MANDATORY verification — a silent no-op still reports Succeeded = 1.
+        // Write target is the inventory_supplier_x_loc flag;
+        // READ inv_loc.primary_supplier_id.
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nVerify via OData (mandatory):");
+        Console.WriteLine(new string('-', 50));
+
+        var mastRows = (JArray)(await client.OData.QueryAsync(
+            "inv_mast",
+            select: "inv_mast_uid",
+            filter: $"item_id eq '{ItemId}'"))["value"]!;
+        if (mastRows.Count == 0)
+        {
+            Console.WriteLine($"  Item {ItemId} not found in inv_mast");
+            return;
+        }
+        var invMastUid = mastRows[0]["inv_mast_uid"]!.ToString();
+
+        var locRows = (JArray)(await client.OData.QueryAsync(
+            "inv_loc",
+            select: "primary_supplier_id",
+            filter: $"inv_mast_uid eq {invMastUid} and location_id eq {LocationId}"))["value"]!;
+        if (locRows.Count == 0)
+        {
+            Console.WriteLine($"  No inv_loc row for item {ItemId} at location {LocationId}");
+            return;
+        }
+        var actual = locRows[0]["primary_supplier_id"]?.ToString();
+
+        if (actual == SupplierId)
+            Console.WriteLine($"  VERIFIED: primary_supplier_id = {actual}");
+        else
+            // Most likely cause: no inventory_supplier_x_loc row at this location.
+            // Add the location supplier row first, then set the flag again.
+            Console.WriteLine(
+                $"  SILENT NO-OP: primary_supplier_id is {actual}, expected {SupplierId}");
+    }
+}

--- a/examples/csharp/Recipes/UpdateContractLines.cs
+++ b/examples/csharp/Recipes/UpdateContractLines.cs
@@ -1,0 +1,163 @@
+// Recipe: Update Contract Lines
+// Docs:   docs/recipes/update-contract-lines.md
+//
+// Update prices on existing JobContractPricing lines, insert new lines onto
+// an existing contract (upsert), and set commission costs — all through the
+// stateless Transaction API.
+//
+// Key rules (all verified live — see the recipe page):
+//   - Status is "New" for BOTH create and update ("Existing" returns HTTP 500).
+//   - pricing_method MUST precede price in the Edits, or price lands as $0.
+//   - One POST per line: inserts re-save the shared header and collide when batched.
+//   - end_date must be >= today; the header is re-validated on every save.
+//   - IgnoreDisabled: true (top level) is required for commission-cost writes.
+
+using Newtonsoft.Json.Linq;
+using P21Examples.Common;
+using static P21Examples.Recipes.RecipeHelpers;
+
+namespace P21Examples.Recipes;
+
+public static class UpdateContractLines
+{
+    private const string CompanyId = "ACME";
+    private const string ContractNo = "A120-12";
+    private const string JobNo = "31";           // unique across renewals — always include it
+    private const string EndDate = "2030-01-01"; // required on EVERY submit, must be >= today
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("Recipe - Update Contract Lines (JobContractPricing)");
+        Console.WriteLine(new string('=', 60));
+
+        using var client = await P21Client.CreateAsync();
+
+        var lines = new (string ItemId, string Uom, decimal Price, decimal? Commission)[]
+        {
+            ("WIDGET-001", "EA", 36.58m, 17.19m),  // already on contract -> updated
+            ("WIDGET-002", "EA", 12.40m, null),    // not on contract     -> inserted (upsert)
+        };
+
+        // One POST per line: inserts re-save the shared header and collide when batched.
+        var payloads = lines.Select(l => LinePayload(l.ItemId, l.Uom, l.Price, l.Commission)).ToList();
+        for (var i = 0; i < lines.Length; i++)
+            PrintPayload($"Payload for {lines[i].ItemId}", payloads[i]);
+
+        if (!ConfirmExecute())
+            return;
+
+        // ------------------------------------------------------------------
+        // Write: one transaction per POST
+        // ------------------------------------------------------------------
+        foreach (var (line, payload) in lines.Zip(payloads))
+        {
+            Console.WriteLine($"\nPosting {line.ItemId}...");
+            var result = await client.Transaction.CreateAsync(payload);
+            Console.WriteLine(CheckResult(result)
+                ? $"  {line.ItemId}: OK"
+                : $"  {line.ItemId}: FAILED");
+        }
+
+        // ------------------------------------------------------------------
+        // Verify via OData (no joins: chain the uid columns)
+        // ------------------------------------------------------------------
+        Console.WriteLine("\nVerify via OData:");
+        Console.WriteLine(new string('-', 50));
+
+        // Renewals can return two headers for one contract_no — match job_no too.
+        var hdrRows = (JArray)(await client.OData.QueryAsync(
+            "job_price_hdr", filter: $"contract_no eq '{ContractNo}'"))["value"]!;
+        if (hdrRows.Count == 0)
+        {
+            Console.WriteLine($"  Contract {ContractNo} not found");
+            return;
+        }
+        var hdrUid = hdrRows[0]["job_price_hdr_uid"];
+
+        foreach (var l in lines)
+        {
+            var imRows = (JArray)(await client.OData.QueryAsync(
+                "inv_mast", filter: $"item_id eq '{l.ItemId}'"))["value"]!;
+            if (imRows.Count == 0)
+            {
+                Console.WriteLine($"  {l.ItemId}: item not found in inv_mast");
+                continue;
+            }
+            var imUid = imRows[0]["inv_mast_uid"];
+
+            var lineRows = (JArray)(await client.OData.QueryAsync(
+                "job_price_line",
+                filter: $"job_price_hdr_uid eq {hdrUid} and inv_mast_uid eq {imUid}"))["value"]!;
+            if (lineRows.Count == 0)
+            {
+                Console.WriteLine($"  {l.ItemId}: no contract line found");
+                continue;
+            }
+
+            var match = (decimal)lineRows[0]["price"]! == l.Price ? "OK" : "MISMATCH";
+            Console.WriteLine(
+                $"  {l.ItemId}: price={lineRows[0]["price"]} expected={l.Price} -> {match}");
+        }
+    }
+
+    /// <summary>Build a one-line upsert payload, optionally with a commission cost.</summary>
+    private static JObject LinePayload(
+        string itemId, string uom, decimal price, decimal? commissionCost)
+    {
+        var elements = new JArray
+        {
+            new JObject
+            {
+                // Header: Keys stays EMPTY; the key fields go in Edits.
+                ["Name"] = "FORM.d_dw_job_price_hdr", ["Type"] = "Form",
+                ["Keys"] = new JArray(),
+                ["Rows"] = new JArray { new JObject {
+                    ["Edits"] = new JArray {
+                        Edit("company_id",  CompanyId),
+                        Edit("contract_no", ContractNo),
+                        Edit("job_no",      JobNo),
+                        Edit("end_date",    EndDate),
+                    },
+                    ["RelativeDateEdits"] = new JArray() } }
+            },
+            new JObject
+            {
+                // Line: keyed by item_id — updates the row if it exists, inserts if not.
+                ["Name"] = "JOBPRICELINE.jobpriceline", ["Type"] = "List",
+                ["Keys"] = new JArray { "item_id" },
+                ["Rows"] = new JArray { new JObject {
+                    ["Edits"] = new JArray {
+                        Edit("item_id",        itemId),
+                        Edit("uom",            uom),
+                        Edit("pricing_method", "Price"),           // MUST come before price
+                        Edit("price",          price.ToString()),
+                    },
+                    ["RelativeDateEdits"] = new JArray() } }
+            },
+        };
+
+        var payload = new JObject
+        {
+            ["Name"] = "JobContractPricing", ["UseCodeValues"] = false,
+            ["Transactions"] = new JArray {
+                new JObject { ["Status"] = "New", ["DataElements"] = elements } }
+        };
+
+        if (commissionCost is not null)
+        {
+            payload["IgnoreDisabled"] = true;  // top level, NOT inside the Transaction
+            elements.Add(new JObject
+            {
+                ["Name"] = "JOBPRICECOST.jobpricecost", ["Type"] = "Form",
+                ["Keys"] = new JArray { "item_id" },
+                ["Rows"] = new JArray { new JObject { ["Edits"] = new JArray {
+                    Edit("item_id",                 itemId),
+                    Edit("commission_cost_type_cd", "Value"),      // type BEFORE value
+                    Edit("commission_cost_value",   commissionCost.ToString()!),
+                } } }
+            });
+        }
+
+        return payload;
+    }
+}

--- a/scripts/recipes/README.md
+++ b/scripts/recipes/README.md
@@ -1,0 +1,31 @@
+# Recipe Scripts
+
+End-to-end runnable Python versions of the [cookbook recipes](../../docs/recipes/README.md) — one script per recipe page. Each script mirrors its page's Python example, adapted to this repo's conventions (`common.auth` / `common.config` instead of the inline `p21_auth()` helper).
+
+| Script | Recipe page |
+|--------|-------------|
+| `update_contract_lines.py` | [update-contract-lines.md](../../docs/recipes/update-contract-lines.md) |
+| `edit_contract_bins.py` | [edit-contract-bins.md](../../docs/recipes/edit-contract-bins.md) |
+| `create_bins.py` | [create-bins.md](../../docs/recipes/create-bins.md) |
+| `create_sales_order.py` | [create-sales-order.md](../../docs/recipes/create-sales-order.md) |
+| `order_with_assembly.py` | [order-with-assembly.md](../../docs/recipes/order-with-assembly.md) |
+| `set_primary_bin_supplier.py` | [set-primary-bin-supplier.md](../../docs/recipes/set-primary-bin-supplier.md) |
+| `generate_pick_ticket_pdf.py` | [generate-pick-ticket-pdf.md](../../docs/recipes/generate-pick-ticket-pdf.md) |
+| `production_order_runbook.py` | [production-order-runbook.md](../../docs/recipes/production-order-runbook.md) |
+| `record_labor_time.py` | [record-labor-time.md](../../docs/recipes/record-labor-time.md) |
+| `inventory_adjustment.py` | [inventory-adjustment.md](../../docs/recipes/inventory-adjustment.md) |
+
+## Setup
+
+```bash
+cp .env.example .env   # set P21_BASE_URL, P21_USERNAME, P21_PASSWORD
+pip install -r requirements.txt
+python scripts/recipes/create_sales_order.py           # dry run
+python scripts/recipes/create_sales_order.py --execute # write + verify
+```
+
+Configuration constants at the top of each script use generic placeholders (`ACME`, `WIDGET-001`, customer `100198`) — substitute your own values before running.
+
+## Dry run by default
+
+Every script that writes to P21 **defaults to a dry run**: it builds and pretty-prints the payload, then exits without sending anything (no credentials needed). Pass `--execute` to actually POST — the script then checks `Summary.Succeeded`/`Failed`, prints `Messages`, and runs the recipe's verify read-back (OData or `POST /api/v2/transaction/get`). Always run against a **test/play environment first**; a `Succeeded` response is not proof the value landed.

--- a/scripts/recipes/create_bins.py
+++ b/scripts/recipes/create_bins.py
@@ -1,0 +1,165 @@
+"""
+Create Bins in Bulk (BinLocation)
+
+Bulk-create warehouse bins with the BinLocation service -- one transaction
+per bin, tens per POST. Constants are cloned from a "twin" bin of the same
+bin_type at the location; bins that already exist are skipped so re-running
+is safe. IgnoreDisabled: true at the payload TOP LEVEL is mandatory
+(frozen_flag and other system columns are disabled on the bin form).
+
+Mirrors: docs/recipes/create-bins.md
+
+Usage:
+    python scripts/recipes/create_bins.py            # dry run (default)
+    python scripts/recipes/create_bins.py --execute  # skip-existing check, POST + verify
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+COMPANY_ID = "ACME"
+LOCATION_ID = "10"
+NEW_BIN_IDS = ["A01-02-01", "A01-02-02", "A01-02-03", "A01-02-04"]
+BATCH_SIZE = 20  # tens of transactions per POST is fine and fast
+
+# Constants cloned from a "twin" bin of the same bin_type at this location.
+# Flags come back Y/N from the database -- convert to ON/OFF for the form.
+TWIN = {
+    "bin_type": "SHELF",
+    "putaway_zone_id": "ZONE-A", "pick_zone_id": "ZONE-A",
+    "bin_length": "10", "bin_width": "10", "bin_height": "11",
+    "warehouse_sequence": "1", "putaway_zone_sequence": "1", "pick_zone_sequence": "1",
+    "max_unique_items": "0",
+    "pick_locked_flag": "OFF", "put_locked_flag": "OFF",
+    "full_flag": "OFF", "frozen_flag": "OFF",
+    "consolidation_bin_flag": "OFF", "stage_bin_flag": "OFF", "door_bin_flag": "OFF",
+}
+
+
+def build_bin_transaction(bin_id: str, location_id: str, twin: dict) -> dict:
+    """Build one Transaction object per bin (keys first, then twin constants).
+
+    Args:
+        bin_id: New bin ID to create.
+        location_id: Stocking location for the bin.
+        twin: Field constants cloned from an existing bin of the same type.
+
+    Returns:
+        dict: Transaction object for the BinLocation payload.
+    """
+    edits = [
+        {"Name": "company_id", "Value": COMPANY_ID},
+        {"Name": "location_id", "Value": location_id},
+        {"Name": "bin_id", "Value": bin_id},
+    ] + [{"Name": name, "Value": value} for name, value in twin.items()]
+    return {
+        "Status": "New",
+        "DataElements": [{
+            "Name": "FORM.form", "Type": "Form",
+            "Keys": ["company_id", "location_id", "bin_id"],
+            "Rows": [{"Edits": edits}],
+        }],
+    }
+
+
+def build_payload(bin_ids: list[str]) -> dict:
+    """Wrap bin transactions in the top-level BinLocation payload.
+
+    Args:
+        bin_ids: Bin IDs for this batch.
+
+    Returns:
+        dict: Complete Transaction API payload (IgnoreDisabled at top level).
+    """
+    return {
+        "Name": "BinLocation",
+        "UseCodeValues": False,
+        "IgnoreDisabled": True,  # TOP LEVEL -- inside a Transaction it is silently ignored
+        "Transactions": [build_bin_transaction(b, LOCATION_ID, TWIN) for b in bin_ids],
+    }
+
+
+def main() -> None:
+    """Entry point: dry run prints the payload; --execute skips existing bins,
+    POSTs batches, and reads the created bins back via p21_view_bin."""
+    parser = argparse.ArgumentParser(
+        description="Bulk-create warehouse bins (docs/recipes/create-bins.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually POST the transactions (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Create Bins in Bulk (BinLocation)")
+    print("=" * 60)
+
+    if not args.execute:
+        print("\nDRY RUN - payload that would be POSTed to {ui_server}/api/v2/transaction")
+        print("(at execute time, bins that already exist at the location are skipped):")
+        print(json.dumps(build_payload(NEW_BIN_IDS), indent=2))
+        print("\nRe-run with --execute to POST it.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    # Skip-existing check via the p21_view_bin view (raw bin table isn't always in OData)
+    existing_resp = httpx.get(
+        f"{config.base_url}/odataservice/odata/view/p21_view_bin",
+        params={"$filter": f"location_id eq {LOCATION_ID}", "$select": "bin_id"},
+        headers=headers, verify=config.verify_ssl, follow_redirects=True,
+    )
+    existing_resp.raise_for_status()
+    existing = {row["bin_id"] for row in existing_resp.json()["value"]}
+
+    to_create = [b for b in NEW_BIN_IDS if b not in existing]
+    print(f"{len(NEW_BIN_IDS) - len(to_create)} already exist, creating {len(to_create)}")
+
+    for start in range(0, len(to_create), BATCH_SIZE):
+        batch = to_create[start:start + BATCH_SIZE]
+        resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                          headers=headers, json=build_payload(batch),
+                          verify=config.verify_ssl, follow_redirects=True, timeout=300)
+        resp.raise_for_status()
+        result = resp.json()
+
+        summary = result["Summary"]
+        print(f"Batch {start // BATCH_SIZE + 1}: "
+              f"Succeeded={summary['Succeeded']}, Failed={summary['Failed']}")
+        if summary["Failed"] > 0:
+            for msg in result.get("Messages") or []:
+                print(f"  {msg}")
+        # Transactions pass/fail independently -- check each one
+        for bin_id, txn in zip(batch, (result.get("Results") or {}).get("Transactions") or []):
+            if txn["Status"] != "Passed":
+                print(f"  FAILED: {bin_id}")
+
+    # --- Verify: read the new bins back through the p21_view_bin view ---
+    print("\nVerify (p21_view_bin read-back -- compare field-for-field against the twin;")
+    print("flags are stored Y/N in the database vs ON/OFF on the form):")
+    for bin_id in to_create:
+        check = httpx.get(
+            f"{config.base_url}/odataservice/odata/view/p21_view_bin",
+            params={"$filter": f"location_id eq {LOCATION_ID} and bin_id eq '{bin_id}'"},
+            headers=headers, verify=config.verify_ssl, follow_redirects=True,
+        )
+        check.raise_for_status()
+        rows = check.json()["value"]
+        print(f"  {bin_id}: {'FOUND' if rows else 'MISSING'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/create_sales_order.py
+++ b/scripts/recipes/create_sales_order.py
@@ -1,0 +1,196 @@
+"""
+Create a Sales Order (Order service)
+
+Create a sales order -- header plus line items -- in one stateless
+Transaction API call, extract the generated order_no from the result rows,
+and read the order back via OData. No assembly lines: the Transaction API
+auto-answers the "add as assembly?" prompt No, killing the explode -- use
+order_with_assembly.py for those.
+
+Mirrors: docs/recipes/create-sales-order.md
+
+Usage:
+    python scripts/recipes/create_sales_order.py            # dry run (default)
+    python scripts/recipes/create_sales_order.py --execute  # POST + verify
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+CUSTOMER_ID = "100198"
+SALES_LOC_ID = "10"
+SOURCE_LOC_ID = "10"       # effectively required -- omitting it fails on tax jurisdiction
+ORDER_DATE = "2030-01-05"
+REQUESTED_DATE = "2030-01-06"  # must be AFTER order_date
+PO_NO = "PO-TEST-001"
+TAKER = "JSMITH"
+SHIP_TO_ID = "200"
+CONTACT_ID = "300"
+
+# (item_id, quantity) -- items must be stocked at the source location
+ORDER_LINES = [
+    ("WIDGET-001", "5"),
+    ("WIDGET-002", "2"),
+]
+
+
+def build_order_payload() -> dict:
+    """Build the Order payload: header form + items list.
+
+    Do NOT send company_id -- it is a disabled column on the Order window.
+
+    Returns:
+        dict: Complete Transaction API payload.
+    """
+    item_rows = [
+        {"Edits": [
+            {"Name": "oe_order_item_id", "Value": item_id},
+            {"Name": "unit_quantity",    "Value": qty},
+        ], "RelativeDateEdits": []}
+        for item_id, qty in ORDER_LINES
+    ]
+    return {
+        "Name": "Order",
+        "UseCodeValues": False,
+        "Transactions": [{
+            "Status": "New",
+            "DataElements": [
+                {
+                    "Name": "TABPAGE_1.order",
+                    "Type": "Form",
+                    "Keys": [],
+                    "Rows": [{
+                        "Edits": [
+                            {"Name": "customer_id",    "Value": CUSTOMER_ID},
+                            {"Name": "sales_loc_id",   "Value": SALES_LOC_ID},
+                            {"Name": "source_loc_id",  "Value": SOURCE_LOC_ID},
+                            {"Name": "order_date",     "Value": ORDER_DATE},
+                            {"Name": "requested_date", "Value": REQUESTED_DATE},
+                            {"Name": "po_no",          "Value": PO_NO},
+                            {"Name": "taker",          "Value": TAKER},
+                            {"Name": "ship_to_id",     "Value": SHIP_TO_ID},
+                            {"Name": "contact_id",     "Value": CONTACT_ID},
+                        ],
+                        "RelativeDateEdits": [],
+                    }],
+                },
+                {
+                    "Name": "TP_ITEMS.items",
+                    "Type": "List",
+                    "Keys": [],
+                    "Rows": item_rows,
+                },
+            ],
+        }],
+    }
+
+
+def extract_order_no(result: dict) -> str | None:
+    """Pull the generated order_no out of the TABPAGE_1.order result rows.
+
+    Args:
+        result: Parsed JSON response from POST /api/v2/transaction.
+
+    Returns:
+        str | None: The generated order number, if present.
+    """
+    order_no = None
+    for txn in result["Results"]["Transactions"]:
+        if txn.get("Status") != "Passed":
+            continue
+        for element in txn.get("DataElements", []):
+            if element.get("Name") != "TABPAGE_1.order":
+                continue
+            for row in element.get("Rows", []):
+                for edit in row.get("Edits", []):
+                    if edit.get("Name") == "order_no":
+                        order_no = edit.get("Value")
+    return order_no
+
+
+def main() -> None:
+    """Entry point: build payload, POST on --execute, then verify via OData."""
+    parser = argparse.ArgumentParser(
+        description="Create a sales order (docs/recipes/create-sales-order.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually POST the transaction (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Create a Sales Order (Order service)")
+    print("=" * 60)
+
+    payload = build_order_payload()
+
+    if not args.execute:
+        print("\nDRY RUN - payload that would be POSTed to {ui_server}/api/v2/transaction:")
+        print(json.dumps(payload, indent=2))
+        print("\nRe-run with --execute to POST it.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    response = httpx.post(f"{ui_server}/api/v2/transaction",
+                          headers=headers, json=payload, verify=config.verify_ssl,
+                          follow_redirects=True, timeout=120)
+    response.raise_for_status()
+    result = response.json()
+
+    # HTTP 200 even on failure -- check the Summary, never the status code
+    summary = result["Summary"]
+    print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+    if summary["Failed"] > 0 or summary["Succeeded"] == 0:
+        for msg in result.get("Messages", []):
+            print(f"  {msg}")
+        raise SystemExit("Order create failed")
+
+    order_no = extract_order_no(result)
+    print(f"Created order_no: {order_no}")
+    if not order_no:
+        raise SystemExit("No order_no in the result rows")
+
+    # --- Verify: read the order back. Succeeded is not proof every value
+    # landed -- a DynaChange auto-answer can drop a line silently. ---
+    print("\nVerify (OData read-back):")
+    hdr_resp = httpx.get(
+        f"{config.base_url}/odataservice/odata/table/oe_hdr",
+        params={"$filter": f"order_no eq '{order_no}'"},
+        headers=headers, verify=config.verify_ssl, follow_redirects=True,
+    )
+    hdr_resp.raise_for_status()
+    for hdr in hdr_resp.json()["value"]:
+        print(f"  Header: taker={hdr.get('taker')} po_no={hdr.get('po_no')} "
+              f"ship2={hdr.get('ship2_name') or hdr.get('address_id')}")
+
+    line_resp = httpx.get(
+        f"{config.base_url}/odataservice/odata/table/oe_line",
+        params={"$filter": f"order_no eq '{order_no}'"},
+        headers=headers, verify=config.verify_ssl, follow_redirects=True,
+    )
+    line_resp.raise_for_status()
+    lines = line_resp.json()["value"]
+    print(f"  Lines on order: {len(lines)} (expected {len(ORDER_LINES)})")
+    for line in lines:
+        print(f"    line {line.get('line_no')}: qty_ordered={line.get('qty_ordered')}")
+    if len(lines) != len(ORDER_LINES):
+        print("  WARNING: line count mismatch -- a DynaChange auto-answer may have "
+              "dropped a line while the transaction still reported Succeeded")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/edit_contract_bins.py
+++ b/scripts/recipes/edit_contract_bins.py
@@ -1,0 +1,167 @@
+"""
+Edit Contract Bin Quantities (JobContractPricing + IgnoreDisabled)
+
+Change min_qty, max_qty, reorder_qty, and capacity on the bins of an existing
+job contract via the Transaction API. The BINS sub-tab is normally disabled;
+IgnoreDisabled: true at the payload TOP LEVEL unlocks it. Batching is fine
+here (unlike line inserts) -- one POST covers every bin, then an OData
+read-back confirms the quantities.
+
+Mirrors: docs/recipes/edit-contract-bins.md
+
+Usage:
+    python scripts/recipes/edit_contract_bins.py            # dry run (default)
+    python scripts/recipes/edit_contract_bins.py --execute  # POST + verify
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+CONTRACT_NO = "A120-12"   # used for the OData read-back
+JOB_NO = "31"             # unique across renewals -- load the header by this
+CUSTOMER_ID = "100198"
+SHIP_TO_ID = "200"
+
+# Per bin: the line's item_id, the bin id, and the new quantities.
+BIN_EDITS = [
+    {"item_id": "WIDGET-001", "bin_id": "A01-02",
+     "min_qty": 30, "max_qty": 100, "reorder_qty": 40, "capacity": 100},
+    {"item_id": "WIDGET-002", "bin_id": "A01-02",
+     "min_qty": 5,  "max_qty": 50,  "reorder_qty": 10, "capacity": 50},
+]
+
+
+def build_bin_payload(job_no: str, customer_id: str, ship_to_id: str,
+                      edits: list[dict]) -> dict:
+    """Build one Transaction with a JOBPRICELINE + BINS.bins pair per bin.
+
+    Args:
+        job_no: Contract job number (unique across renewals).
+        customer_id: Customer on the contract header.
+        ship_to_id: Ship-to on the contract header.
+        edits: One dict per bin with item_id, bin_id, and the new quantities.
+
+    Returns:
+        dict: Complete Transaction API payload (IgnoreDisabled at top level).
+    """
+    elements = [
+        {"Name": "FORM.d_dw_job_price_hdr", "Type": "Form", "Keys": [],
+         "Rows": [{"Edits": [
+             {"Name": "job_no",      "Value": job_no},
+             {"Name": "customer_id", "Value": customer_id},
+             {"Name": "ship_to_id",  "Value": ship_to_id},
+         ]}]},
+    ]
+    for e in edits:
+        elements.append(
+            {"Name": "JOBPRICELINE.jobpriceline", "Type": "List",
+             "Keys": ["item_id"],   # select by item_id, NOT line_no
+             "Rows": [{"Edits": [{"Name": "item_id", "Value": e["item_id"]}]}]})
+        elements.append(
+            {"Name": "BINS.bins", "Type": "List",
+             "Keys": ["contract_bin_id", "customer_id", "ship_to_id"],
+             "Rows": [{"Edits": [
+                 {"Name": "contract_bin_id", "Value": e["bin_id"]},
+                 {"Name": "customer_id",     "Value": customer_id},
+                 {"Name": "ship_to_id",      "Value": ship_to_id},
+                 {"Name": "min_qty",         "Value": str(e["min_qty"])},
+                 {"Name": "max_qty",         "Value": str(e["max_qty"])},
+                 {"Name": "reorder_qty",     "Value": str(e["reorder_qty"])},
+                 {"Name": "capacity",        "Value": str(e["capacity"])},
+             ]}]})
+    return {"Name": "JobContractPricing", "UseCodeValues": False,
+            "IgnoreDisabled": True,  # top level -- mandatory for the BINS sub-tab
+            "Transactions": [{"Status": "New", "DataElements": elements}]}
+
+
+def odata(base_url: str, headers: dict, verify_ssl: bool,
+          table: str, filter_expr: str) -> list[dict]:
+    """Query an OData table and return its value rows.
+
+    Args:
+        base_url: P21 base URL.
+        headers: Auth headers.
+        verify_ssl: Whether to verify SSL certificates.
+        table: OData table name.
+        filter_expr: OData $filter expression.
+
+    Returns:
+        list[dict]: Matching rows.
+    """
+    resp = httpx.get(f"{base_url}/odataservice/odata/table/{table}",
+                     params={"$filter": filter_expr},
+                     headers=headers, verify=verify_ssl, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.json()["value"]
+
+
+def main() -> None:
+    """Entry point: build payload, POST on --execute, then verify via OData."""
+    parser = argparse.ArgumentParser(
+        description="Edit contract bin quantities (docs/recipes/edit-contract-bins.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually POST the transaction (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Edit Contract Bin Quantities (JobContractPricing)")
+    print("=" * 60)
+
+    payload = build_bin_payload(JOB_NO, CUSTOMER_ID, SHIP_TO_ID, BIN_EDITS)
+
+    if not args.execute:
+        print("\nDRY RUN - payload that would be POSTed to {ui_server}/api/v2/transaction:")
+        print(json.dumps(payload, indent=2))
+        print("\nRe-run with --execute to POST it.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                      headers=headers, json=payload, verify=config.verify_ssl,
+                      follow_redirects=True, timeout=60)
+    resp.raise_for_status()  # HTTP 200 even when the transaction failed
+    result = resp.json()
+    summary = result["Summary"]
+    print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+    if summary["Failed"] or not summary["Succeeded"]:
+        for msg in result.get("Messages", []):
+            print(f"  FAILED: {msg}")
+        raise SystemExit(1)
+
+    # --- Verify via OData (no joins: chain the uid columns) ---
+    print("\nVerify (OData read-back):")
+    hdr = odata(config.base_url, headers, config.verify_ssl,
+                "job_price_hdr", f"contract_no eq '{CONTRACT_NO}'")[0]
+    for e in BIN_EDITS:
+        im_uid = odata(config.base_url, headers, config.verify_ssl,
+                       "inv_mast", f"item_id eq '{e['item_id']}'")[0]["inv_mast_uid"]
+        line = odata(config.base_url, headers, config.verify_ssl,
+                     "job_price_line",
+                     f"job_price_hdr_uid eq {hdr['job_price_hdr_uid']} "
+                     f"and inv_mast_uid eq {im_uid}")[0]
+        for bin_row in odata(config.base_url, headers, config.verify_ssl,
+                             "job_price_bin",
+                             f"job_price_line_uid eq {line['job_price_line_uid']}"):
+            print(f"  {e['item_id']}: min={bin_row['min_qty']} max={bin_row['max_qty']} "
+                  f"reorder={bin_row['reorder_qty']} "
+                  f"(expected {e['min_qty']}/{e['max_qty']}/{e['reorder_qty']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/generate_pick_ticket_pdf.py
+++ b/scripts/recipes/generate_pick_ticket_pdf.py
@@ -1,0 +1,165 @@
+"""
+Generate a Pick Ticket PDF (m_picktickets via /api/v2/process/pdfreport)
+
+Generate a production-order pick ticket as a base64-encoded PDF via the
+dedicated report endpoint. m_picktickets CREATES the pick-ticket record at
+location_id AND returns its PDF in one call -- which is why this script is
+gated behind --execute. Never post an m_* report to /api/v2/transaction: it
+returns Succeeded and emits nothing.
+
+Prerequisite: the production order's form must already be printed
+(prod_order_hdr.printed = 'Y') -- run a ProductionOrder transaction with
+print_form = ON first.
+
+Mirrors: docs/recipes/generate-pick-ticket-pdf.md
+
+Usage:
+    python scripts/recipes/generate_pick_ticket_pdf.py            # dry run (default)
+    python scripts/recipes/generate_pick_ticket_pdf.py --execute  # run report, save PDF
+"""
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+PROD_ORDER = "1000123"  # production order number
+LOCATION_ID = "10"      # location whose inventory the components pick from
+
+
+def build_report_payload() -> dict:
+    """Build the m_picktickets report payload.
+
+    Reports use numeric Status/Type 0 and Keys: [] -- not the "New"
+    record-edit shape. m_picktickets requires UseCodeValues: true with the
+    code "P" (Production Order); False returns HTTP 500.
+
+    Returns:
+        dict: Complete pdfreport payload.
+    """
+    return {
+        "Name": "m_picktickets",
+        "UseCodeValues": True,   # required here -- False returns HTTP 500
+        "Transactions": [{
+            "Status": 0,         # numeric 0 for report payloads
+            "DataElements": [{
+                "Keys": [],      # always empty for reports
+                "Type": 0,       # numeric 0 for report payloads
+                "Name": "TABPAGE_1.tp_1_dw_1",
+                "Rows": [{"Edits": [
+                    # code "P" = Production Order (the display label is rejected)
+                    {"Name": "create_pick_ticket_type", "Value": "P"},
+                    {"Name": "beg_prod_order", "Value": PROD_ORDER},
+                    {"Name": "end_prod_order", "Value": PROD_ORDER},
+                    {"Name": "location_id", "Value": LOCATION_ID},
+                ]}],
+            }],
+        }],
+    }
+
+
+def run_report(ui_server: str, headers: dict, verify_ssl: bool, payload: dict) -> list[dict]:
+    """POST the report payload and return the document array.
+
+    Errors come back as the standard P21 error envelope
+    (ErrorType/ErrorMessage), NOT the Summary/Messages format of /transaction.
+
+    Args:
+        ui_server: UI server URL.
+        headers: Auth headers.
+        verify_ssl: Whether to verify SSL certificates.
+        payload: Report payload from build_report_payload().
+
+    Returns:
+        list[dict]: Documents (success is a JSON array, even for one document).
+
+    Raises:
+        SystemExit: On HTTP errors, error envelopes, or an empty result.
+    """
+    response = httpx.post(
+        f"{ui_server}/api/v2/process/pdfreport",  # NOT /api/v2/transaction
+        headers=headers, json=payload, verify=verify_ssl,
+        follow_redirects=True, timeout=120,
+    )
+    if response.status_code >= 400:
+        raise SystemExit(f"HTTP {response.status_code}: {response.text}")
+    result = response.json()
+    if isinstance(result, dict) and "ErrorMessage" in result:
+        raise SystemExit(f"{result.get('ErrorType')}: {result['ErrorMessage']}")
+    if not (isinstance(result, list) and result):
+        raise SystemExit(f"No documents returned: {result}")
+    return result
+
+
+def save_documents(documents: list[dict]) -> None:
+    """Decode and save each returned document, verifying it is a PDF.
+
+    Args:
+        documents: Document array from run_report().
+    """
+    for doc in documents:
+        status = doc.get("ResponseStatus", {}).get("StatusCode")
+        if status != "Success" or not doc.get("DocumentData"):
+            msg = doc.get("ResponseStatus", {}).get("Message", "Unknown error")
+            print(f"Document failed: {msg}")
+            continue
+        pdf_bytes = base64.b64decode(doc["DocumentData"])
+        # FileName includes .pdf, e.g. "PPT<nnn> PRODUCTION_PICK_TICKET.pdf"
+        filename = doc.get("FileName", "pick_ticket.pdf")
+        with open(filename, "wb") as f:
+            f.write(pdf_bytes)
+        # Verify: decoded bytes must start with %PDF
+        is_pdf = pdf_bytes.startswith(b"%PDF")
+        print(f"Saved {filename} ({len(pdf_bytes)} bytes) "
+              f"{'-- verified %PDF header' if is_pdf else '-- WARNING: not a PDF'}")
+
+
+def main() -> None:
+    """Entry point: build payload; on --execute run the report and save the PDF."""
+    parser = argparse.ArgumentParser(
+        description="Generate a pick-ticket PDF (docs/recipes/generate-pick-ticket-pdf.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually run the report -- this CREATES the pick-ticket "
+                             "record in P21 (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Generate Pick Ticket PDF (m_picktickets)")
+    print("=" * 60)
+
+    payload = build_report_payload()
+
+    if not args.execute:
+        print("\nDRY RUN - payload that would be POSTed to "
+              "{ui_server}/api/v2/process/pdfreport")
+        print("(side effect at execute time: the pick-ticket record is CREATED at "
+              f"location {LOCATION_ID}):")
+        print(json.dumps(payload, indent=2))
+        print("\nRe-run with --execute to run the report.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    documents = run_report(ui_server, headers, config.verify_ssl, payload)
+    save_documents(documents)
+    print("\nTo prove the pick-ticket row landed, reprint it with "
+          "m_reprintpicktickets using the ticket number from the FileName "
+          "(beg_prod_pick_ticket_no / end_prod_pick_ticket_no).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/inventory_adjustment.py
+++ b/scripts/recipes/inventory_adjustment.py
@@ -1,0 +1,187 @@
+"""
+Adjust On-Hand Quantity / Write-Off (InventoryAdjustment service)
+
+Post an inventory adjustment -- a signed on-hand quantity change with no
+invoice -- via the InventoryAdjustment service, then read the adjustment
+back by its server-generated adjustment_number. unit_quantity is the SIGNED
+DELTA (e.g. -5 writes off 5 units), not the new on-hand, and the save posts
+the adjustment immediately (no draft state).
+
+Mirrors: docs/recipes/inventory-adjustment.md
+
+Usage:
+    python scripts/recipes/inventory_adjustment.py            # dry run (default)
+    python scripts/recipes/inventory_adjustment.py --execute  # POST + read-back
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+COMPANY_ID = "ACME"
+LOCATION_ID = "10"
+REASON_ID = "ADJUST"          # the reason's DISPLAY TEXT (UseCodeValues: false)
+DESCRIPTION = "Cycle count write-off"
+ITEM_ID = "WIDGET-001"
+UNIT_QUANTITY = "-5"          # SIGNED delta, NOT the new on-hand
+
+
+def build_adjustment_payload() -> dict:
+    """Build the InventoryAdjustment payload: header form + one line.
+
+    adjustment_number is server-generated -- leave it unset on a new
+    adjustment.
+
+    Returns:
+        dict: Complete Transaction API payload.
+    """
+    return {
+        "Name": "InventoryAdjustment",
+        "UseCodeValues": False,  # reason_id is the display text, not the code
+        "Transactions": [{
+            "Status": "New",
+            "DataElements": [
+                {
+                    "Name": "TABPAGE_1.tp_1_dw_1",
+                    "Type": "Form",
+                    "Keys": [],
+                    "Rows": [{
+                        "Edits": [
+                            {"Name": "company_id", "Value": COMPANY_ID},
+                            {"Name": "location_id", "Value": LOCATION_ID},
+                            {"Name": "reason_id", "Value": REASON_ID},  # display text
+                            {"Name": "inv_adj_description", "Value": DESCRIPTION},
+                        ],
+                        "RelativeDateEdits": [],
+                    }],
+                },
+                {
+                    "Name": "TABPAGE_17.tp_17_dw_17",
+                    "Type": "List",
+                    "Keys": [],
+                    "Rows": [{
+                        "Edits": [
+                            {"Name": "item_id", "Value": ITEM_ID},
+                            {"Name": "unit_quantity", "Value": UNIT_QUANTITY},  # signed delta
+                        ],
+                        "RelativeDateEdits": [],
+                    }],
+                },
+            ],
+        }],
+    }
+
+
+def extract_adjustment_number(result: dict) -> str | None:
+    """Pull the server-generated adjustment_number out of the echoed DataElements.
+
+    Args:
+        result: Parsed JSON response from POST /api/v2/transaction.
+
+    Returns:
+        str | None: The adjustment number, if present.
+    """
+    adjustment_number = None
+    for txn in result.get("Results", {}).get("Transactions", []):
+        for de in txn.get("DataElements", []):
+            if de.get("Name") == "TABPAGE_1.tp_1_dw_1":
+                for row in de.get("Rows", []):
+                    for edit in row.get("Edits", []):
+                        if edit["Name"] == "adjustment_number" and edit.get("Value"):
+                            adjustment_number = edit["Value"]
+    return adjustment_number
+
+
+def read_adjustment(ui_server: str, headers: dict, verify_ssl: bool,
+                    adjustment_number: str) -> None:
+    """Read the adjustment back by its key and print the fields that matter.
+
+    Args:
+        ui_server: UI server URL.
+        headers: Auth headers.
+        verify_ssl: Whether to verify SSL certificates.
+        adjustment_number: Server-generated adjustment number.
+    """
+    get_payload = {
+        "ServiceName": "InventoryAdjustment",
+        "TransactionStates": [{
+            "DataElementName": "TABPAGE_1.tp_1_dw_1",
+            "Keys": [{"Name": "adjustment_number", "Value": adjustment_number}],
+        }],
+    }
+    resp = httpx.post(f"{ui_server}/api/v2/transaction/get",
+                      headers=headers, json=get_payload, verify=verify_ssl,
+                      follow_redirects=True, timeout=60)
+    resp.raise_for_status()
+    wanted = ("adjustment_number", "location_id", "reason_id",
+              "item_id", "unit_quantity", "new_qoh")
+    for txn in resp.json().get("Transactions", []):
+        for de in txn.get("DataElements", []):
+            for row in de.get("Rows", []):
+                for edit in row.get("Edits", []):
+                    if edit["Name"] in wanted:
+                        print(f"  {edit['Name']}: {edit['Value']}")
+
+
+def main() -> None:
+    """Entry point: build payload, POST on --execute, then read it back."""
+    parser = argparse.ArgumentParser(
+        description="Inventory adjustment (docs/recipes/inventory-adjustment.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually POST the adjustment -- the save POSTS it "
+                             "immediately, no draft state (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Adjust On-Hand Quantity (InventoryAdjustment)")
+    print("=" * 60)
+
+    payload = build_adjustment_payload()
+
+    if not args.execute:
+        print("\nDRY RUN - payload that would be POSTed to {ui_server}/api/v2/transaction:")
+        print(json.dumps(payload, indent=2))
+        print("\nRe-run with --execute to POST it.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                      headers=headers, json=payload, verify=config.verify_ssl,
+                      follow_redirects=True, timeout=120)
+    resp.raise_for_status()  # HTTP 200 even on failure -- check the Summary
+    result = resp.json()
+
+    summary = result["Summary"]
+    print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+    if summary["Failed"] > 0:
+        for msg in result.get("Messages", []):
+            print(f"  {msg}")
+        raise SystemExit("Adjustment failed")
+
+    adjustment_number = extract_adjustment_number(result)
+    print(f"Adjustment number: {adjustment_number}")
+    if not adjustment_number:
+        raise SystemExit("No adjustment_number in the echoed DataElements")
+
+    # --- Verify: read the adjustment back by its server-generated key ---
+    print("\nVerify (transaction/get read-back):")
+    read_adjustment(ui_server, headers, config.verify_ssl, adjustment_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/order_with_assembly.py
+++ b/scripts/recipes/order_with_assembly.py
@@ -1,0 +1,346 @@
+"""
+Order with an Assembly Line (Interactive API)
+
+Enter a sales order interactively when a line is an assembly that must
+explode into components and/or spawn a production order. The Transaction API
+auto-answers the "add as assembly?" prompt No, killing the explode -- the
+Interactive API lets you answer it (cb_1 = Yes). The session is started with
+ResponseWindowHandlingEnabled: true so prompts come back as windowopened
+events that this script answers via GET/POST /v2/tools.
+
+Mirrors: docs/recipes/order-with-assembly.md
+
+Usage:
+    python scripts/recipes/order_with_assembly.py            # dry run: print call plan
+    python scripts/recipes/order_with_assembly.py --execute  # run the full session flow
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+SALES_LOC_ID = "10"
+SOURCE_LOC_ID = "10"
+CUSTOMER_ID = "100198"
+SHIP_TO_ID = "200"
+CONTACT_ID = "300"
+ORDER_DATE = "2030-01-05"
+REQUESTED_DATE = "2030-01-06"  # must differ from order_date
+PO_NO = "PO-TEST-001"
+TAKER = "JSMITH"               # else the order is attributed to the API user
+ASSEMBLY_ITEM_ID = "WIDGET-001"  # an assembly item (assembly_hdr exists)
+QUANTITY = "5"
+
+CALL_PLAN = """\
+Planned Interactive API call sequence (nothing has been sent):
+
+  1. POST {iapi}/sessions                {{"ResponseWindowHandlingEnabled": true}}
+  2. POST {iapi}/v2/window               {{"ServiceName": "Order"}}
+  3. PUT  {iapi}/v2/change  (TABPAGE_1 / order, one field per call):
+        quote=OFF, sales_loc_id={sales_loc}, source_loc_id={source_loc},
+        customer_id={customer}, ship_to_id={ship_to}, contact_id={contact},
+        order_date={order_date}  (answers date-cascade prompt with cb_ok),
+        requested_date={req_date} (answers date-cascade prompt with cb_ok),
+        po_no={po_no}, taker={taker}
+  4. PUT  {iapi}/v2/tab                  {{"PageName": "TP_ITEMS"}}
+  5. PUT  {iapi}/v2/change  (TP_ITEMS / items, EXISTING first row):
+        oe_order_item_id={item}  (answers assembly prompt with cb_1 = Yes)
+  6. PUT  {iapi}/v2/change  unit_quantity={qty}
+  7. PUT  {iapi}/v2/data    (body = bare window-ID string) -- SAVE
+        (follow-on prompts answered with their proceed button)
+  8. PUT  {iapi}/v2/tab back to TABPAGE_1, GET {iapi}/v2/data?id=... -> order_no
+  9. DELETE {iapi}/v2/window?id=...; DELETE {iapi}/sessions
+ 10. Verify: OData oe_line assembly codes for the new order
+        (B kit parent, N component, P production-order line, S build-to-stock)
+"""
+
+
+def is_blocked(result: dict) -> bool:
+    """True when the last action was blocked by a response window.
+
+    Status is an integer (ResultStatus enum: 0 None, 1 Success, 2 Failure,
+    3 Blocked) but may appear as a string in some contexts -- handle both.
+    """
+    return result.get("Status") in (3, "Blocked")
+
+
+def popup_ids(result: dict) -> list[str]:
+    """Window IDs of popups opened by the last action.
+
+    Events[].Data is a key-value list: [{"Key": "windowid", "Value": "..."}].
+    """
+    ids = []
+    for event in result.get("Events", []):
+        if event.get("Name") == "windowopened":
+            for kv in event.get("Data", []):
+                if kv.get("Key") == "windowid":
+                    ids.append(kv["Value"])
+    return ids
+
+
+class InteractiveOrderSession:
+    """Drives the Order window over the Interactive API v2 endpoints."""
+
+    def __init__(self, ui_server: str, headers: dict, verify_ssl: bool) -> None:
+        """Store connection details.
+
+        Args:
+            ui_server: UI server URL from get_ui_server_url().
+            headers: Auth headers from get_auth_headers().
+            verify_ssl: Whether to verify SSL certificates.
+        """
+        self.iapi = f"{ui_server}/api/ui/interactive"
+        self.headers = headers
+        self.verify = verify_ssl
+
+    def start_session(self) -> None:
+        """Start a session with response-window handling enabled."""
+        httpx.post(
+            f"{self.iapi}/sessions", headers=self.headers, verify=self.verify,
+            json={"ResponseWindowHandlingEnabled": True},
+        ).raise_for_status()
+
+    def open_window(self, service_name: str) -> str:
+        """Open a window and return its window ID."""
+        win = httpx.post(
+            f"{self.iapi}/v2/window", headers=self.headers, verify=self.verify,
+            json={"ServiceName": service_name},
+        )
+        win.raise_for_status()
+        return win.json()["WindowId"]
+
+    def answer_response_windows(self, result: dict, button: str | None = None) -> dict:
+        """Answer every popup the last action opened, then return the last result.
+
+        Discovers buttons via GET /v2/tools?windowId= (the tools endpoint takes
+        ?windowId=, NOT ?id=), then clicks via POST /v2/tools with the POPUP's
+        window ID. If button is None, picks the first proceed-style button.
+
+        Args:
+            result: The blocked result carrying windowopened events.
+            button: Specific button to click, or None for the first proceed button.
+
+        Returns:
+            dict: The result of the last button click.
+        """
+        for popup_id in popup_ids(result):
+            tools = httpx.get(
+                f"{self.iapi}/v2/tools", params={"windowId": popup_id},
+                headers=self.headers, verify=self.verify,
+            )
+            tools.raise_for_status()
+            available = [t.get("Name") or t.get("ToolName") for t in tools.json()]
+            pick = button
+            if pick is None:  # prefer common proceed buttons
+                pick = next((b for b in ("cb_ok", "cb_1", "cb_yes") if b in available), None)
+            if pick is None or pick not in available:
+                raise RuntimeError(f"Popup {popup_id}: buttons {available}, wanted {button}")
+            click = httpx.post(
+                f"{self.iapi}/v2/tools", headers=self.headers, verify=self.verify,
+                json={"WindowId": popup_id, "ToolName": pick},
+            )
+            click.raise_for_status()
+            result = click.json()
+        return result
+
+    def change(self, window_id: str, tab: str, dw: str, field: str, value: str,
+               answer: str | None = None) -> dict:
+        """Change one field; answer the popup it triggers (if any) with answer.
+
+        Args:
+            window_id: Target window ID.
+            tab: TabName of the field.
+            dw: DatawindowName (required on P21 25.2+).
+            field: Field name to change.
+            value: New value.
+            answer: Button to answer a triggered popup with, or None for auto.
+
+        Returns:
+            dict: Final result after any popups were answered.
+
+        Raises:
+            RuntimeError: When the change comes back as a Failure.
+        """
+        resp = httpx.put(
+            f"{self.iapi}/v2/change", headers=self.headers, verify=self.verify,
+            json={"WindowId": window_id, "List": [{
+                "TabName": tab, "DatawindowName": dw,  # DatawindowName required on 25.2+
+                "FieldName": field, "Value": value,
+            }]},
+        )
+        resp.raise_for_status()
+        result = resp.json()
+        if result.get("Status") in (2, "Failure"):
+            raise RuntimeError(f"{field}: {result.get('Messages')}")
+        if is_blocked(result):
+            result = self.answer_response_windows(result, answer)
+        return result
+
+    def tab(self, window_id: str, page_name: str) -> None:
+        """Switch the window's active tab page."""
+        httpx.put(
+            f"{self.iapi}/v2/tab", headers=self.headers, verify=self.verify,
+            json={"WindowId": window_id, "PageName": page_name},
+        ).raise_for_status()
+
+    def save(self, window_id: str) -> dict:
+        """Save the window; v2 body is the bare window-ID string, not an object.
+
+        Follow-on prompts are answered with their proceed button.
+
+        Raises:
+            RuntimeError: When the save comes back as a Failure.
+        """
+        resp = httpx.put(f"{self.iapi}/v2/data", headers=self.headers,
+                         verify=self.verify, json=window_id)
+        resp.raise_for_status()
+        result = resp.json()
+        while is_blocked(result):  # follow-on prompts: answer with proceed button
+            result = self.answer_response_windows(result)
+        if result.get("Status") in (2, "Failure"):
+            raise RuntimeError(f"Save failed: {result.get('Messages')}")
+        return result
+
+    def get_data(self, window_id: str) -> list[dict]:
+        """Return the datawindows on the window's ACTIVE surface."""
+        data = httpx.get(
+            f"{self.iapi}/v2/data", params={"id": window_id},
+            headers=self.headers, verify=self.verify,
+        )
+        data.raise_for_status()
+        return data.json()
+
+    def cleanup(self, window_id: str | None) -> None:
+        """Close the window and end the session (window uses ?id=)."""
+        if window_id:
+            httpx.delete(f"{self.iapi}/v2/window", params={"id": window_id},
+                         headers=self.headers, verify=self.verify)
+        httpx.delete(f"{self.iapi}/sessions", headers=self.headers, verify=self.verify)
+
+
+def run_flow(session: InteractiveOrderSession) -> str | None:
+    """Drive the full order-entry flow and return the generated order_no.
+
+    Args:
+        session: Connected InteractiveOrderSession.
+
+    Returns:
+        str | None: The generated order number, if it could be read back.
+    """
+    session.start_session()
+    window_id = session.open_window("Order")
+    order_no = None
+    try:
+        # Header -- TABPAGE_1 / datawindow "order". quote OFF = real order.
+        session.change(window_id, "TABPAGE_1", "order", "quote", "OFF")
+        session.change(window_id, "TABPAGE_1", "order", "sales_loc_id", SALES_LOC_ID)
+        session.change(window_id, "TABPAGE_1", "order", "source_loc_id", SOURCE_LOC_ID)
+        session.change(window_id, "TABPAGE_1", "order", "customer_id", CUSTOMER_ID)
+        session.change(window_id, "TABPAGE_1", "order", "ship_to_id", SHIP_TO_ID)
+        session.change(window_id, "TABPAGE_1", "order", "contact_id", CONTACT_ID)
+        # Dates fire the w_response_common date-cascade prompt even on a NEW order
+        session.change(window_id, "TABPAGE_1", "order", "order_date", ORDER_DATE,
+                       answer="cb_ok")
+        session.change(window_id, "TABPAGE_1", "order", "requested_date", REQUESTED_DATE,
+                       answer="cb_ok")
+        session.change(window_id, "TABPAGE_1", "order", "po_no", PO_NO)
+        session.change(window_id, "TABPAGE_1", "order", "taker", TAKER)
+
+        # Lines tab
+        session.tab(window_id, "TP_ITEMS")
+
+        # Item on the EXISTING items row (no /v2/row add for the first line).
+        # Assembly prompt: cb_1 = Yes (explode / link prod order).
+        session.change(window_id, "TP_ITEMS", "items", "oe_order_item_id",
+                       ASSEMBLY_ITEM_ID, answer="cb_1")
+        session.change(window_id, "TP_ITEMS", "items", "unit_quantity", QUANTITY)
+
+        # Save -- v2 body is the bare window-ID string (an object => 422)
+        session.save(window_id)
+
+        # Read order_no back. GET /v2/data returns the ACTIVE surface --
+        # switch back to the header tab first.
+        session.tab(window_id, "TABPAGE_1")
+        for dw in session.get_data(window_id):
+            if dw.get("Name") == "order":
+                row = dw["Data"][dw.get("ActiveRow", 0)]
+                order_no = row[dw["Columns"].index("order_no")]
+                print(f"Created order_no: {order_no}")
+    finally:
+        session.cleanup(window_id)
+    return order_no
+
+
+def verify_order(config, headers: dict, order_no: str) -> None:
+    """Read back the order lines and print their assembly codes.
+
+    Codes: B = kit parent, N = component, P = production-order line,
+    S = build-to-stock allocation.
+
+    Args:
+        config: Loaded P21Config.
+        headers: Auth headers.
+        order_no: Order number to verify.
+    """
+    resp = httpx.get(
+        f"{config.base_url}/odataservice/odata/table/oe_line",
+        params={"$filter": f"order_no eq '{order_no}'"},
+        headers=headers, verify=config.verify_ssl, follow_redirects=True,
+    )
+    resp.raise_for_status()
+    print("\nVerify (oe_line assembly codes):")
+    for line in resp.json()["value"]:
+        print(f"  line {line.get('line_no')}: assembly={line.get('assembly')} "
+              f"qty_ordered={line.get('qty_ordered')}")
+
+
+def main() -> None:
+    """Entry point: print the call plan (dry run) or run the full flow."""
+    parser = argparse.ArgumentParser(
+        description="Order with an assembly line (docs/recipes/order-with-assembly.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Run the full Interactive API flow (default: print the call plan)")
+    args = parser.parse_args()
+
+    print("Recipe - Order with an Assembly Line (Interactive API)")
+    print("=" * 60)
+
+    if not args.execute:
+        print("\nDRY RUN - no session is opened.\n")
+        print(CALL_PLAN.format(
+            iapi="{ui_server}/api/ui/interactive",
+            sales_loc=SALES_LOC_ID, source_loc=SOURCE_LOC_ID,
+            customer=CUSTOMER_ID, ship_to=SHIP_TO_ID, contact=CONTACT_ID,
+            order_date=ORDER_DATE, req_date=REQUESTED_DATE,
+            po_no=PO_NO, taker=TAKER, item=ASSEMBLY_ITEM_ID, qty=QUANTITY,
+        ))
+        print("Re-run with --execute to open the session and enter the order.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    session = InteractiveOrderSession(ui_server, headers, config.verify_ssl)
+    order_no = run_flow(session)
+
+    if order_no:
+        verify_order(config, headers, order_no)
+    else:
+        print("Could not read order_no back from the window data")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/production_order_runbook.py
+++ b/scripts/recipes/production_order_runbook.py
@@ -1,0 +1,226 @@
+"""
+Production Order Runbook -- Create to Invoice (checklist + one automated stage)
+
+The runbook page is a checklist, not a script. This file prints that
+checklist (stages 1-2 and 4-7: what to call, the fields that matter, and the
+trap for each), and automates the stage most people automate first --
+Stage 3: generate the production pick ticket at the STOCK location with
+m_picktickets (creates the ticket record AND returns the PDF), then read the
+new ticket back with POST /api/v2/transaction/get to check its status.
+
+Mirrors: docs/recipes/production-order-runbook.md
+
+Usage:
+    python scripts/recipes/production_order_runbook.py            # checklist + dry run
+    python scripts/recipes/production_order_runbook.py --execute  # run Stage 3 + read-back
+"""
+
+import argparse
+import base64
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+PROD_ORDER = "1000123"   # production order number
+STOCK_LOCATION = "10"    # where the components stock (NOT necessarily the make location)
+
+CHECKLIST = """\
+Runbook stages (this script automates Stage 3 only -- see the recipe page
+docs/recipes/production-order-runbook.md and the linked recipes for the rest):
+
+Stage 1 - Create the production order
+  Path A: sales order auto-create (make-to-order) -- enter the assembly line
+          via the Interactive API (scripts/recipes/order_with_assembly.py).
+          Auto-create NETS AGAINST STOCK: on-hand means no order spawns.
+  Path B: direct build-to-stock -- ProductionOrder window: header
+          source_loc_id, then TABPAGE_17.tp_17_dw_17 assembly_item_id +
+          qty_to_make.
+  Traps:  salesrep must be valid at the sales location; order date must
+          differ from required date.
+
+Stage 2 - Log labor BEFORE printing (scripts/recipes/record_labor_time.py)
+  Trap:   labor added after printing (no reprint) sits on no ticket
+          (qty_on_pick_tickets = 0) and completion fails with
+          "components have a quantity used of 0."
+
+Stage 3 - Print the pick ticket and form  [AUTOMATED BELOW]
+  m_picktickets at POST /api/v2/process/pdfreport, at the STOCK location.
+  Traps:  print_pick_ticket on a ProductionOrder transaction emits only at
+          the MAKE location; never post an m_* report to /api/v2/transaction
+          (it returns Succeeded and emits nothing); the order's form must
+          already be printed (prod_order_hdr.printed = 'Y').
+
+Stage 4 - Confirm the pick (Interactive API ONLY)
+  ProductionOrderPicking window: load the ticket on
+  TP_PRODPICKTICKETCONF.tp_prodpickticketconf (key prod_pick_ticket_number),
+  set row_status_flag = "Confirm", save. Confirm EVERY ticket -- parts AND
+  labor/intangibles.
+  Trap:   a bare Transaction API confirm is a SHELL confirm -- status flips
+          to 1962 but qty_applied stays 0 and no stock moves.
+
+Stage 5 - Complete the order (ProductionOrderProcessing window)
+  Select the line on TABPAGE_17.tp_17_dw_17, set qty_to_complete; then on
+  TABPAGE_ASSEMBLY_BIN.tabpage_assembly_bin set bin_cd and unit_quantity as
+  TWO SEPARATE change calls; optional new_cost on TABPAGE_18.tp_18_dw_18; save.
+  Trap:   combining bin_cd and unit_quantity in one call drops the quantity.
+
+Stage 6 - Ship and invoice the linked sales order
+  Order transaction with print_tix = ON on TP_FRONTCOUNTER.tp_frontcounter,
+  then the Shipping service keyed by pick_ticket_no -- retrieve and save
+  (create_invoice defaults ON: the save ships AND invoices).
+  Traps:  the item needs a packaging code; for contract pricing leave
+          unit_price unset.
+
+Stage 7 - Fix quantity fallout (scripts/recipes/inventory_adjustment.py)
+
+Ticket status codes (prod_pick_ticket_hdr.row_status_flag):
+  702 Open / 1962 Confirmed / 1268 Completed
+  A 1962 alone does not prove stock moved (see shell confirm).
+"""
+
+
+def build_report_payload() -> dict:
+    """Build the Stage 3 m_picktickets payload for PROD_ORDER at STOCK_LOCATION.
+
+    Returns:
+        dict: Complete pdfreport payload (numeric Status/Type 0, Keys []).
+    """
+    return {
+        "Name": "m_picktickets",
+        "UseCodeValues": True,  # m_picktickets REQUIRES code values; False returns HTTP 500
+        "Transactions": [{
+            "Status": 0,        # reports use numeric 0, not "New"
+            "DataElements": [{
+                "Keys": [],
+                "Type": 0,
+                "Name": "TABPAGE_1.tp_1_dw_1",
+                "Rows": [{"Edits": [
+                    {"Name": "create_pick_ticket_type", "Value": "P"},  # code "P" = Production Order
+                    {"Name": "beg_prod_order", "Value": PROD_ORDER},
+                    {"Name": "end_prod_order", "Value": PROD_ORDER},
+                    {"Name": "location_id", "Value": STOCK_LOCATION},
+                ]}],
+            }],
+        }],
+    }
+
+
+def generate_pick_ticket(ui_server: str, headers: dict, verify_ssl: bool) -> str:
+    """Run m_picktickets, save the PDF, and return the saved file name.
+
+    Args:
+        ui_server: UI server URL.
+        headers: Auth headers.
+        verify_ssl: Whether to verify SSL certificates.
+
+    Returns:
+        str: The saved PDF file name (contains the ticket number).
+
+    Raises:
+        SystemExit: When the report fails.
+    """
+    resp = httpx.post(
+        f"{ui_server}/api/v2/process/pdfreport",  # NOT /api/v2/transaction (silent no-op there)
+        headers=headers, json=build_report_payload(), verify=verify_ssl,
+        follow_redirects=True, timeout=120,
+    )
+    resp.raise_for_status()
+    result = resp.json()
+
+    if not isinstance(result, list):  # errors come back as an envelope, not an array
+        raise SystemExit(f"Report failed: {result.get('ErrorMessage')}")
+
+    doc = result[0]
+    if doc["ResponseStatus"]["StatusCode"] != "Success" or not doc.get("DocumentData"):
+        raise SystemExit(f"Report failed: {doc['ResponseStatus'].get('Message')}")
+
+    file_name = doc["FileName"]  # e.g. "PPT123456 PRODUCTION_PICK_TICKET.pdf"
+    with open(file_name, "wb") as f:
+        f.write(base64.b64decode(doc["DocumentData"]))
+    print(f"Saved {file_name}")
+    return file_name
+
+
+def read_ticket_status(ui_server: str, headers: dict, verify_ssl: bool,
+                       ticket_no: str) -> None:
+    """Read the new ticket back via /transaction/get and print its status.
+
+    Args:
+        ui_server: UI server URL.
+        headers: Auth headers.
+        verify_ssl: Whether to verify SSL certificates.
+        ticket_no: Production pick-ticket number (from the PDF FileName).
+    """
+    get_payload = {
+        "ServiceName": "ProductionOrderPicking",
+        "TransactionStates": [{
+            "DataElementName": "TP_PRODPICKTICKETCONF.tp_prodpickticketconf",
+            "Keys": [{"Name": "prod_pick_ticket_number", "Value": ticket_no}],
+        }],
+    }
+    resp = httpx.post(f"{ui_server}/api/v2/transaction/get",
+                      headers=headers, json=get_payload, verify=verify_ssl,
+                      follow_redirects=True, timeout=60)
+    resp.raise_for_status()
+
+    for txn in resp.json().get("Transactions", []):
+        for de in txn.get("DataElements", []):
+            for row in de.get("Rows", []):
+                fields = {e["Name"]: e["Value"] for e in row.get("Edits", [])}
+                if "row_status_flag" in fields:
+                    # 702 = Open, 1962 = Confirmed, 1268 = Completed
+                    print(f"Ticket {fields.get('prod_pick_ticket_number')} "
+                          f"for prod order {fields.get('prod_order_number')}: "
+                          f"status {fields.get('row_status_flag')}")
+
+
+def main() -> None:
+    """Entry point: print the runbook checklist; on --execute run Stage 3."""
+    parser = argparse.ArgumentParser(
+        description="Production order runbook (docs/recipes/production-order-runbook.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Run Stage 3 (m_picktickets) -- CREATES the pick-ticket "
+                             "record in P21 (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Production Order Runbook (Create to Invoice)")
+    print("=" * 60)
+    print()
+    print(CHECKLIST)
+
+    if not args.execute:
+        print("DRY RUN - Stage 3 payload that would be POSTed to "
+              "{ui_server}/api/v2/process/pdfreport:")
+        print(json.dumps(build_report_payload(), indent=2))
+        print("\nRe-run with --execute to generate the pick ticket and read its status back.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    # --- Stage 3, part 1: generate the pick ticket (record + PDF) ---
+    file_name = generate_pick_ticket(ui_server, headers, config.verify_ssl)
+
+    # --- Stage 3, part 2: read the new ticket back (number from the FileName) ---
+    match = re.match(r"PPT(\d+)", file_name)
+    if not match:
+        raise SystemExit(f"Could not extract ticket number from '{file_name}'")
+    read_ticket_status(ui_server, headers, config.verify_ssl, match.group(1))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/record_labor_time.py
+++ b/scripts/recipes/record_labor_time.py
@@ -1,0 +1,166 @@
+"""
+Record Labor Time on a Production Order (TimeEntry service)
+
+Post a technician's labor hours to a production order with the TimeEntry
+service, then read the labor grid back via POST /api/v2/transaction/get.
+Labor grid fields must be entered in strict order (prod_order_number ->
+item_id -> component_labor_id -> start_time -> end_time) or downstream
+fields stay disabled. Time ACCUMULATES across entries -- re-posting the same
+entry doubles the labor.
+
+Mirrors: docs/recipes/record-labor-time.md
+
+Usage:
+    python scripts/recipes/record_labor_time.py            # dry run (default)
+    python scripts/recipes/record_labor_time.py --execute  # POST + read-back
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+COMPANY_ID = "ACME"
+PROD_ORDER = "1000123"
+TECHNICIAN_ID = "300"          # a CONTACT id, not a P21 user id
+ENTRY_DATE = "2030-01-05"      # accounting period for this date must be open
+ASSEMBLY_ITEM_ID = "ASSY-100"  # the assembly LINE's item (not the component)
+LABOR_COMPONENT_ID = "LABOR-SHOP"
+START_TIME = "2030-01-05T08:00:00"
+END_TIME = "2030-01-05T12:00:00"
+LABOR_TYPE = "Rate"            # required -- valid: Rate, OT Rate, Prem Rate
+
+
+def build_time_entry_payload() -> dict:
+    """Build the TimeEntry payload: technician header + one labor line.
+
+    Returns:
+        dict: Complete Transaction API payload.
+    """
+    return {
+        "Name": "TimeEntry",
+        "UseCodeValues": False,
+        "Transactions": [{
+            "Status": "New",
+            "DataElements": [
+                {
+                    "Name": "TP_TECHNICIAN.tp_technician",
+                    "Type": "Form",
+                    "Keys": [],
+                    "Rows": [{
+                        "Edits": [
+                            {"Name": "company_id", "Value": COMPANY_ID},
+                            {"Name": "technician_id", "Value": TECHNICIAN_ID},  # CONTACT id
+                            {"Name": "entry_date", "Value": ENTRY_DATE},
+                        ],
+                        "RelativeDateEdits": [],
+                    }],
+                },
+                {
+                    "Name": "TP_LABORRECORDING.prod_order_line_comp_labor",
+                    "Type": "List",
+                    "Keys": ["prod_order_number"],
+                    "Rows": [{
+                        # Strict order: prod_order_number -> item_id ->
+                        # component_labor_id -> start_time -> end_time
+                        "Edits": [
+                            {"Name": "prod_order_number", "Value": PROD_ORDER},
+                            {"Name": "item_id", "Value": ASSEMBLY_ITEM_ID},
+                            {"Name": "component_labor_id", "Value": LABOR_COMPONENT_ID},
+                            {"Name": "start_time", "Value": START_TIME},
+                            {"Name": "end_time", "Value": END_TIME},
+                            {"Name": "labor_type_cd", "Value": LABOR_TYPE},
+                        ],
+                        "RelativeDateEdits": [],
+                    }],
+                },
+            ],
+        }],
+    }
+
+
+def read_labor_grid(ui_server: str, headers: dict, verify_ssl: bool) -> None:
+    """Read the labor grid back for PROD_ORDER and print accumulated time.
+
+    Args:
+        ui_server: UI server URL.
+        headers: Auth headers.
+        verify_ssl: Whether to verify SSL certificates.
+    """
+    get_payload = {
+        "ServiceName": "TimeEntry",
+        "TransactionStates": [{
+            "DataElementName": "TP_LABORRECORDING.prod_order_line_comp_labor",
+            "Keys": [{"Name": "prod_order_number", "Value": PROD_ORDER}],
+        }],
+    }
+    resp = httpx.post(f"{ui_server}/api/v2/transaction/get",
+                      headers=headers, json=get_payload, verify=verify_ssl,
+                      follow_redirects=True, timeout=60)
+    resp.raise_for_status()
+    for txn in resp.json().get("Transactions", []):
+        for de in txn.get("DataElements", []):
+            for row in de.get("Rows", []):
+                fields = {e["Name"]: e["Value"] for e in row.get("Edits", [])}
+                if fields.get("prod_order_number"):
+                    print(f"  {fields.get('component_labor_id') or fields.get('service_labor_id')}: "
+                          f"time_worked={fields.get('time_worked')}")
+
+
+def main() -> None:
+    """Entry point: build payload, POST on --execute, then read the grid back."""
+    parser = argparse.ArgumentParser(
+        description="Record labor time (docs/recipes/record-labor-time.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually POST the time entry -- labor ACCUMULATES, "
+                             "re-posting doubles it (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Record Labor Time (TimeEntry)")
+    print("=" * 60)
+
+    payload = build_time_entry_payload()
+
+    if not args.execute:
+        print("\nDRY RUN - payload that would be POSTed to {ui_server}/api/v2/transaction:")
+        print(json.dumps(payload, indent=2))
+        print("\nRe-run with --execute to POST it.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                      headers=headers, json=payload, verify=config.verify_ssl,
+                      follow_redirects=True, timeout=120)
+    resp.raise_for_status()  # HTTP 200 even on failure -- check the Summary
+    result = resp.json()
+
+    summary = result["Summary"]
+    print(f"Succeeded: {summary['Succeeded']}, Failed: {summary['Failed']}")
+    if summary["Failed"] > 0:
+        for msg in result.get("Messages", []):
+            print(f"  {msg}")
+        raise SystemExit("Time entry failed")
+
+    # --- Verify: read back the labor grid for the order. time_worked should
+    # reflect the ACCUMULATED total, not just this entry. ---
+    print("\nVerify (labor grid read-back):")
+    read_labor_grid(ui_server, headers, config.verify_ssl)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/set_primary_bin_supplier.py
+++ b/scripts/recipes/set_primary_bin_supplier.py
@@ -1,0 +1,171 @@
+"""
+Set an Item's Primary Bin or Primary Supplier at a Location (Item service)
+
+Update an item's primary bin or primary supplier for one stocking location
+via the Item service's nested Form -> List -> detail pattern, with a
+MANDATORY OData read-back: the primary-supplier write silently no-ops when
+the supplier has no location-level row (inventory_supplier_x_loc), while the
+transaction still reports Succeeded = 1.
+
+Mirrors: docs/recipes/set-primary-bin-supplier.md
+
+Usage:
+    python scripts/recipes/set_primary_bin_supplier.py                          # dry run, supplier variant
+    python scripts/recipes/set_primary_bin_supplier.py --target bin             # dry run, bin variant
+    python scripts/recipes/set_primary_bin_supplier.py --execute                # write + verify supplier
+    python scripts/recipes/set_primary_bin_supplier.py --target bin --execute   # write + verify bin
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+ITEM_ID = "WIDGET-001"
+LOCATION_ID = "10"
+SUPPLIER_ID = "20000"   # --target supplier: must already have an
+                        # inventory_supplier_x_loc row at LOCATION_ID
+PRIMARY_BIN = "A01-02"  # --target bin
+
+
+def build_payload(target: str) -> dict:
+    """Build the nested Item payload for the chosen target.
+
+    Status "New" with populated Keys updates the existing keyed record --
+    it does not create a new item.
+
+    Args:
+        target: "supplier" (Form -> List -> List) or "bin" (Form -> List -> Form).
+
+    Returns:
+        dict: Complete Transaction API payload.
+    """
+    if target == "supplier":
+        detail = {"Name": "SUPPLIER_X_LOCATION.supplier_x_location", "Type": "List",
+                  "Keys": ["supplier_id"],
+                  "Rows": [{"Edits": [
+                      {"Name": "supplier_id", "Value": SUPPLIER_ID},
+                      {"Name": "primary_supplier", "Value": "ON"},
+                  ]}]}
+    else:
+        detail = {"Name": "TABPAGE_18.inv_loc_detail", "Type": "Form",
+                  "Keys": ["location_id"],
+                  "Rows": [{"Edits": [
+                      {"Name": "location_id", "Value": LOCATION_ID},
+                      {"Name": "bin", "Value": PRIMARY_BIN},
+                  ]}]}
+    return {
+        "Name": "Item",
+        "UseCodeValues": False,
+        "Transactions": [{
+            "Status": "New",  # updates the keyed record; does not create a new item
+            "DataElements": [
+                {"Name": "TABPAGE_1.tp_1_dw_1", "Type": "Form", "Keys": ["item_id"],
+                 "Rows": [{"Edits": [{"Name": "item_id", "Value": ITEM_ID}]}]},
+                {"Name": "TABPAGE_17.invloclist", "Type": "List", "Keys": ["location_id"],
+                 "Rows": [{"Edits": [{"Name": "location_id", "Value": LOCATION_ID}]}]},
+                detail,
+            ],
+        }],
+    }
+
+
+def read_inv_loc_field(config, headers: dict, field: str) -> str:
+    """Resolve inv_mast_uid from ITEM_ID, then read one inv_loc field.
+
+    Args:
+        config: Loaded P21Config.
+        headers: Auth headers.
+        field: inv_loc column to read (primary_supplier_id or primary_bin).
+
+    Returns:
+        str: The field's current value as a string.
+    """
+    mast = httpx.get(
+        f"{config.base_url}/odataservice/odata/table/inv_mast",
+        params={"$filter": f"item_id eq '{ITEM_ID}'", "$select": "inv_mast_uid"},
+        headers=headers, verify=config.verify_ssl, follow_redirects=True,
+    )
+    mast.raise_for_status()
+    inv_mast_uid = mast.json()["value"][0]["inv_mast_uid"]
+
+    loc = httpx.get(
+        f"{config.base_url}/odataservice/odata/table/inv_loc",
+        params={
+            "$filter": f"inv_mast_uid eq {inv_mast_uid} and location_id eq {LOCATION_ID}",
+            "$select": field,
+        },
+        headers=headers, verify=config.verify_ssl, follow_redirects=True,
+    )
+    loc.raise_for_status()
+    return str(loc.json()["value"][0][field])
+
+
+def main() -> None:
+    """Entry point: build payload, POST on --execute, then verify via OData."""
+    parser = argparse.ArgumentParser(
+        description="Set primary bin/supplier (docs/recipes/set-primary-bin-supplier.md)")
+    parser.add_argument("--target", choices=["supplier", "bin"], default="supplier",
+                        help="Which primary to set (default: supplier)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually POST the transaction (default: dry run)")
+    args = parser.parse_args()
+
+    print(f"Recipe - Set Primary {args.target.capitalize()} at a Location (Item service)")
+    print("=" * 60)
+
+    payload = build_payload(args.target)
+
+    if not args.execute:
+        print("\nDRY RUN - payload that would be POSTed to {ui_server}/api/v2/transaction:")
+        print(json.dumps(payload, indent=2))
+        print("\nRe-run with --execute to POST it.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                      headers=headers, json=payload, verify=config.verify_ssl,
+                      follow_redirects=True, timeout=120)
+    resp.raise_for_status()
+    result = resp.json()
+    print(f"Succeeded: {result['Summary']['Succeeded']}, "
+          f"Failed: {result['Summary']['Failed']}")
+    for msg in result.get("Messages") or []:
+        print(f"  {msg}")  # watch for 'Unexpected response window: Item Issues Detected'
+
+    # MANDATORY verification -- a silent no-op still reports Succeeded = 1.
+    # Supplier: write the inventory_supplier_x_loc flag, READ inv_loc.primary_supplier_id.
+    print("\nVerify (OData read-back):")
+    if args.target == "supplier":
+        actual = read_inv_loc_field(config, headers, "primary_supplier_id")
+        if actual == SUPPLIER_ID:
+            print(f"  VERIFIED: primary_supplier_id = {actual}")
+        else:
+            # Most likely cause: no inventory_supplier_x_loc row at this location.
+            # Add the location supplier row first, then set the flag again.
+            print(f"  SILENT NO-OP: primary_supplier_id is {actual}, expected {SUPPLIER_ID}")
+    else:
+        actual = read_inv_loc_field(config, headers, "primary_bin")
+        if actual == PRIMARY_BIN:
+            print(f"  VERIFIED: primary_bin = {actual}")
+        else:
+            print(f"  MISMATCH: primary_bin is {actual}, expected {PRIMARY_BIN}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recipes/update_contract_lines.py
+++ b/scripts/recipes/update_contract_lines.py
@@ -1,0 +1,186 @@
+"""
+Update Contract Lines (JobContractPricing)
+
+Update prices on existing JobContractPricing lines, insert new lines onto an
+existing contract (upsert), and set commission costs -- all through the
+stateless Transaction API. One POST per line (inserts re-save the shared
+header and collide when batched), then an OData read-back of every price.
+
+Mirrors: docs/recipes/update-contract-lines.md
+
+Usage:
+    python scripts/recipes/update_contract_lines.py            # dry run (default)
+    python scripts/recipes/update_contract_lines.py --execute  # POST + verify
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+from common.auth import get_token, get_auth_headers, get_ui_server_url
+from common.config import load_config
+
+import warnings
+warnings.filterwarnings("ignore")
+
+# --- Configuration (generic placeholders -- substitute your own) ------------
+CONTRACT = {
+    "company_id": "ACME",
+    "contract_no": "A120-12",
+    "job_no": "31",            # unique across renewals -- include it
+    "end_date": "2030-01-01",  # required on EVERY submit, must be >= today
+}
+
+# (item_id, uom, price, commission_cost or None)
+LINES = [
+    ("WIDGET-001", "EA", 36.58, 17.19),  # already on contract -> updated
+    ("WIDGET-002", "EA", 12.40, None),   # not on contract     -> inserted (upsert)
+]
+
+
+def line_payload(contract: dict, item_id: str, uom: str, price: float,
+                 commission_cost: float | None = None) -> dict:
+    """Build a one-line upsert payload, optionally with a commission cost.
+
+    Args:
+        contract: Header key fields (company_id, contract_no, job_no, end_date).
+        item_id: Item on the contract line (the JOBPRICELINE upsert key).
+        uom: Unit of measure for the line.
+        price: Fixed price (pricing_method "Price").
+        commission_cost: Optional commission cost value; requires
+            IgnoreDisabled at the payload top level.
+
+    Returns:
+        dict: Complete Transaction API payload for one line.
+    """
+    elements = [
+        {"Name": "FORM.d_dw_job_price_hdr", "Type": "Form", "Keys": [],
+         "Rows": [{"Edits": [
+             {"Name": "company_id",  "Value": contract["company_id"]},
+             {"Name": "contract_no", "Value": contract["contract_no"]},
+             {"Name": "job_no",      "Value": contract["job_no"]},
+             {"Name": "end_date",    "Value": contract["end_date"]},
+         ], "RelativeDateEdits": []}]},
+        {"Name": "JOBPRICELINE.jobpriceline", "Type": "List", "Keys": ["item_id"],
+         "Rows": [{"Edits": [
+             {"Name": "item_id",        "Value": item_id},
+             {"Name": "uom",            "Value": uom},
+             {"Name": "pricing_method", "Value": "Price"},   # MUST come before price
+             {"Name": "price",          "Value": str(price)},
+         ], "RelativeDateEdits": []}]},
+    ]
+    payload = {"Name": "JobContractPricing", "UseCodeValues": False,
+               "Transactions": [{"Status": "New", "DataElements": elements}]}
+    if commission_cost is not None:
+        payload["IgnoreDisabled"] = True  # top level, NOT inside the Transaction
+        elements.append(
+            {"Name": "JOBPRICECOST.jobpricecost", "Type": "Form", "Keys": ["item_id"],
+             "Rows": [{"Edits": [
+                 {"Name": "item_id",                 "Value": item_id},
+                 {"Name": "commission_cost_type_cd", "Value": "Value"},  # type before value
+                 {"Name": "commission_cost_value",   "Value": str(commission_cost)},
+             ]}]})
+    return payload
+
+
+def post_line(ui_server: str, headers: dict, verify_ssl: bool, payload: dict) -> bool:
+    """POST one transaction; True only if the Summary says it landed.
+
+    Args:
+        ui_server: UI server URL from get_ui_server_url().
+        headers: Auth headers from get_auth_headers().
+        verify_ssl: Whether to verify SSL certificates.
+        payload: Transaction API payload from line_payload().
+
+    Returns:
+        bool: True when Summary.Succeeded > 0 and Summary.Failed == 0.
+    """
+    resp = httpx.post(f"{ui_server}/api/v2/transaction",
+                      headers=headers, json=payload, verify=verify_ssl,
+                      follow_redirects=True, timeout=60)
+    resp.raise_for_status()  # HTTP 200 even when the transaction failed
+    result = resp.json()
+    summary = result["Summary"]
+    if summary["Failed"] or not summary["Succeeded"]:
+        for msg in result.get("Messages", []):
+            print(f"  FAILED: {msg}")
+        return False
+    return True
+
+
+def odata(base_url: str, headers: dict, verify_ssl: bool,
+          table: str, filter_expr: str) -> list[dict]:
+    """Query an OData table and return its value rows.
+
+    Args:
+        base_url: P21 base URL.
+        headers: Auth headers.
+        verify_ssl: Whether to verify SSL certificates.
+        table: OData table name.
+        filter_expr: OData $filter expression.
+
+    Returns:
+        list[dict]: Matching rows.
+    """
+    resp = httpx.get(f"{base_url}/odataservice/odata/table/{table}",
+                     params={"$filter": filter_expr},
+                     headers=headers, verify=verify_ssl, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.json()["value"]
+
+
+def main() -> None:
+    """Entry point: build payloads, POST on --execute, then verify via OData."""
+    parser = argparse.ArgumentParser(
+        description="Update/insert JobContractPricing lines (docs/recipes/update-contract-lines.md)")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually POST the transactions (default: dry run)")
+    args = parser.parse_args()
+
+    print("Recipe - Update Contract Lines (JobContractPricing)")
+    print("=" * 60)
+
+    payloads = [(item_id, line_payload(CONTRACT, item_id, uom, price, commission))
+                for item_id, uom, price, commission in LINES]
+
+    if not args.execute:
+        print("\nDRY RUN - one POST per line to {ui_server}/api/v2/transaction:")
+        for item_id, payload in payloads:
+            print(f"\n--- {item_id} ---")
+            print(json.dumps(payload, indent=2))
+        print("\nRe-run with --execute to POST the transactions.")
+        return
+
+    config = load_config()
+    token_data = get_token(config)
+    headers = get_auth_headers(token_data["AccessToken"])
+    ui_server = get_ui_server_url(config.base_url, token_data["AccessToken"], config.verify_ssl)
+    print(f"UI Server: {ui_server}")
+
+    # One POST per line: inserts re-save the shared header and collide when batched.
+    for item_id, payload in payloads:
+        ok = post_line(ui_server, headers, config.verify_ssl, payload)
+        print(f"{item_id}: {'OK' if ok else 'failed'}")
+
+    # --- Verify via OData (no joins: chain the uid columns) ---
+    print("\nVerify (OData read-back):")
+    # Renewals can return two headers for one contract_no -- match job_no too.
+    hdr = odata(config.base_url, headers, config.verify_ssl,
+                "job_price_hdr", f"contract_no eq '{CONTRACT['contract_no']}'")[0]
+    for item_id, _uom, price, _commission in LINES:
+        im_uid = odata(config.base_url, headers, config.verify_ssl,
+                       "inv_mast", f"item_id eq '{item_id}'")[0]["inv_mast_uid"]
+        line = odata(config.base_url, headers, config.verify_ssl,
+                     "job_price_line",
+                     f"job_price_hdr_uid eq {hdr['job_price_hdr_uid']} "
+                     f"and inv_mast_uid eq {im_uid}")[0]
+        match = "OK" if float(line["price"]) == price else "MISMATCH"
+        print(f"  {item_id}: price={line['price']} expected={price} -> {match}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Blends the two example styles: recipe pages keep portable inline snippets, and each now links a **complete end-to-end file** for readers who want the whole program.

- **`scripts/recipes/`** — 10 runnable Python scripts (repo conventions: `common.auth`/`common.config`, `.env`), **dry-run by default** (print the payload; `--execute` posts + Summary check + verify read-back). All compile; ruff clean.
- **`examples/csharp/Recipes/`** — new solution project with menu `Program.cs`, one class per recipe, `EXECUTE`-gated writes through `P21Examples.Common`. `dotnet build` on the project and full solution: 0 warnings, 0 errors.
- Recipe pages link the files under their tabs; recipes README explains the snippet-vs-file split.

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE