### PR TITLE
feat(docs): P21 Breaking Changes registry (doc 14) + standing changelog alerts — 2026.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ p21-api-documentation/
 │   ├── 11-Inventory-REST-API.md
 │   ├── 12-Production-Labor-API.md
 │   ├── 13-UDT-Service-API.md
+│   ├── 14-Breaking-Changes.md
 │   └── html/                    # Generated HTML versions
 │
 ├── definitions/                 # Sanitized full-field service definition JSONs (schema library)
@@ -210,6 +211,12 @@ window.ChangeData("Criteria", "tp_1_dw_1", "po_criteria_id", "20");
 **Updates**: `Status: "Existing"` is *unused*, not a write ban. For JobContractPricing the verified update path is `Status: "New"` with FORM key fields (`company_id`, `contract_no`, `job_no`, `end_date`) in `Edits` and List `Keys` identifying the row by `item_id` — see [JobContractPricing > Updating an Existing Contract](docs/03-Transaction-API.md#updating-an-existing-contract) (Fixes #44, May 2026). Other services (Assembly, SalesPricePage, TimeEntry) are untested but likely follow the same pattern; the Interactive API remains a fallback.
 
 **Upserts (July 2026)**: keyed `Status: "New"` List rows are an upsert — update when the key matches, **insert a new row when it doesn't** (verified: 81 new JobContractPricing lines in one run, DB-confirmed; credit Alex Westemeier). Gotchas: order `pricing_method` before `price` in Edits (cascade silently zeroes the price); one transaction per POST when inserts re-save a shared FORM header (optimistic-concurrency collisions + duplicate `line_no`); header saves validate `end_date` ≥ today. `IgnoreDisabled: true` (payload top level ONLY — silently ignored inside a Transaction object) unlocks disabled columns and tabs, e.g. contract BINS quantities and JOBPRICECOST commission fields.
+
+---
+
+### P21 2026.1 Breaking Changes (June 2026, verified 2026.1.5873.1 vs 2025.2.5855.0)
+
+Interactive endpoints return an **empty HTTP 500 without `Accept: application/json`** (`Accept: */*` defaults fail), and the failed session create leaves a **ghost session** (409 "Session already exists" until `SessionCleanupExpiration` ~6 min → alternating 500/409). Contract changes: session-create response `SessionId` → `Id`; `/v2/tab` binds `PageName` only; **silent-false-success hazards** — nonexistent record loads return `Status: 2` with an empty window (was `Status: 0`), and multi-field `/v2/change` drops non-active-tab fields while returning `Status: 1`. Mitigations (all verified): force the Accept header in one shared builder; read `Id` or `SessionId`; existence pre-read before window writes; one field per change call per active tab + read-back. Reported to Epicor (defect pending). Full registry: [docs/14-Breaking-Changes.md](docs/14-Breaking-Changes.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The repo is built for **progressive disclosure**: this README routes you, each a
 | Area | What's there | Start at |
 |------|--------------|----------|
 | [`docs/INDEX.md`](docs/INDEX.md) | "I want to…" → exact doc-section routing map | the index itself |
-| [`docs/`](docs/INDEX.md#doc-inventory-what-each-file-is) | The deep manual — 14 numbered guides (auth, each API, errors, patterns) | Task Index, not the raw files |
+| [`docs/`](docs/INDEX.md#doc-inventory-what-each-file-is) | The deep manual — 15 numbered guides (auth, each API, errors, patterns) | Task Index, not the raw files |
 | [`docs/recipes/`](docs/recipes/README.md) | Copy-and-run task pages: complete payload + runnable Python & C# + verified gotchas | [recipes README](docs/recipes/README.md) |
 | [`definitions/`](definitions/README.md) | Full-field service schemas (every DataElement, field, key, label + payload template), sanitized | [definitions README](definitions/README.md) |
 | [`examples/python/`](examples/python/README.md) | Runnable Python examples for every API + end-to-end recipe scripts (dry-run by default) | [python README](examples/python/README.md) |
@@ -60,7 +60,7 @@ For C#: `cd examples/csharp && dotnet build`, then `dotnet run --project <Projec
 
 - **Getting started:** [Authentication](docs/00-Authentication.md) · [API Selection Guide](docs/01-API-Selection-Guide.md)
 - **API reference:** [OData](docs/02-OData-API.md) · [Transaction](docs/03-Transaction-API.md) · [Interactive](docs/04-Interactive-API.md) · [Entity](docs/05-Entity-API.md) · [Inventory REST](docs/11-Inventory-REST-API.md) · [Production & Labor](docs/12-Production-Labor-API.md) · [UDT Service](docs/13-UDT-Service-API.md)
-- **Troubleshooting:** [Error Handling](docs/06-Error-Handling.md) · [Session Pool Issues](docs/07-Session-Pool-Troubleshooting.md)
+- **Troubleshooting:** [P21 Breaking Changes](docs/14-Breaking-Changes.md) · [Error Handling](docs/06-Error-Handling.md) · [Session Pool Issues](docs/07-Session-Pool-Troubleshooting.md)
 - **Reference:** [SalesPricePage Codes](docs/08-SalesPricePage-Codes.md) · [Batch Processing Patterns](docs/09-Batch-Processing-Patterns.md) · [Changelog](docs/10-Changelog.md)
 
 All documentation pages include tabbed Python/C# code blocks; the [online docs](https://mrwuss.github.io/p21-api-documentation/html/) sync language selection across every block on a page.

--- a/docs/00-Authentication.md
+++ b/docs/00-Authentication.md
@@ -421,6 +421,10 @@ If you receive a `401` or `403` "not authorized" error with a valid token:
 
 ## Using the Token
 
+> **`Accept: application/json` is not optional on 2026.1.** Every example in this documentation sends it; on P21 **2026.1** the Interactive API returns an **empty HTTP 500** for requests without it (including the `Accept: */*` default of httpx and .NET HttpClient), and the failed session create leaves a ghost session behind. See [Breaking Changes § 2026.1](14-Breaking-Changes.md#p21-20261).
+
+
+
 Include the token in the `Authorization` header for all API requests:
 
 ```http

--- a/docs/04-Interactive-API.md
+++ b/docs/04-Interactive-API.md
@@ -1936,6 +1936,9 @@ When setting numeric fields, send whole numbers as integer strings (`"30"`), not
 
 ## v1 vs v2 API Differences
 
+> **Upgrading P21?** Version-specific middleware changes that break interactive integrations (25.2's required `DatawindowName`, 2026.1's Accept-header 500 / ghost sessions / `SessionId`→`Id` / silent-false-success hazards) are cataloged in [P21 Breaking Changes by Version](14-Breaking-Changes.md).
+
+
 > **Important:** Some P21 servers only support v2 endpoints (v1 returns 404). Always try v2 first.
 
 ### Summary Table

--- a/docs/06-Error-Handling.md
+++ b/docs/06-Error-Handling.md
@@ -229,6 +229,16 @@ See [Session Pool Troubleshooting](07-Session-Pool-Troubleshooting.md) for detai
 
 ## Interactive API Errors
 
+### Empty HTTP 500 on Every Interactive Call (2026.1)
+
+On P21 **2026.1**, any interactive request without an explicit `Accept: application/json` header — including the `Accept: */*` default of httpx and .NET HttpClient — returns an **empty-body HTTP 500**. The same request with the header succeeds; 2025.2 is unaffected.
+
+**Solution**: send `Accept: application/json` on every request. Details: [Breaking Changes § 2026.1](14-Breaking-Changes.md#p21-20261).
+
+### Alternating 500 / 409 "Session already exists" (2026.1)
+
+The failed session create above still **half-creates the session** server-side, so retries hit 409 until `SessionCleanupExpiration` (~6 min). If you see this pattern on 2026.1, check the `Accept` header first — it is not a session-pool problem. Details: [Breaking Changes § 2026.1](14-Breaking-Changes.md#p21-20261).
+
 ### Session Errors
 
 **Session Not Found**

--- a/docs/10-Changelog.md
+++ b/docs/10-Changelog.md
@@ -8,6 +8,19 @@ All notable changes to this documentation project are listed below, grouped by d
 
 ---
 
+## ⚠ P21 Breaking-Change Alerts
+
+> Standing alerts for P21 **platform** version changes that break or silently corrupt API integrations — maintained in [**P21 Breaking Changes by Version**](14-Breaking-Changes.md). Check before any upgrade.
+>
+> - **2026.1** — Interactive endpoints return an **empty HTTP 500 without `Accept: application/json`** (httpx/.NET defaults break), and the failed session create leaves a **ghost session** (409 until cleanup); `SessionId` → `Id`; `TabName` no longer accepted on `/v2/tab`; **two silent-false-success hazards** (nonexistent record loads as `Status: 2` + empty window; multi-field changes drop non-active-tab fields while reporting Success). Verified 2026.1.5873.1 vs 2025.2.5855.0. → [details](14-Breaking-Changes.md#p21-20261)
+> - **25.2** — `DatawindowName` **required** in Interactive change requests (3-param form stops working). → [details](14-Breaking-Changes.md#p21-252)
+
+---
+
+## 2026-07-10 — v1.2.0
+
+- **feat:** New **[P21 Breaking Changes by Version](14-Breaking-Changes.md)** registry (doc 14) — a first-class page cataloging middleware changes that break or silently corrupt integrations, checked before upgrades. Launches with **2026.1** (verified 2026.1.5873.1 vs 2025.2.5855.0 during upgrade validation; reported to Epicor): Interactive endpoints return an **empty HTTP 500 without `Accept: application/json`** (httpx/.NET `Accept: */*` defaults fail) with a **ghost-session** side effect (409 "Session already exists" until cleanup → alternating 500/409); session-create response renamed `SessionId` → `Id`; `/v2/tab` binds `PageName` only; and two **silent-false-success hazards** — nonexistent record loads return `Status: 2` with an empty window (was `Status: 0`), and multi-field `/v2/change` silently drops non-active-tab fields while returning `Status: 1` — each with its verified mitigation (existence pre-read; one-field-per-change-per-active-tab + read-back). The 25.2 `DatawindowName` change is consolidated into the same registry. Standing **Breaking-Change Alerts** header added to the top of this changelog; cross-references added in 00/04/06/INDEX/CLAUDE.md — Fixes #96 — *@mrwuss*
+
 ## 2026-07-10 — v1.1.1
 
 End-to-end alignment audit: nine area agents checked **every tracked file** against the session's live-verified findings; ~118 findings triaged and fixed in one pass (PR #94). Highlights:

--- a/docs/14-Breaking-Changes.md
+++ b/docs/14-Breaking-Changes.md
@@ -1,0 +1,105 @@
+# P21 Breaking Changes by Version
+
+> **Disclaimer:** This is unofficial, community-created documentation for Epicor Prophet 21 APIs. It is not affiliated with, endorsed by, or supported by Epicor Software Corporation. All product names, trademarks, and registered trademarks are property of their respective owners. Use at your own risk.
+
+---
+
+## Overview
+
+A version-indexed registry of P21 middleware changes that **break or silently corrupt existing API integrations**. Every entry here was found the hard way during a real upgrade validation and verified against live tenants — including confirming the behavior does *not* exist on the prior version. Check this page **before** any P21 upgrade, and re-test the listed surfaces on your own test tenant first.
+
+| Version | Entries | Severity |
+|---------|---------|----------|
+| [2026.1](#p21-20261) | Empty 500 without `Accept` header · ghost sessions (500/409) · `SessionId` → `Id` · `TabName` no longer accepted on `/v2/tab` · **two silent-false-success hazards** | High — one hard break, two data-integrity hazards |
+| [25.2](#p21-252) | `DatawindowName` required in change requests | High — hard break for 3-param change calls |
+
+---
+
+## P21 2026.1
+
+All findings verified on **2026.1.5873.1** (self-hosted middleware, test tenant) during upgrade validation, June 2026. **None reproduce on 2025.2.5855.0** with identical requests. The empty-500 defect has been reported to Epicor; the contract changes are awaiting written confirmation of intent. Re-verify against your own 2026.1 tenant before relying on the details.
+
+### 1. Interactive API returns an empty HTTP 500 without an explicit `Accept: application/json` header
+
+**Hard break — every interactive endpoint.**
+
+On 2026.1, any request to `/uiserver0/api/ui/interactive/...` that omits the `Accept` header — or sends `Accept: */*`, which is the **default for most HTTP libraries, including Python `httpx` and .NET `HttpClient`** — fails with an **empty-body HTTP 500**. The identical request with `Accept: application/json` added succeeds. 2025.2 falls back to a default representation instead of failing.
+
+```http
+POST {uiserver}/api/ui/interactive/sessions/ HTTP/1.1
+Authorization: Bearer {token}
+Content-Type: application/json
+Accept: application/json        <-- REQUIRED on 2026.1; omit it and you get an empty 500
+
+{"ResponseWindowHandlingEnabled": true}
+```
+
+**Mitigation:** send `Accept: application/json` on **every** P21 request, ideally forced in one shared header builder rather than per call site. Every example in this repo already does this — the consequence of omitting it is what changed.
+
+### 2. Ghost sessions: the failed create still half-creates the session (alternating 500/409)
+
+**Diagnosis trap that amplifies #1.**
+
+When the session create fails with the empty 500 above, the session is still **partially created server-side** — it appears in UI Server Administration and blocks subsequent creates with **409 "Session already exists"** until `SessionCleanupExpiration` (~6 minutes) passes. A retrying integration therefore sees an **alternating 500 / 409 pattern** that looks like a session-pool or concurrency problem and is very hard to trace back to a missing header.
+
+**Mitigation:** fix the `Accept` header (#1). If you see 500/409 alternation on 2026.1, check the headers before anything else; waiting out `SessionCleanupExpiration` clears the ghost.
+
+### 3. Session-create response field renamed: `SessionId` → `Id`
+
+`POST /api/ui/interactive/sessions/` returns the session identifier under **`Id`** on 2026.1; 2025.2 returned **`SessionId`**.
+
+**Mitigation:** read both (`data.get("Id") or data.get("SessionId")` / the C# equivalent) so one client works across versions.
+
+### 4. `PUT /v2/tab` no longer accepts `TabName`
+
+2026.1 binds **`PageName`** (PagePath structure) only; 2025.2 also tolerated `TabName` in the body. Requests still sending `TabName` stop working.
+
+```json
+PUT /api/ui/interactive/v2/tab
+{"WindowId": "{windowId}", "PageName": "TP_ITEMS"}
+```
+
+**Mitigation:** none needed if you follow the documented v2 shape — this repo has always documented `PageName` ([Interactive API § Changing Tabs](04-Interactive-API.md#changing-tabs)). Audit any legacy client for `TabName` in tab-change bodies.
+
+### 5. Silent false success: loading a nonexistent record returns `Status: 2` with an **empty window**
+
+**Data-integrity hazard.**
+
+On 2026.1, keying a window to a record that doesn't exist (e.g., setting `po_no` to a nonexistent PO) returns **`Status: 2`** and leaves the window **empty**. 2025.2 returned `Status: 0` for the same action. An integration that treats "not found" as `Status: 0` — or that doesn't gate on load status at all — will **silently proceed to write against an empty window**.
+
+**Mitigation (verified):** do not infer existence from the load status at all. Gate with an **existence pre-read** (OData or `POST /api/v2/transaction/get`) *before* opening/keying the window, and abort on no-match. Treat any non-Success load status as fatal.
+
+### 6. Silent false success: multi-field `/v2/change` drops fields on non-active tabs while returning `Status: 1`
+
+**Data-integrity hazard.**
+
+A single `PUT /v2/change` carrying multiple fields where at least one field belongs to a **tab that is not currently active** returns **`Status: 1` (Success)** while **silently not applying** that field. Observed live on 2026.1: a batched change partially applied, with one date field dropped, and nothing in the response indicated it.
+
+**Mitigation (verified):** write **one field per `/change` call**, activating each tab (`PUT /v2/tab`) before changing its fields, and check the status of every call. Then prove the result with a **read-back** — see [Verifying Writes](04-Interactive-API.md#verifying-writes-dont-trust-save-status-alone). A production run of 81 records using this pattern read back with zero silent drops.
+
+---
+
+## P21 25.2
+
+### `DatawindowName` is required in Interactive API change requests
+
+25.2 changed window data structures so `DatawindowName` is **required** in v2 change payloads — the 3-parameter form (TabName + FieldName + Value) stops working. Confirmed through 25.2.5776.1 and acknowledged by Epicor as a development bug; affected windows include Item, PO Receiving Group, Delivery List, Group Pick Ticket, ConvertPOToVoucher, Order Entry, Clippership Auto Shipping, and Doc Links.
+
+```json
+{"TabName": "FORM", "DatawindowName": "form", "FieldName": "field", "Value": "value"}
+```
+
+Full detail, affected-window credits, and C# SDK impact: [Interactive API § v1 vs v2 differences](04-Interactive-API.md#v1-vs-v2-api-differences) and the [Known Issues](04-Interactive-API.md#known-issues-and-workarounds) section.
+
+---
+
+## Reporting new breaking changes
+
+Found a behavior change during an upgrade? [Open an issue](https://github.com/mrwuss/p21-api-documentation/issues/new?template=bug-report.md) with the exact middleware versions (working and broken), a deterministic repro, and — for anything in the silent-false-success class — the read-back evidence. Entries are added here only after live verification on both sides of the version line.
+
+## Related
+
+- [Interactive API](04-Interactive-API.md) — the surface most version changes hit
+- [Error Handling](06-Error-Handling.md) — symptom → cause tables
+- [Session Pool Troubleshooting](07-Session-Pool-Troubleshooting.md) — the other source of "mystery" interactive failures
+- [Changelog](10-Changelog.md) — documentation change history and standing alerts

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -65,11 +65,11 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 | Item: **primary bin / primary supplier** at a location | [set-primary-bin-supplier](recipes/set-primary-bin-supplier.md) | [03 § Item Service](03-Transaction-API.md#item-service----nested-location-edits) |
 | **Create warehouse bins** | [create-bins](recipes/create-bins.md) | [03 § BinLocation Service](03-Transaction-API.md#binlocation-service----creating-bins) |
 | **Sales price pages** (codes, breaks, field order) | — | [08 SalesPricePage Codes](08-SalesPricePage-Codes.md) |
-| Customers / vendors / contacts / addresses (simple CRUD) | [05 § CRUD Operations](05-Entity-API.md#crud-operations) |
+| Customers / vendors / contacts / addresses (simple CRUD) | — | [05 § CRUD Operations](05-Entity-API.md#crud-operations) |
 | Read/create **sales orders via REST** (`/api/sales/orders`) | — | [05 § Other REST Endpoint Families](05-Entity-API.md#other-rest-endpoint-families) |
-| Inventory items: read / create / update locations | [11 § Reading Items](11-Inventory-REST-API.md#reading-items) · [11 § Minimum Create Payload](11-Inventory-REST-API.md#minimum-create-payload) · [11 § Updating Existing Location Fields](11-Inventory-REST-API.md#updating-existing-location-fields) |
+| Inventory items: read / create / update locations | — | [11 § Reading Items](11-Inventory-REST-API.md#reading-items) · [11 § Minimum Create Payload](11-Inventory-REST-API.md#minimum-create-payload) · [11 § Updating Existing Location Fields](11-Inventory-REST-API.md#updating-existing-location-fields) |
 | Customer-specific **price + availability** lookup | — | [11 § Pricing Endpoints](11-Inventory-REST-API.md#pricing-endpoints) |
-| User-defined tables (UDT) rows | [13 § Insert](13-UDT-Service-API.md#insert) · [13 § Update](13-UDT-Service-API.md#update) · [13 § Delete](13-UDT-Service-API.md#delete) |
+| User-defined tables (UDT) rows | — | [13 § Insert](13-UDT-Service-API.md#insert) · [13 § Update](13-UDT-Service-API.md#update) · [13 § Delete](13-UDT-Service-API.md#delete) |
 
 ## Drive a window (Interactive API)
 
@@ -118,6 +118,7 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 
 | Task | Where |
 |------|-------|
+| **Upgrading P21? What breaks between versions** | [14 Breaking Changes](14-Breaking-Changes.md) — 2026.1 (Accept-header 500, ghost sessions, silent-false-success hazards) · 25.2 (DatawindowName) |
 | Error catalog by API | [06 Error Handling](06-Error-Handling.md) (per-API sections) |
 | Quick symptom → cause table | [06 § Common Issues Quick Reference](06-Error-Handling.md#common-issues-quick-reference) |
 | Auth failures | [06 § Authentication Errors](06-Error-Handling.md#authentication-errors) |
@@ -144,4 +145,5 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 | [11-Inventory-REST-API](11-Inventory-REST-API.md) | `/api/inventory/parts` read/append/update | large |
 | [12-Production-Labor-API](12-Production-Labor-API.md) | Production services + end-to-end lifecycle | large |
 | [13-UDT-Service-API](13-UDT-Service-API.md) | User-defined table CRUD | large |
+| [14-Breaking-Changes](14-Breaking-Changes.md) | P21 version breaking-change registry (check before upgrading) | small — read whole |
 | [`definitions/`](../definitions/README.md) | Full-field service definition JSONs (every DataElement, field, key, label + payload template) | load one file per service |

--- a/docs/html/00-Authentication.html
+++ b/docs/html/00-Authentication.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>
@@ -969,6 +970,9 @@
 </ol>
 <hr />
 <h2 id="using-the-token">Using the Token</h2>
+<blockquote>
+<p><strong><code>Accept: application/json</code> is not optional on 2026.1.</strong> Every example in this documentation sends it; on P21 <strong>2026.1</strong> the Interactive API returns an <strong>empty HTTP 500</strong> for requests without it (including the <code>Accept: */*</code> default of httpx and .NET HttpClient), and the failed session create leaves a ghost session behind. See <a href="14-Breaking-Changes.html#p21-20261">Breaking Changes § 2026.1</a>.</p>
+</blockquote>
 <p>Include the token in the <code>Authorization</code> header for all API requests:</p>
 <div class="highlight"><pre><span></span><code><span class="nf">GET</span> <span class="nn">/odataservice/odata/table/supplier</span> <span class="kr">HTTP</span><span class="o">/</span><span class="m">1.1</span>
 <span class="na">Host</span><span class="o">:</span> <span class="l">play.p21server.com</span>

--- a/docs/html/01-API-Selection-Guide.html
+++ b/docs/html/01-API-Selection-Guide.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/02-OData-API.html
+++ b/docs/html/02-OData-API.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/04-Interactive-API.html
+++ b/docs/html/04-Interactive-API.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>
@@ -2994,6 +2995,7 @@ Row 5 selected → Detail shows row 4 (1 behind)
 <hr />
 <h2 id="v1-vs-v2-api-differences">v1 vs v2 API Differences</h2>
 <blockquote>
+<p><strong>Upgrading P21?</strong> Version-specific middleware changes that break interactive integrations (25.2's required <code>DatawindowName</code>, 2026.1's Accept-header 500 / ghost sessions / <code>SessionId</code>→<code>Id</code> / silent-false-success hazards) are cataloged in <a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a>.</p>
 <p><strong>Important:</strong> Some P21 servers only support v2 endpoints (v1 returns 404). Always try v2 first.</p>
 </blockquote>
 <h3 id="summary-table">Summary Table</h3>

--- a/docs/html/05-Entity-API.html
+++ b/docs/html/05-Entity-API.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/06-Error-Handling.html
+++ b/docs/html/06-Error-Handling.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>
@@ -423,6 +424,8 @@
 </ul>
 </li>
 <li><a href="#interactive-api-errors">Interactive API Errors</a><ul>
+<li><a href="#empty-http-500-on-every-interactive-call-20261">Empty HTTP 500 on Every Interactive Call (2026.1)</a></li>
+<li><a href="#alternating-500-409-session-already-exists-20261">Alternating 500 / 409 "Session already exists" (2026.1)</a></li>
 <li><a href="#session-errors">Session Errors</a></li>
 <li><a href="#window-errors">Window Errors</a></li>
 <li><a href="#422-400-wrong-query-parameter">422 / 400 - Wrong Query Parameter</a></li>
@@ -741,6 +744,11 @@
 <p>See <a href="07-Session-Pool-Troubleshooting.html">Session Pool Troubleshooting</a> for details.</p>
 <hr />
 <h2 id="interactive-api-errors">Interactive API Errors</h2>
+<h3 id="empty-http-500-on-every-interactive-call-20261">Empty HTTP 500 on Every Interactive Call (2026.1)</h3>
+<p>On P21 <strong>2026.1</strong>, any interactive request without an explicit <code>Accept: application/json</code> header — including the <code>Accept: */*</code> default of httpx and .NET HttpClient — returns an <strong>empty-body HTTP 500</strong>. The same request with the header succeeds; 2025.2 is unaffected.</p>
+<p><strong>Solution</strong>: send <code>Accept: application/json</code> on every request. Details: <a href="14-Breaking-Changes.html#p21-20261">Breaking Changes § 2026.1</a>.</p>
+<h3 id="alternating-500-409-session-already-exists-20261">Alternating 500 / 409 "Session already exists" (2026.1)</h3>
+<p>The failed session create above still <strong>half-creates the session</strong> server-side, so retries hit 409 until <code>SessionCleanupExpiration</code> (~6 min). If you see this pattern on 2026.1, check the <code>Accept</code> header first — it is not a session-pool problem. Details: <a href="14-Breaking-Changes.html#p21-20261">Breaking Changes § 2026.1</a>.</p>
 <h3 id="session-errors">Session Errors</h3>
 <p><strong>Session Not Found</strong></p>
 <div class="highlight"><pre><span></span><code><span class="p">{</span>

--- a/docs/html/07-Session-Pool-Troubleshooting.html
+++ b/docs/html/07-Session-Pool-Troubleshooting.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/08-SalesPricePage-Codes.html
+++ b/docs/html/08-SalesPricePage-Codes.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/09-Batch-Processing-Patterns.html
+++ b/docs/html/09-Batch-Processing-Patterns.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/10-Changelog.html
+++ b/docs/html/10-Changelog.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>
@@ -398,6 +399,8 @@
             <div class="page-toc" id="page-toc">
                 <div class="toc">
 <ul>
+<li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-07-10-v120">2026-07-10 — v1.2.0</a></li>
 <li><a href="#2026-07-10-v111">2026-07-10 — v1.1.1</a></li>
 <li><a href="#2026-07-10-v110">2026-07-10 — v1.1.0</a></li>
 <li><a href="#2026-07-10-v100">2026-07-10 — v1.0.0</a></li>
@@ -439,6 +442,19 @@
 <hr />
 <p>All notable changes to this documentation project are listed below, grouped by date. This project uses <a href="https://www.conventionalcommits.org/">Conventional Commits</a>.</p>
 <hr />
+<h2 id="p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</h2>
+<blockquote>
+<p>Standing alerts for P21 <strong>platform</strong> version changes that break or silently corrupt API integrations — maintained in <a href="14-Breaking-Changes.html"><strong>P21 Breaking Changes by Version</strong></a>. Check before any upgrade.</p>
+<ul>
+<li><strong>2026.1</strong> — Interactive endpoints return an <strong>empty HTTP 500 without <code>Accept: application/json</code></strong> (httpx/.NET defaults break), and the failed session create leaves a <strong>ghost session</strong> (409 until cleanup); <code>SessionId</code> → <code>Id</code>; <code>TabName</code> no longer accepted on <code>/v2/tab</code>; <strong>two silent-false-success hazards</strong> (nonexistent record loads as <code>Status: 2</code> + empty window; multi-field changes drop non-active-tab fields while reporting Success). Verified 2026.1.5873.1 vs 2025.2.5855.0. → <a href="14-Breaking-Changes.html#p21-20261">details</a></li>
+<li><strong>25.2</strong> — <code>DatawindowName</code> <strong>required</strong> in Interactive change requests (3-param form stops working). → <a href="14-Breaking-Changes.html#p21-252">details</a></li>
+</ul>
+</blockquote>
+<hr />
+<h2 id="2026-07-10-v120">2026-07-10 — v1.2.0</h2>
+<ul>
+<li><strong>feat:</strong> New <strong><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></strong> registry (doc 14) — a first-class page cataloging middleware changes that break or silently corrupt integrations, checked before upgrades. Launches with <strong>2026.1</strong> (verified 2026.1.5873.1 vs 2025.2.5855.0 during upgrade validation; reported to Epicor): Interactive endpoints return an <strong>empty HTTP 500 without <code>Accept: application/json</code></strong> (httpx/.NET <code>Accept: */*</code> defaults fail) with a <strong>ghost-session</strong> side effect (409 "Session already exists" until cleanup → alternating 500/409); session-create response renamed <code>SessionId</code> → <code>Id</code>; <code>/v2/tab</code> binds <code>PageName</code> only; and two <strong>silent-false-success hazards</strong> — nonexistent record loads return <code>Status: 2</code> with an empty window (was <code>Status: 0</code>), and multi-field <code>/v2/change</code> silently drops non-active-tab fields while returning <code>Status: 1</code> — each with its verified mitigation (existence pre-read; one-field-per-change-per-active-tab + read-back). The 25.2 <code>DatawindowName</code> change is consolidated into the same registry. Standing <strong>Breaking-Change Alerts</strong> header added to the top of this changelog; cross-references added in 00/04/06/INDEX/CLAUDE.md — Fixes #96 — <em>@mrwuss</em></li>
+</ul>
 <h2 id="2026-07-10-v111">2026-07-10 — v1.1.1</h2>
 <p>End-to-end alignment audit: nine area agents checked <strong>every tracked file</strong> against the session's live-verified findings; ~118 findings triaged and fixed in one pass (PR #94). Highlights:</p>
 <ul>

--- a/docs/html/11-Inventory-REST-API.html
+++ b/docs/html/11-Inventory-REST-API.html
@@ -374,6 +374,7 @@
         <li class="active"><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/12-Production-Labor-API.html
+++ b/docs/html/12-Production-Labor-API.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li class="active"><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/13-UDT-Service-API.html
+++ b/docs/html/13-UDT-Service-API.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li class="active"><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/14-Breaking-Changes.html
+++ b/docs/html/14-Breaking-Changes.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Home - P21 API Documentation</title>
+    <title>P21 Breaking Changes by Version - P21 API Documentation</title>
     <style>
         /* ===== Reset & Base ===== */
         * { box-sizing: border-box; }
@@ -374,7 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
-        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
+        <li class="active"><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>
@@ -397,212 +397,116 @@
         <div class="sidebar-section page-toc-section">
             <div class="sidebar-section-title">On This Page</div>
             <div class="page-toc" id="page-toc">
-                <ul>
-<li><a href="#getting-started">Getting Started</a></li>
-<li><a href="#api-reference">API Reference</a></li>
-<li><a href="#recipes">Recipes</a></li>
-<li><a href="#troubleshooting-reference">Troubleshooting &amp; Reference</a></li>
+                <div class="toc">
+<ul>
+<li><a href="#overview">Overview</a></li>
+<li><a href="#p21-20261">P21 2026.1</a><ul>
+<li><a href="#1-interactive-api-returns-an-empty-http-500-without-an-explicit-accept-applicationjson-header">1. Interactive API returns an empty HTTP 500 without an explicit Accept: application/json header</a></li>
+<li><a href="#2-ghost-sessions-the-failed-create-still-half-creates-the-session-alternating-500409">2. Ghost sessions: the failed create still half-creates the session (alternating 500/409)</a></li>
+<li><a href="#3-session-create-response-field-renamed-sessionid-id">3. Session-create response field renamed: SessionId → Id</a></li>
+<li><a href="#4-put-v2tab-no-longer-accepts-tabname">4. PUT /v2/tab no longer accepts TabName</a></li>
+<li><a href="#5-silent-false-success-loading-a-nonexistent-record-returns-status-2-with-an-empty-window">5. Silent false success: loading a nonexistent record returns Status: 2 with an empty window</a></li>
+<li><a href="#6-silent-false-success-multi-field-v2change-drops-fields-on-non-active-tabs-while-returning-status-1">6. Silent false success: multi-field /v2/change drops fields on non-active tabs while returning Status: 1</a></li>
 </ul>
+</li>
+<li><a href="#p21-252">P21 25.2</a><ul>
+<li><a href="#datawindowname-is-required-in-interactive-api-change-requests">DatawindowName is required in Interactive API change requests</a></li>
+</ul>
+</li>
+<li><a href="#reporting-new-breaking-changes">Reporting new breaking changes</a></li>
+<li><a href="#related">Related</a></li>
+</ul>
+</div>
+
             </div>
         </div>
     </nav>
 
     <main class="content">
         <button class="print-btn" onclick="window.print()">Print / Save as PDF</button>
-
-<h1 id="p21-api-documentation">P21 API Documentation</h1>
-<p class="index-subtitle">Comprehensive guides and examples for Epicor Prophet 21 APIs</p>
+<h1 id="p21-breaking-changes-by-version">P21 Breaking Changes by Version</h1>
 <blockquote>
-<strong>Disclaimer:</strong> This is unofficial, community-created documentation.
-It is not affiliated with, endorsed by, or supported by Epicor Software Corporation.
-All trademarks are property of their respective owners. Use at your own risk.
+<p><strong>Disclaimer:</strong> This is unofficial, community-created documentation for Epicor Prophet 21 APIs. It is not affiliated with, endorsed by, or supported by Epicor Software Corporation. All product names, trademarks, and registered trademarks are property of their respective owners. Use at your own risk.</p>
 </blockquote>
+<hr />
+<h2 id="overview">Overview</h2>
+<p>A version-indexed registry of P21 middleware changes that <strong>break or silently corrupt existing API integrations</strong>. Every entry here was found the hard way during a real upgrade validation and verified against live tenants — including confirming the behavior does <em>not</em> exist on the prior version. Check this page <strong>before</strong> any P21 upgrade, and re-test the listed surfaces on your own test tenant first.</p>
+<table>
+<thead>
+<tr>
+<th>Version</th>
+<th>Entries</th>
+<th>Severity</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#p21-20261">2026.1</a></td>
+<td>Empty 500 without <code>Accept</code> header · ghost sessions (500/409) · <code>SessionId</code> → <code>Id</code> · <code>TabName</code> no longer accepted on <code>/v2/tab</code> · <strong>two silent-false-success hazards</strong></td>
+<td>High — one hard break, two data-integrity hazards</td>
+</tr>
+<tr>
+<td><a href="#p21-252">25.2</a></td>
+<td><code>DatawindowName</code> required in change requests</td>
+<td>High — hard break for 3-param change calls</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="p21-20261">P21 2026.1</h2>
+<p>All findings verified on <strong>2026.1.5873.1</strong> (self-hosted middleware, test tenant) during upgrade validation, June 2026. <strong>None reproduce on 2025.2.5855.0</strong> with identical requests. The empty-500 defect has been reported to Epicor; the contract changes are awaiting written confirmation of intent. Re-verify against your own 2026.1 tenant before relying on the details.</p>
+<h3 id="1-interactive-api-returns-an-empty-http-500-without-an-explicit-accept-applicationjson-header">1. Interactive API returns an empty HTTP 500 without an explicit <code>Accept: application/json</code> header</h3>
+<p><strong>Hard break — every interactive endpoint.</strong></p>
+<p>On 2026.1, any request to <code>/uiserver0/api/ui/interactive/...</code> that omits the <code>Accept</code> header — or sends <code>Accept: */*</code>, which is the <strong>default for most HTTP libraries, including Python <code>httpx</code> and .NET <code>HttpClient</code></strong> — fails with an <strong>empty-body HTTP 500</strong>. The identical request with <code>Accept: application/json</code> added succeeds. 2025.2 falls back to a default representation instead of failing.</p>
+<div class="highlight"><pre><span></span><code><span class="nf">POST</span> <span class="nn">{uiserver}/api/ui/interactive/sessions/</span> <span class="kr">HTTP</span><span class="o">/</span><span class="m">1.1</span>
+<span class="na">Authorization</span><span class="o">:</span> <span class="l">Bearer {token}</span>
+<span class="na">Content-Type</span><span class="o">:</span> <span class="l">application/json</span>
+<span class="na">Accept</span><span class="o">:</span> <span class="l">application/json        &lt;-- REQUIRED on 2026.1; omit it and you get an empty 500</span>
 
-<h2 id="getting-started">Getting Started</h2>
-<div class="index-grid">
-<a href="task-index.html" class="index-card">
-            <h3>Task Index</h3>
-            <p>"I want to..." routing map — jump straight to the exact section for your task instead of reading whole guides.</p>
-        </a>
-<a href="00-Authentication.html" class="index-card">
-            <h3>Authentication</h3>
-            <p>Token generation, credentials vs consumer keys, V1 and V2 endpoints, and token refresh patterns.</p>
-        </a>
-<a href="01-API-Selection-Guide.html" class="index-card">
-            <h3>API Selection Guide</h3>
-            <p>Decision tree and comparison table to help you choose the right API for your use case.</p>
-        </a>
-</div>
+<span class="p">{</span><span class="nt">&quot;ResponseWindowHandlingEnabled&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">}</span>
+</code></pre></div>
 
-<h2 id="api-reference">API Reference</h2>
-<div class="index-grid">
-<a href="02-OData-API.html" class="index-card">
-            <h3>OData API <span class="badge badge-read">READ</span></h3>
-            <p>Query any P21 table using standard OData v3 protocol. Filtering, pagination, and complex queries.</p>
-        </a>
-<a href="03-Transaction-API.html" class="index-card">
-            <h3>Transaction API <span class="badge badge-write">WRITE</span></h3>
-            <p>Stateless bulk operations for creating and updating records. Service discovery and async operations.</p>
-        </a>
-<a href="04-Interactive-API.html" class="index-card">
-            <h3>Interactive API <span class="badge badge-both">READ/WRITE</span></h3>
-            <p>Stateful window interactions with full business logic. Sessions, windows, and response handling.</p>
-        </a>
-<a href="05-Entity-API.html" class="index-card">
-            <h3>Entity API <span class="badge badge-both">CRUD</span></h3>
-            <p>Simple REST operations on customers, vendors, contacts, and addresses.</p>
-        </a>
-<a href="11-Inventory-REST-API.html" class="index-card">
-            <h3>Inventory REST API <span class="badge badge-both">CRUD</span></h3>
-            <p>Inventory item CRUD and multi-company workflows. Read inv_loc data, append locations and suppliers.</p>
-        </a>
-<a href="12-Production-Labor-API.html" class="index-card">
-            <h3>Production & Labor API <span class="badge badge-both">READ/WRITE</span></h3>
-            <p>Production orders, labor hours, time entry, and the end-to-end production lifecycle.</p>
-        </a>
-<a href="13-UDT-Service-API.html" class="index-card">
-            <h3>UDT Service API <span class="badge badge-both">CRUD</span></h3>
-            <p>Insert, update, and delete rows in user-defined tables via /udtservice/api/udtdata/.</p>
-        </a>
-</div>
+<p><strong>Mitigation:</strong> send <code>Accept: application/json</code> on <strong>every</strong> P21 request, ideally forced in one shared header builder rather than per call site. Every example in this repo already does this — the consequence of omitting it is what changed.</p>
+<h3 id="2-ghost-sessions-the-failed-create-still-half-creates-the-session-alternating-500409">2. Ghost sessions: the failed create still half-creates the session (alternating 500/409)</h3>
+<p><strong>Diagnosis trap that amplifies #1.</strong></p>
+<p>When the session create fails with the empty 500 above, the session is still <strong>partially created server-side</strong> — it appears in UI Server Administration and blocks subsequent creates with <strong>409 "Session already exists"</strong> until <code>SessionCleanupExpiration</code> (~6 minutes) passes. A retrying integration therefore sees an <strong>alternating 500 / 409 pattern</strong> that looks like a session-pool or concurrency problem and is very hard to trace back to a missing header.</p>
+<p><strong>Mitigation:</strong> fix the <code>Accept</code> header (#1). If you see 500/409 alternation on 2026.1, check the headers before anything else; waiting out <code>SessionCleanupExpiration</code> clears the ghost.</p>
+<h3 id="3-session-create-response-field-renamed-sessionid-id">3. Session-create response field renamed: <code>SessionId</code> → <code>Id</code></h3>
+<p><code>POST /api/ui/interactive/sessions/</code> returns the session identifier under <strong><code>Id</code></strong> on 2026.1; 2025.2 returned <strong><code>SessionId</code></strong>.</p>
+<p><strong>Mitigation:</strong> read both (<code>data.get("Id") or data.get("SessionId")</code> / the C# equivalent) so one client works across versions.</p>
+<h3 id="4-put-v2tab-no-longer-accepts-tabname">4. <code>PUT /v2/tab</code> no longer accepts <code>TabName</code></h3>
+<p>2026.1 binds <strong><code>PageName</code></strong> (PagePath structure) only; 2025.2 also tolerated <code>TabName</code> in the body. Requests still sending <code>TabName</code> stop working.</p>
+<div class="highlight"><pre><span></span><code><span class="err">PUT</span><span class="w"> </span><span class="err">/api/ui/i</span><span class="kc">ntera</span><span class="err">c</span><span class="kc">t</span><span class="err">ive/v</span><span class="mi">2</span><span class="err">/</span><span class="kc">ta</span><span class="err">b</span>
+<span class="p">{</span><span class="nt">&quot;WindowId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;{windowId}&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;PageName&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;TP_ITEMS&quot;</span><span class="p">}</span>
+</code></pre></div>
 
-<h2 id="recipes">Recipes — Copy-and-Run Tasks</h2>
-<p>Self-contained task pages: one task, one page — the complete payload, a full runnable example in Python and C#, and every verified gotcha.</p>
-<div class="index-grid">
-<a href="recipes/README.html" class="index-card">
-            <h3>Recipes Overview</h3>
-            <p>How the cookbook works: conventions, shared auth helper, dry-run and verify rules.</p>
-        </a>
-<a href="recipes/create-bins.html" class="index-card">
-            <h3>Create Bins (Bulk)</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/create-sales-order.html" class="index-card">
-            <h3>Create a Sales Order</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/edit-contract-bins.html" class="index-card">
-            <h3>Edit Contract Bin Quantities</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/generate-pick-ticket-pdf.html" class="index-card">
-            <h3>Generate Pick Ticket and PO PDFs</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/inventory-adjustment.html" class="index-card">
-            <h3>Adjust On-Hand Quantity (Write-Off)</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/order-with-assembly.html" class="index-card">
-            <h3>Order with an Assembly Line</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/production-order-runbook.html" class="index-card">
-            <h3>Production Order Runbook — Create to Invoice</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/record-labor-time.html" class="index-card">
-            <h3>Record Labor Time on a Production Order</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/set-primary-bin-supplier.html" class="index-card">
-            <h3>Set an Item's Primary Bin or Primary Supplier at a Location</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-<a href="recipes/update-contract-lines.html" class="index-card">
-            <h3>Update Contract Lines</h3>
-            <p>Complete payload, runnable Python & C#, verified gotchas.</p>
-        </a>
-</div>
+<p><strong>Mitigation:</strong> none needed if you follow the documented v2 shape — this repo has always documented <code>PageName</code> (<a href="04-Interactive-API.html#changing-tabs">Interactive API § Changing Tabs</a>). Audit any legacy client for <code>TabName</code> in tab-change bodies.</p>
+<h3 id="5-silent-false-success-loading-a-nonexistent-record-returns-status-2-with-an-empty-window">5. Silent false success: loading a nonexistent record returns <code>Status: 2</code> with an <strong>empty window</strong></h3>
+<p><strong>Data-integrity hazard.</strong></p>
+<p>On 2026.1, keying a window to a record that doesn't exist (e.g., setting <code>po_no</code> to a nonexistent PO) returns <strong><code>Status: 2</code></strong> and leaves the window <strong>empty</strong>. 2025.2 returned <code>Status: 0</code> for the same action. An integration that treats "not found" as <code>Status: 0</code> — or that doesn't gate on load status at all — will <strong>silently proceed to write against an empty window</strong>.</p>
+<p><strong>Mitigation (verified):</strong> do not infer existence from the load status at all. Gate with an <strong>existence pre-read</strong> (OData or <code>POST /api/v2/transaction/get</code>) <em>before</em> opening/keying the window, and abort on no-match. Treat any non-Success load status as fatal.</p>
+<h3 id="6-silent-false-success-multi-field-v2change-drops-fields-on-non-active-tabs-while-returning-status-1">6. Silent false success: multi-field <code>/v2/change</code> drops fields on non-active tabs while returning <code>Status: 1</code></h3>
+<p><strong>Data-integrity hazard.</strong></p>
+<p>A single <code>PUT /v2/change</code> carrying multiple fields where at least one field belongs to a <strong>tab that is not currently active</strong> returns <strong><code>Status: 1</code> (Success)</strong> while <strong>silently not applying</strong> that field. Observed live on 2026.1: a batched change partially applied, with one date field dropped, and nothing in the response indicated it.</p>
+<p><strong>Mitigation (verified):</strong> write <strong>one field per <code>/change</code> call</strong>, activating each tab (<code>PUT /v2/tab</code>) before changing its fields, and check the status of every call. Then prove the result with a <strong>read-back</strong> — see <a href="04-Interactive-API.html#verifying-writes-dont-trust-save-status-alone">Verifying Writes</a>. A production run of 81 records using this pattern read back with zero silent drops.</p>
+<hr />
+<h2 id="p21-252">P21 25.2</h2>
+<h3 id="datawindowname-is-required-in-interactive-api-change-requests"><code>DatawindowName</code> is required in Interactive API change requests</h3>
+<p>25.2 changed window data structures so <code>DatawindowName</code> is <strong>required</strong> in v2 change payloads — the 3-parameter form (TabName + FieldName + Value) stops working. Confirmed through 25.2.5776.1 and acknowledged by Epicor as a development bug; affected windows include Item, PO Receiving Group, Delivery List, Group Pick Ticket, ConvertPOToVoucher, Order Entry, Clippership Auto Shipping, and Doc Links.</p>
+<div class="highlight"><pre><span></span><code><span class="p">{</span><span class="nt">&quot;TabName&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;FORM&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;DatawindowName&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;form&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;FieldName&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;field&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;Value&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;value&quot;</span><span class="p">}</span>
+</code></pre></div>
 
-<h2 id="troubleshooting-reference">Troubleshooting &amp; Reference</h2>
-<div class="index-grid">
-<a href="14-Breaking-Changes.html" class="index-card">
-            <h3>P21 Breaking Changes</h3>
-            <p>Version-indexed registry of P21 upgrade changes that break or silently corrupt integrations. Check before upgrading.</p>
-        </a>
-<a href="06-Error-Handling.html" class="index-card">
-            <h3>Error Handling</h3>
-            <p>HTTP status codes, API-specific errors, Python error handling patterns, and debugging tips.</p>
-        </a>
-<a href="07-Session-Pool-Troubleshooting.html" class="index-card">
-            <h3>Session Pool Issues</h3>
-            <p>Diagnosing and fixing Transaction API session pool contamination and related problems.</p>
-        </a>
-<a href="08-SalesPricePage-Codes.html" class="index-card">
-            <h3>SalesPricePage Codes</h3>
-            <p>Dropdown code mappings for the Sales Price Page window in the Interactive API.</p>
-        </a>
-<a href="09-Batch-Processing-Patterns.html" class="index-card">
-            <h3>Batch Processing Patterns</h3>
-            <p>Production patterns for bulk operations: session batching, error recovery, and async client.</p>
-        </a>
-<a href="10-Changelog.html" class="index-card">
-            <h3>Changelog</h3>
-            <p>Complete history of changes, additions, and contributors to this documentation project.</p>
-        </a>
-</div>
-
-<hr>
-<p style="text-align: center; color: #666;">
-<a href="https://github.com/mrwuss/p21-api-documentation">View on GitHub</a>
-</p>
-
-<style>
-.index-subtitle {
-    font-size: 1.15em;
-    color: #555;
-    margin-top: -20px;
-    margin-bottom: 30px;
-}
-.index-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 16px;
-    margin-bottom: 30px;
-}
-.index-card {
-    display: block;
-    background: #f8f9fa;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    padding: 20px;
-    text-decoration: none;
-    color: inherit;
-    transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
-}
-.index-card:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    border-color: #2874a6;
-}
-.index-card h3 {
-    color: #1a5276;
-    margin: 0 0 8px 0;
-    font-size: 1.1em;
-    border: none;
-    padding: 0;
-}
-.index-card p {
-    color: #666;
-    margin: 0;
-    font-size: 0.9em;
-    line-height: 1.5;
-}
-.badge {
-    display: inline-block;
-    padding: 2px 7px;
-    border-radius: 3px;
-    font-size: 0.7em;
-    font-weight: bold;
-    margin-left: 6px;
-    vertical-align: middle;
-}
-.badge-read { background: #3498db; color: white; }
-.badge-write { background: #e74c3c; color: white; }
-.badge-both { background: #9b59b6; color: white; }
-</style>
-
+<p>Full detail, affected-window credits, and C# SDK impact: <a href="04-Interactive-API.html#v1-vs-v2-api-differences">Interactive API § v1 vs v2 differences</a> and the <a href="04-Interactive-API.html#known-issues-and-workarounds">Known Issues</a> section.</p>
+<hr />
+<h2 id="reporting-new-breaking-changes">Reporting new breaking changes</h2>
+<p>Found a behavior change during an upgrade? <a href="https://github.com/mrwuss/p21-api-documentation/issues/new?template=bug-report.md">Open an issue</a> with the exact middleware versions (working and broken), a deterministic repro, and — for anything in the silent-false-success class — the read-back evidence. Entries are added here only after live verification on both sides of the version line.</p>
+<h2 id="related">Related</h2>
+<ul>
+<li><a href="04-Interactive-API.html">Interactive API</a> — the surface most version changes hit</li>
+<li><a href="06-Error-Handling.html">Error Handling</a> — symptom → cause tables</li>
+<li><a href="07-Session-Pool-Troubleshooting.html">Session Pool Troubleshooting</a> — the other source of "mystery" interactive failures</li>
+<li><a href="10-Changelog.html">Changelog</a> — documentation change history and standing alerts</li>
+</ul>
     </main>
 
     <script>

--- a/docs/html/recipes/README.html
+++ b/docs/html/recipes/README.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/create-bins.html
+++ b/docs/html/recipes/create-bins.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/create-sales-order.html
+++ b/docs/html/recipes/create-sales-order.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/edit-contract-bins.html
+++ b/docs/html/recipes/edit-contract-bins.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/generate-pick-ticket-pdf.html
+++ b/docs/html/recipes/generate-pick-ticket-pdf.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/inventory-adjustment.html
+++ b/docs/html/recipes/inventory-adjustment.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/order-with-assembly.html
+++ b/docs/html/recipes/order-with-assembly.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/production-order-runbook.html
+++ b/docs/html/recipes/production-order-runbook.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/record-labor-time.html
+++ b/docs/html/recipes/record-labor-time.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/set-primary-bin-supplier.html
+++ b/docs/html/recipes/set-primary-bin-supplier.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/recipes/update-contract-lines.html
+++ b/docs/html/recipes/update-contract-lines.html
@@ -374,6 +374,7 @@
         <li><a href="../11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="../12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="../13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="../14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li><a href="../task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>

--- a/docs/html/task-index.html
+++ b/docs/html/task-index.html
@@ -374,6 +374,7 @@
         <li><a href="11-Inventory-REST-API.html">Inventory REST API</a></li>
         <li><a href="12-Production-Labor-API.html">Production Order & Labor Hour APIs</a></li>
         <li><a href="13-UDT-Service-API.html">User Defined Tables (UDT) Service API</a></li>
+        <li><a href="14-Breaking-Changes.html">P21 Breaking Changes by Version</a></li>
         <li class="active"><a href="task-index.html">Task Index — Find the Right Section Fast</a></li>
             </ul>
         </div>
@@ -631,8 +632,8 @@
 </tr>
 <tr>
 <td>Customers / vendors / contacts / addresses (simple CRUD)</td>
+<td>—</td>
 <td><a href="05-Entity-API.html#crud-operations">05 § CRUD Operations</a></td>
-<td></td>
 </tr>
 <tr>
 <td>Read/create <strong>sales orders via REST</strong> (<code>/api/sales/orders</code>)</td>
@@ -641,8 +642,8 @@
 </tr>
 <tr>
 <td>Inventory items: read / create / update locations</td>
+<td>—</td>
 <td><a href="11-Inventory-REST-API.html#reading-items">11 § Reading Items</a> · <a href="11-Inventory-REST-API.html#minimum-create-payload">11 § Minimum Create Payload</a> · <a href="11-Inventory-REST-API.html#updating-existing-location-fields">11 § Updating Existing Location Fields</a></td>
-<td></td>
 </tr>
 <tr>
 <td>Customer-specific <strong>price + availability</strong> lookup</td>
@@ -651,8 +652,8 @@
 </tr>
 <tr>
 <td>User-defined tables (UDT) rows</td>
+<td>—</td>
 <td><a href="13-UDT-Service-API.html#insert">13 § Insert</a> · <a href="13-UDT-Service-API.html#update">13 § Update</a> · <a href="13-UDT-Service-API.html#delete">13 § Delete</a></td>
-<td></td>
 </tr>
 </tbody>
 </table>
@@ -811,6 +812,10 @@
 </thead>
 <tbody>
 <tr>
+<td><strong>Upgrading P21? What breaks between versions</strong></td>
+<td><a href="14-Breaking-Changes.html">14 Breaking Changes</a> — 2026.1 (Accept-header 500, ghost sessions, silent-false-success hazards) · 25.2 (DatawindowName)</td>
+</tr>
+<tr>
 <td>Error catalog by API</td>
 <td><a href="06-Error-Handling.html">06 Error Handling</a> (per-API sections)</td>
 </tr>
@@ -912,6 +917,11 @@
 <td><a href="13-UDT-Service-API.html">13-UDT-Service-API</a></td>
 <td>User-defined table CRUD</td>
 <td>large</td>
+</tr>
+<tr>
+<td><a href="14-Breaking-Changes.html">14-Breaking-Changes</a></td>
+<td>P21 version breaking-change registry (check before upgrading)</td>
+<td>small — read whole</td>
 </tr>
 <tr>
 <td><a href="https://github.com/mrwuss/p21-api-documentation/blob/master/definitions/README.md"><code>definitions/</code></a></td>

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -875,12 +875,13 @@ def generate_index_page():
         "11-Inventory-REST-API": ("Inventory REST API", "Inventory item CRUD and multi-company workflows. Read inv_loc data, append locations and suppliers.", "CRUD"),
         "12-Production-Labor-API": ("Production & Labor API", "Production orders, labor hours, time entry, and the end-to-end production lifecycle.", "READ/WRITE"),
         "13-UDT-Service-API": ("UDT Service API", "Insert, update, and delete rows in user-defined tables via /udtservice/api/udtdata/.", "CRUD"),
+        "14-Breaking-Changes": ("P21 Breaking Changes", "Version-indexed registry of P21 upgrade changes that break or silently corrupt integrations. Check before upgrading."),
     }
 
     # Build sections
     getting_started = ["INDEX", "00-Authentication", "01-API-Selection-Guide"]
     api_reference = ["02-OData-API", "03-Transaction-API", "04-Interactive-API", "05-Entity-API", "11-Inventory-REST-API", "12-Production-Labor-API", "13-UDT-Service-API"]
-    troubleshooting = ["06-Error-Handling", "07-Session-Pool-Troubleshooting", "08-SalesPricePage-Codes", "09-Batch-Processing-Patterns", "10-Changelog"]
+    troubleshooting = ["14-Breaking-Changes", "06-Error-Handling", "07-Session-Pool-Troubleshooting", "08-SalesPricePage-Codes", "09-Batch-Processing-Patterns", "10-Changelog"]
 
     def make_card(stem):
         info = page_info.get(stem, (stem, ""))


### PR DESCRIPTION
## Summary
First-class **Breaking Changes** page (doc 14), treated like every other doc — site page, landing card, sidebar, INDEX, README, CLAUDE.md — plus a standing **⚠ Breaking-Change Alerts** header at the top of the changelog (markdown and HTML).

Launches with the **2026.1** findings from upgrade validation (verified 2026.1.5873.1 vs 2025.2.5855.0; the 500 defect is filed with Epicor):
- Empty HTTP 500 on every interactive call without explicit `Accept: application/json` (httpx/.NET `*/*` defaults break)
- Ghost sessions: the failed create half-creates the session → alternating 500/409 until cleanup
- `SessionId` → `Id`; `/v2/tab` binds `PageName` only
- **Two silent-false-success hazards** with verified mitigations: nonexistent record loads return `Status: 2` + empty window (gate with an existence pre-read), and multi-field `/v2/change` drops non-active-tab fields while returning `Status: 1` (one field per call per active tab + read-back)

The 25.2 `DatawindowName` change is consolidated into the same registry. Cross-references added in 00/04/06. All links/anchors validated; full-site crawl 0 broken.

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQjYqVuAtgJscnhmNF78sE