### PR TITLE
docs: POST /api/sales/orders/ creates a sales order (contributed by @roblandham, 25.2)

### DIFF
--- a/docs/01-API-Selection-Guide.md
+++ b/docs/01-API-Selection-Guide.md
@@ -198,7 +198,7 @@ Some P21 servers only support v2 Interactive API endpoints. If you receive 404 e
 - You prefer stateless REST over Interactive API session management
 
 ### Don't Use When
-- You need orders — those live in the same REST API at `/api/sales/orders` (see [Other REST Endpoint Families](05-Entity-API.md#other-rest-endpoint-families))
+- You need orders — those live in the same REST API at `/api/sales/orders`, which reads *and* creates ([Other REST Endpoint Families](05-Entity-API.md#other-rest-endpoint-families) · [Creating an Order](05-Entity-API.md#creating-an-order-post-apisalesorders))
 - You need inventory items — use the [Inventory REST API](11-Inventory-REST-API.md) (`/api/inventory/parts`)
 - You need invoices, POs, or other business objects (no endpoint family found)
 - You need bulk operations (use Transaction API)

--- a/docs/05-Entity-API.md
+++ b/docs/05-Entity-API.md
@@ -1915,14 +1915,379 @@ The REST API exposes more than `/api/entity/` and `/api/inventory/parts`. Verifi
 | `GET /api/sales/orders/{order_no}` | 200 — ~70 top-level fields |
 | `GET /api/sales/orders/{order_no}/approve` | 405 — route exists; the middleware documents PUT for this action (PUT untested) |
 | `GET /api/sales/orders/?$query=...` | 500 with an unrecognized field name — list query syntax not yet discovered |
+| `POST /api/sales/orders/` | Creates an order — **trailing slash required**, lines nest under `Lines.list`. See [Creating an Order](#creating-an-order-post-apisalesorders) (community-verified on 25.2) |
 
-Writes and the approve action are **untested** — treat this family as read-verified only until documented further.
+The approve action and every other write on this family remain **untested**; order creation is the one write with a reported working payload, below.
+
+### Creating an Order (`POST /api/sales/orders/`)
+
+`/api/sales/orders/` is not read-only: the same URL accepts a **POST** whose body is a single order — header fields at the top level, lines nested inside. `GET /api/sales/orders/new` shows you the object's shape but says nothing about how to submit one, which is why this went undocumented for so long.
+
+> **Contributed and tested on P21 25.2 by [Rob Landham](https://github.com/roblandham) ([issue #108](https://github.com/mrwuss/p21-api-documentation/issues/108))** — the payload shape and both rules below are their findings, reproduced here as reported. They have **not** been re-verified on this repo's tenant, and the [open questions](#what-is-not-pinned-down-yet) at the end of this section list exactly what nobody has pinned down yet. Treat the field list as an example header, not a required-field spec: which fields your environment demands depends on its configuration.
+
+Two shape rules decide whether the call works at all.
+
+**1. The trailing slash is required.** `POST /api/sales/orders/` routes correctly; drop the slash and the request is not routed to the API. This is the write-side face of the [307 on list endpoints](#trailing-slash-on-list-endpoints) — except that on a POST you cannot paper over it with a redirect-following client and call it handled, because whether the body and method survive the hop is up to the client. Send the slash.
+
+**2. `Lines` is an object, not an array.** The lines go in an array under `Lines.list`. A top-level `Lines` array **fails** — this is the mistake the `/new` template does not protect you from, since it shows the container without explaining the nesting.
+
+#### Header fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `CustomerId` | string | P21 customer ID the order is placed against |
+| `CompanyId` | string | Company/branch code |
+| `LocationId` | string | Fulfilling location ID |
+| `Taker` | string | User/service account identifier that "took" the order |
+| `PromiseDate` | string (`YYYY-MM-DD`) | Promised ship/delivery date |
+| `TermsId` | string | Payment terms code (e.g. `NET30`) |
+| `ShipToId` | string | Ship-to record ID |
+| `ShipToName`, `ShipToAddress1`, `ShipToAddress2`, `ShipToCity`, `ShipToState`, `ZipCode`, `ShipToCountry` | string | Ship-to address fields — sent inline when `ShipToId` alone doesn't resolve the full address |
+| `ShipToEmail`, `ShipToPhone` | string | Ship-to contact details |
+| `SourceLocId` | string | Source location for the order |
+| `PoNo` | string | Customer PO number reference |
+| `Quote` | string (`"Y"`/`"N"`) | Whether this is a quote rather than a firm order |
+| `DeletedFlag` | string (`"Y"`/`"N"`) | Soft-delete flag — `"N"` for new orders |
+| `Lines` | object | Container wrapping the lines — **not** an array |
+| `Lines.list` | array | The line objects |
+
+#### Line fields (`Lines.list[]`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ItemId` | string | Item being ordered |
+| `UnitQuantity` | number | Quantity in `UnitOfMeasure` |
+| `UnitOfMeasure` | string | e.g. `EA` |
+| `UnitPrice` | number | Price per unit |
+| `TaxItem` | string (`"Y"`/`"N"`) | Whether the line is taxable |
+| `Delete` | string (`"Y"`/`"N"`) | `"N"` on a new line |
+
+Note the type split: quantities and prices are **JSON numbers** here, while the flags are `"Y"`/`"N"` **strings** — unlike the Transaction API, where every `Value` is a string.
+
+#### Example request body
+
+```json
+POST {base_url}/api/sales/orders/
+
+{
+    "CustomerId": "100198",
+    "CompanyId": "ACME",
+    "LocationId": "10",
+    "Taker": "JSMITH",
+    "PromiseDate": "2030-01-06",
+    "TermsId": "NET30",
+    "ShipToId": "200",
+    "ShipToName": "Acme Fulfillment Co",
+    "ShipToAddress1": "123 Example Street",
+    "ShipToAddress2": "Ste 100",
+    "ShipToCity": "Atlanta",
+    "ShipToState": "GA",
+    "ZipCode": "30000",
+    "ShipToCountry": "US",
+    "ShipToEmail": "orders@example.com",
+    "ShipToPhone": "000-000-0000",
+    "SourceLocId": "10",
+    "PoNo": "PO-TEST-001",
+    "Quote": "N",
+    "DeletedFlag": "N",
+    "Lines": {
+        "list": [
+            {
+                "ItemId": "WIDGET-001",
+                "UnitQuantity": 1,
+                "UnitOfMeasure": "EA",
+                "UnitPrice": 0.99,
+                "TaxItem": "N",
+                "Delete": "N"
+            }
+        ]
+    }
+}
+```
+
+#### Complete example
+
+The create response shape is unconfirmed (see [below](#what-is-not-pinned-down-yet)), so this program **prints the raw body** before trying to find an order number in it, and reads the order back when it finds one. Run it against a play tenant first — it writes a real order.
+
+<!-- tabs -->
+
+**Python:**
+```python
+"""Create a sales order through the REST API, then read it back."""
+import re
+
+import httpx
+
+# ---- EDIT THESE -----------------------------------------------------------
+BASE_URL = "https://play.p21server.com"   # your P21 server
+USERNAME = "apiuser"
+PASSWORD = "your-password"
+VERIFY_SSL = False                        # True once you trust the cert chain
+CUSTOMER_ID = "100198"
+COMPANY_ID = "ACME"
+LOCATION_ID = "10"
+TAKER = "JSMITH"
+PROMISE_DATE = "2030-01-06"
+TERMS_ID = "NET30"
+SHIP_TO_ID = "200"
+ITEM_ID = "WIDGET-001"
+QUANTITY = 1
+UNIT_PRICE = 0.99
+# ---------------------------------------------------------------------------
+
+ORDER = {
+    "CustomerId": CUSTOMER_ID,
+    "CompanyId": COMPANY_ID,
+    "LocationId": LOCATION_ID,
+    "Taker": TAKER,
+    "PromiseDate": PROMISE_DATE,
+    "TermsId": TERMS_ID,
+    "ShipToId": SHIP_TO_ID,
+    "SourceLocId": LOCATION_ID,
+    "PoNo": "PO-TEST-001",
+    "Quote": "N",                          # "Y" makes it a quote, not an order
+    "DeletedFlag": "N",
+    # Lines is an OBJECT wrapping a list -- a top-level array fails.
+    "Lines": {
+        "list": [
+            {
+                "ItemId": ITEM_ID,
+                "UnitQuantity": QUANTITY,
+                "UnitOfMeasure": "EA",
+                "UnitPrice": UNIT_PRICE,
+                "TaxItem": "N",
+                "Delete": "N",
+            }
+        ]
+    },
+}
+
+
+def get_token(client: httpx.Client) -> str:
+    """v2 token endpoint — credentials go in the body, never in headers."""
+    r = client.post(
+        f"{BASE_URL}/api/security/token/v2",
+        json={"username": USERNAME, "password": PASSWORD},
+        headers={"Accept": "application/json"},
+    )
+    r.raise_for_status()
+    try:
+        return r.json()["AccessToken"]
+    except (ValueError, KeyError):  # some middleware answers in XML
+        match = re.search(r"<AccessToken>([^<]+)</AccessToken>", r.text)
+        if not match:
+            raise ValueError(f"No AccessToken in response: {r.text[:200]}") from None
+        return match.group(1)
+
+
+with httpx.Client(verify=VERIFY_SSL, timeout=120, follow_redirects=True) as client:
+    token = get_token(client)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",       # 2026.1 returns an empty 500 without this
+        "Content-Type": "application/json",
+    }
+
+    # The trailing slash is required -- without it the request isn't routed here.
+    resp = client.post(f"{BASE_URL}/api/sales/orders/", headers=headers, json=ORDER)
+    print(f"HTTP {resp.status_code}")
+    print(resp.text[:1000] or "(empty body)")   # success shape is unconfirmed -- read it raw
+    resp.raise_for_status()
+
+    # Find the new order number. The response key is not confirmed, so try the
+    # plausible spellings rather than assuming one.
+    body = resp.json() if resp.text.strip().startswith("{") else {}
+    order_no = next(
+        (str(body[key]) for key in ("OrderNo", "OrderNumber", "Id", "OrderId") if body.get(key)),
+        None,
+    )
+    if not order_no:
+        raise SystemExit("No order number in the create response -- see the body printed above")
+
+    # Read back -- HTTP 200 on the POST doesn't confirm what actually landed.
+    resp = client.get(f"{BASE_URL}/api/sales/orders/{order_no}", headers=headers)
+    resp.raise_for_status()
+    order = resp.json()
+    lines = (order.get("Lines") or {}).get("list") or []
+    print(f"Order {order_no}: customer {order.get('CustomerId')}, {len(lines)} line(s)")
+```
+
+**C#:**
+```csharp
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+// ---- EDIT THESE -----------------------------------------------------------
+const string BaseUrl = "https://play.p21server.com";   // your P21 server
+const string Username = "apiuser";
+const string Password = "your-password";
+const string CustomerId = "100198";
+const string CompanyId = "ACME";
+const string LocationId = "10";
+const string Taker = "JSMITH";
+const string PromiseDate = "2030-01-06";
+const string TermsId = "NET30";
+const string ShipToId = "200";
+const string ItemId = "WIDGET-001";
+const decimal Quantity = 1m;
+const decimal UnitPrice = 0.99m;
+// ---------------------------------------------------------------------------
+
+var order = new Dictionary<string, object?>
+{
+    ["CustomerId"] = CustomerId,
+    ["CompanyId"] = CompanyId,
+    ["LocationId"] = LocationId,
+    ["Taker"] = Taker,
+    ["PromiseDate"] = PromiseDate,
+    ["TermsId"] = TermsId,
+    ["ShipToId"] = ShipToId,
+    ["SourceLocId"] = LocationId,
+    ["PoNo"] = "PO-TEST-001",
+    ["Quote"] = "N",                                    // "Y" makes it a quote, not an order
+    ["DeletedFlag"] = "N",
+    // Lines is an OBJECT wrapping a list -- a top-level array fails.
+    ["Lines"] = new Dictionary<string, object?>
+    {
+        ["list"] = new[]
+        {
+            new Dictionary<string, object?>
+            {
+                ["ItemId"] = ItemId,
+                ["UnitQuantity"] = Quantity,
+                ["UnitOfMeasure"] = "EA",
+                ["UnitPrice"] = UnitPrice,
+                ["TaxItem"] = "N",
+                ["Delete"] = "N",
+            },
+        },
+    },
+};
+
+var handler = new HttpClientHandler
+{
+    // Test tenants often present a self-signed cert. Delete this line in production.
+    ServerCertificateCustomValidationCallback =
+        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+    AllowAutoRedirect = true,
+};
+using var client = new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(2) };
+client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+var token = await GetTokenAsync(client);
+client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+// The trailing slash is required -- without it the request isn't routed here.
+var resp = await client.PostAsync(
+    $"{BaseUrl}/api/sales/orders/",
+    new StringContent(JsonSerializer.Serialize(order), Encoding.UTF8, "application/json"));
+var responseBody = await resp.Content.ReadAsStringAsync();
+Console.WriteLine($"HTTP {(int)resp.StatusCode}");
+Console.WriteLine(responseBody.Length > 0
+    ? responseBody[..Math.Min(1000, responseBody.Length)]   // success shape is unconfirmed
+    : "(empty body)");
+resp.EnsureSuccessStatusCode();
+
+// Find the new order number. The response key is not confirmed, so try the
+// plausible spellings rather than assuming one.
+string? orderNo = null;
+if (responseBody.TrimStart().StartsWith("{"))
+{
+    using var created = JsonDocument.Parse(responseBody);
+    foreach (var key in new[] { "OrderNo", "OrderNumber", "Id", "OrderId" })
+    {
+        if (created.RootElement.TryGetProperty(key, out var value) &&
+            value.ValueKind is not (JsonValueKind.Null or JsonValueKind.Undefined))
+        {
+            orderNo = value.ToString();
+            if (!string.IsNullOrWhiteSpace(orderNo)) break;
+        }
+    }
+}
+
+if (string.IsNullOrWhiteSpace(orderNo))
+{
+    Console.WriteLine("No order number in the create response -- see the body printed above");
+    return;
+}
+
+// Read back -- HTTP 200 on the POST doesn't confirm what actually landed.
+resp = await client.GetAsync($"{BaseUrl}/api/sales/orders/{orderNo}");
+resp.EnsureSuccessStatusCode();
+using var readBack = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+var lineCount = readBack.RootElement.TryGetProperty("Lines", out var lines) &&
+                lines.TryGetProperty("list", out var list) &&
+                list.ValueKind == JsonValueKind.Array
+    ? list.GetArrayLength()
+    : 0;
+var customer = readBack.RootElement.TryGetProperty("CustomerId", out var c) ? c.ToString() : "?";
+Console.WriteLine($"Order {orderNo}: customer {customer}, {lineCount} line(s)");
+
+// --- helpers ---------------------------------------------------------------
+
+// v2 token endpoint — credentials go in the body, never in headers.
+static async Task<string> GetTokenAsync(HttpClient client)
+{
+    var payload = JsonSerializer.Serialize(new { username = Username, password = Password });
+    var response = await client.PostAsync(
+        $"{BaseUrl}/api/security/token/v2",
+        new StringContent(payload, Encoding.UTF8, "application/json"));
+    response.EnsureSuccessStatusCode();
+    return ReadField(await response.Content.ReadAsStringAsync(), "AccessToken");
+}
+
+// Some middleware answers this endpoint in XML even when asked for JSON.
+static string ReadField(string payload, string field)
+{
+    try
+    {
+        var value = JsonDocument.Parse(payload).RootElement.GetProperty(field).GetString();
+        if (!string.IsNullOrEmpty(value)) return value;
+    }
+    catch (Exception ex) when (ex is JsonException or KeyNotFoundException) { }
+
+    var match = System.Text.RegularExpressions.Regex.Match(payload, $"<{field}>([^<]+)</{field}>");
+    if (!match.Success)
+        throw new InvalidOperationException(
+            $"No {field} in response: {payload[..Math.Min(200, payload.Length)]}");
+    return match.Groups[1].Value;
+}
+```
+
+<!-- /tabs -->
+
+#### What is not pinned down yet
+
+Stated as unknowns rather than guessed at — if you settle one against your tenant, [open an issue](https://github.com/mrwuss/p21-api-documentation/issues/new/choose) and it gets documented:
+
+- **The success response shape**, including where the generated order number comes back. The example above prints the raw body and probes four plausible key spellings for exactly this reason.
+- **Which fields are strictly required** versus optional. The header above is one working example from one 25.2 tenant, not a minimum payload — configuration (taxes, terms, ship-to defaults) decides what your server insists on.
+- **Whether the inline ship-to fields are required alongside `ShipToId`** or only act as a fallback when the ship-to record doesn't resolve a full address.
+- **HTTP status codes and body for validation failures** — the write-side error vocabulary of this family is undocumented.
+- **The other collections in the `/new` template** (`Notes`, `Salesreps`, `BuilderSelectionSheets`, `Samples`) — presumably the same `{"list": [...]}` nesting as `Lines`, but untested.
+
+#### REST vs the Transaction API for order creation
+
+Both create orders. Pick by what you need:
+
+| | `POST /api/sales/orders/` | Transaction API `Order` service |
+|---|---|---|
+| Payload | Plain domain JSON, lines under `Lines.list` | `DataElements` / `Rows` / `Edits`, every value a string |
+| Verified by | Contributor, 25.2 ([issue #108](https://github.com/mrwuss/p21-api-documentation/issues/108)) | This repo, against a live tenant |
+| Error reporting | Undocumented (see above) | `Summary.Succeeded` / `Failed` envelope, [documented traps](06-Error-Handling.md) |
+| Bulk | One order per call | Many orders per call |
+| Assembly lines | Untested | Auto-answers the explode prompt **No** — use the [order-with-assembly](recipes/order-with-assembly.md) recipe instead |
+
+For a walk-through of the Transaction path, see the [create-sales-order recipe](recipes/create-sales-order.md).
 
 ### Families that 404 on the tested tenant
 
 `sales/customers`, `sales/quotes`, `sales/invoices`, `sales/shipments`, `sales/payments`, `purchasing/*`, `ar/*`, `inventory/items`, `inventory/lots` — all returned 404 on ping. Availability may vary by version; the SOA middleware admin site lists the endpoint families your server actually exposes.
 
 *Credit: Felipe Maurer ([P21WWUG profile](https://forums.p21ww.org/UserInfo10045.aspx)) — surfaced `/api/sales/orders` and the middleware endpoint listing in [this forum topic](https://forums.p21ww.org/Topic245514-3.aspx).*
+
+*Credit: [Rob Landham](https://github.com/roblandham) — documented `POST /api/sales/orders/`, the required trailing slash and the `Lines.list` nesting, tested on 25.2 ([issue #108](https://github.com/mrwuss/p21-api-documentation/issues/108)).*
 
 ---
 

--- a/docs/10-Changelog.md
+++ b/docs/10-Changelog.md
@@ -17,6 +17,14 @@ All notable changes to this documentation project are listed below, grouped by d
 
 ---
 
+## 2026-08-19 — v1.5.1
+
+Community contribution: the `/api/sales/orders` family creates orders as well as reading them.
+
+- **feat:** **`POST /api/sales/orders/` creates a sales order** — documented from a community contribution tested on **25.2**, with the two shape rules that decide whether the call works at all: the **trailing slash is required** (without it the request is not routed to the API — and on a POST you cannot lean on a redirect-following client the way the read-side 307 lets you), and **`Lines` is an object, not an array** — the lines go in `Lines.list`, which the `/new` template shows without explaining. Adds the header and line field tables, an example body, a complete runnable Python/C# program, and a REST-vs-Transaction comparison for choosing between the two order-creation paths. The section states plainly what the contribution does **not** settle — the success response shape and where the order number comes back, which fields are strictly required versus optional, whether the inline ship-to fields are required alongside `ShipToId` or only a fallback, the validation-error status codes, and whether the `/new` template's other collections (`Notes`, `Salesreps`, …) use the same `list` nesting — so nobody mistakes one working payload for a specification. Doc 05's "writes are untested" note, the selection guide and the task index are updated accordingly. → [05 § Creating an Order](05-Entity-API.md#creating-an-order-post-apisalesorders) — *Rob Landham ([@roblandham](https://github.com/roblandham)), documented by @mrwuss* — Fixes #108
+
+---
+
 ## 2026-08-11 — v1.5.0
 
 Cleared issues #103 and #105–#107, converted every API-calling code example in the docs into a complete runnable program, and re-verified a batch of long-standing claims against a live tenant. Verification build: **26.1.5910.3**. The checks turned up several errors in our own documentation; those are listed first.
@@ -306,6 +314,7 @@ First tagged release. This wave cross-checked the docs against a community proce
 | Claude Jones | [@RadAJones](https://github.com/RadAJones) | Reusable P21 API client with sync/async support ([PR #16](https://github.com/mrwuss/p21-api-documentation/pull/16)) |
 | Sibin Francis | [@sibinfrancisaj](https://github.com/sibinfrancisaj) | Inventory REST API documentation ([PR #23](https://github.com/mrwuss/p21-api-documentation/pull/23)) |
 | NextTWis | [@NextTWis](https://github.com/NextTWis) | Postman Collection for P21 API verification ([PR #24](https://github.com/mrwuss/p21-api-documentation/pull/24)) |
+| Rob Landham | [@roblandham](https://github.com/roblandham) | `POST /api/sales/orders/` order creation — payload shape, required trailing slash, `Lines.list` nesting ([issue #108](https://github.com/mrwuss/p21-api-documentation/issues/108)) |
 | Alex Westemeier | [@AWestemeier](https://github.com/AWestemeier) | Report-service discovery, Transaction upsert + IgnoreDisabled findings, production lifecycle verification |
 | Jeff Poss | | PDF Report Generation endpoint discovery |
 | Felipe Maurer | | Entity API taxonomy correction, UDT Service API discovery and testing, Inventory pricing endpoints, Stored Procedure Executor UID discovery, DynaChange enforcement in TAPI |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -77,7 +77,7 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 | **Create a requisition PO** (`po_type` 'R'; disabled `po_hdr_po_type`; vendor vs supplier) | [create-requisition-po](recipes/create-requisition-po.md) | [03 § Purchase Order Types](03-Transaction-API.md#purchase-order-types-and-the-disabled-po_hdr_po_type-column) |
 | **GL dimensions via API** (voucher services carry them; POs don't) | — | [03 § GL Dimensions in the API](03-Transaction-API.md#gl-dimensions-in-the-api) |
 | Customers / vendors / contacts / addresses (simple CRUD) | — | [05 § CRUD Operations](05-Entity-API.md#crud-operations) |
-| Read/create **sales orders via REST** (`/api/sales/orders`) | — | [05 § Other REST Endpoint Families](05-Entity-API.md#other-rest-endpoint-families) |
+| Read/create **sales orders via REST** (`/api/sales/orders`) | — | [05 § Other REST Endpoint Families](05-Entity-API.md#other-rest-endpoint-families) · [05 § Creating an Order](05-Entity-API.md#creating-an-order-post-apisalesorders) — **trailing slash required; lines nest under `Lines.list`** |
 | Inventory items: read / create / update locations | — | [11 § Reading Items](11-Inventory-REST-API.md#reading-items) · [11 § Minimum Create Payload](11-Inventory-REST-API.md#minimum-create-payload) · [11 § Updating Existing Location Fields](11-Inventory-REST-API.md#updating-existing-location-fields) |
 | Customer-specific **price + availability** lookup | — | [11 § Pricing Endpoints](11-Inventory-REST-API.md#pricing-endpoints) |
 | User-defined tables (UDT) rows | — | [13 § Insert](13-UDT-Service-API.md#insert) · [13 § Update](13-UDT-Service-API.md#update) · [13 § Delete](13-UDT-Service-API.md#delete) — **update/delete need a `row_uid` column; 2026.1-created UDTs don't have one** |

--- a/docs/html/01-API-Selection-Guide.html
+++ b/docs/html/01-API-Selection-Guide.html
@@ -926,7 +926,7 @@
 </ul>
 <h3 id="dont-use-when_3">Don't Use When</h3>
 <ul>
-<li>You need orders — those live in the same REST API at <code>/api/sales/orders</code> (see <a href="05-Entity-API.html#other-rest-endpoint-families">Other REST Endpoint Families</a>)</li>
+<li>You need orders — those live in the same REST API at <code>/api/sales/orders</code>, which reads <em>and</em> creates (<a href="05-Entity-API.html#other-rest-endpoint-families">Other REST Endpoint Families</a> · <a href="05-Entity-API.html#creating-an-order-post-apisalesorders">Creating an Order</a>)</li>
 <li>You need inventory items — use the <a href="11-Inventory-REST-API.html">Inventory REST API</a> (<code>/api/inventory/parts</code>)</li>
 <li>You need invoices, POs, or other business objects (no endpoint family found)</li>
 <li>You need bulk operations (use Transaction API)</li>

--- a/docs/html/05-Entity-API.html
+++ b/docs/html/05-Entity-API.html
@@ -602,6 +602,7 @@
 </li>
 <li><a href="#other-rest-endpoint-families">Other REST Endpoint Families</a><ul>
 <li><a href="#apisalesorders-exists-and-responds">/api/sales/orders — exists and responds</a></li>
+<li><a href="#creating-an-order-post-apisalesorders">Creating an Order (POST /api/sales/orders/)</a></li>
 <li><a href="#families-that-404-on-the-tested-tenant">Families that 404 on the tested tenant</a></li>
 </ul>
 </li>
@@ -3875,12 +3876,492 @@ UI-server redirect to resolve (that only applies to Transaction and Interactive)
 <td><code>GET /api/sales/orders/?$query=...</code></td>
 <td>500 with an unrecognized field name — list query syntax not yet discovered</td>
 </tr>
+<tr>
+<td><code>POST /api/sales/orders/</code></td>
+<td>Creates an order — <strong>trailing slash required</strong>, lines nest under <code>Lines.list</code>. See <a href="#creating-an-order-post-apisalesorders">Creating an Order</a> (community-verified on 25.2)</td>
+</tr>
 </tbody>
 </table></div>
-<p>Writes and the approve action are <strong>untested</strong> — treat this family as read-verified only until documented further.</p>
+<p>The approve action and every other write on this family remain <strong>untested</strong>; order creation is the one write with a reported working payload, below.</p>
+<h3 id="creating-an-order-post-apisalesorders">Creating an Order (<code>POST /api/sales/orders/</code>)</h3>
+<p><code>/api/sales/orders/</code> is not read-only: the same URL accepts a <strong>POST</strong> whose body is a single order — header fields at the top level, lines nested inside. <code>GET /api/sales/orders/new</code> shows you the object's shape but says nothing about how to submit one, which is why this went undocumented for so long.</p>
+<blockquote>
+<p><strong>Contributed and tested on P21 25.2 by <a href="https://github.com/roblandham">Rob Landham</a> (<a href="https://github.com/mrwuss/p21-api-documentation/issues/108">issue #108</a>)</strong> — the payload shape and both rules below are their findings, reproduced here as reported. They have <strong>not</strong> been re-verified on this repo's tenant, and the <a href="#what-is-not-pinned-down-yet">open questions</a> at the end of this section list exactly what nobody has pinned down yet. Treat the field list as an example header, not a required-field spec: which fields your environment demands depends on its configuration.</p>
+</blockquote>
+<p>Two shape rules decide whether the call works at all.</p>
+<p><strong>1. The trailing slash is required.</strong> <code>POST /api/sales/orders/</code> routes correctly; drop the slash and the request is not routed to the API. This is the write-side face of the <a href="#trailing-slash-on-list-endpoints">307 on list endpoints</a> — except that on a POST you cannot paper over it with a redirect-following client and call it handled, because whether the body and method survive the hop is up to the client. Send the slash.</p>
+<p><strong>2. <code>Lines</code> is an object, not an array.</strong> The lines go in an array under <code>Lines.list</code>. A top-level <code>Lines</code> array <strong>fails</strong> — this is the mistake the <code>/new</code> template does not protect you from, since it shows the container without explaining the nesting.</p>
+<h4 id="header-fields">Header fields</h4>
+<div class="table-wrap"><table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>CustomerId</code></td>
+<td>string</td>
+<td>P21 customer ID the order is placed against</td>
+</tr>
+<tr>
+<td><code>CompanyId</code></td>
+<td>string</td>
+<td>Company/branch code</td>
+</tr>
+<tr>
+<td><code>LocationId</code></td>
+<td>string</td>
+<td>Fulfilling location ID</td>
+</tr>
+<tr>
+<td><code>Taker</code></td>
+<td>string</td>
+<td>User/service account identifier that "took" the order</td>
+</tr>
+<tr>
+<td><code>PromiseDate</code></td>
+<td>string (<code>YYYY-MM-DD</code>)</td>
+<td>Promised ship/delivery date</td>
+</tr>
+<tr>
+<td><code>TermsId</code></td>
+<td>string</td>
+<td>Payment terms code (e.g. <code>NET30</code>)</td>
+</tr>
+<tr>
+<td><code>ShipToId</code></td>
+<td>string</td>
+<td>Ship-to record ID</td>
+</tr>
+<tr>
+<td><code>ShipToName</code>, <code>ShipToAddress1</code>, <code>ShipToAddress2</code>, <code>ShipToCity</code>, <code>ShipToState</code>, <code>ZipCode</code>, <code>ShipToCountry</code></td>
+<td>string</td>
+<td>Ship-to address fields — sent inline when <code>ShipToId</code> alone doesn't resolve the full address</td>
+</tr>
+<tr>
+<td><code>ShipToEmail</code>, <code>ShipToPhone</code></td>
+<td>string</td>
+<td>Ship-to contact details</td>
+</tr>
+<tr>
+<td><code>SourceLocId</code></td>
+<td>string</td>
+<td>Source location for the order</td>
+</tr>
+<tr>
+<td><code>PoNo</code></td>
+<td>string</td>
+<td>Customer PO number reference</td>
+</tr>
+<tr>
+<td><code>Quote</code></td>
+<td>string (<code>"Y"</code>/<code>"N"</code>)</td>
+<td>Whether this is a quote rather than a firm order</td>
+</tr>
+<tr>
+<td><code>DeletedFlag</code></td>
+<td>string (<code>"Y"</code>/<code>"N"</code>)</td>
+<td>Soft-delete flag — <code>"N"</code> for new orders</td>
+</tr>
+<tr>
+<td><code>Lines</code></td>
+<td>object</td>
+<td>Container wrapping the lines — <strong>not</strong> an array</td>
+</tr>
+<tr>
+<td><code>Lines.list</code></td>
+<td>array</td>
+<td>The line objects</td>
+</tr>
+</tbody>
+</table></div>
+<h4 id="line-fields-lineslist">Line fields (<code>Lines.list[]</code>)</h4>
+<div class="table-wrap"><table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>ItemId</code></td>
+<td>string</td>
+<td>Item being ordered</td>
+</tr>
+<tr>
+<td><code>UnitQuantity</code></td>
+<td>number</td>
+<td>Quantity in <code>UnitOfMeasure</code></td>
+</tr>
+<tr>
+<td><code>UnitOfMeasure</code></td>
+<td>string</td>
+<td>e.g. <code>EA</code></td>
+</tr>
+<tr>
+<td><code>UnitPrice</code></td>
+<td>number</td>
+<td>Price per unit</td>
+</tr>
+<tr>
+<td><code>TaxItem</code></td>
+<td>string (<code>"Y"</code>/<code>"N"</code>)</td>
+<td>Whether the line is taxable</td>
+</tr>
+<tr>
+<td><code>Delete</code></td>
+<td>string (<code>"Y"</code>/<code>"N"</code>)</td>
+<td><code>"N"</code> on a new line</td>
+</tr>
+</tbody>
+</table></div>
+<p>Note the type split: quantities and prices are <strong>JSON numbers</strong> here, while the flags are <code>"Y"</code>/<code>"N"</code> <strong>strings</strong> — unlike the Transaction API, where every <code>Value</code> is a string.</p>
+<h4 id="example-request-body">Example request body</h4>
+<div class="highlight"><pre><span></span><code><span class="err">POST</span><span class="w"> </span><span class="p">{</span><span class="err">base_url</span><span class="p">}</span><span class="err">/api/sales/orders/</span>
+
+<span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;CustomerId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;100198&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;CompanyId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;ACME&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;LocationId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;10&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Taker&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;JSMITH&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;PromiseDate&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2030-01-06&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;TermsId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;NET30&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;200&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToName&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Acme Fulfillment Co&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToAddress1&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;123 Example Street&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToAddress2&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Ste 100&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToCity&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Atlanta&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToState&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;GA&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ZipCode&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;30000&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToCountry&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;US&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToEmail&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;orders@example.com&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;ShipToPhone&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;000-000-0000&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;SourceLocId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;10&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;PoNo&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;PO-TEST-001&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Quote&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;N&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;DeletedFlag&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;N&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="nt">&quot;Lines&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
+<span class="w">        </span><span class="nt">&quot;list&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">            </span><span class="p">{</span>
+<span class="w">                </span><span class="nt">&quot;ItemId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;WIDGET-001&quot;</span><span class="p">,</span>
+<span class="w">                </span><span class="nt">&quot;UnitQuantity&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">1</span><span class="p">,</span>
+<span class="w">                </span><span class="nt">&quot;UnitOfMeasure&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;EA&quot;</span><span class="p">,</span>
+<span class="w">                </span><span class="nt">&quot;UnitPrice&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">0.99</span><span class="p">,</span>
+<span class="w">                </span><span class="nt">&quot;TaxItem&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;N&quot;</span><span class="p">,</span>
+<span class="w">                </span><span class="nt">&quot;Delete&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;N&quot;</span>
+<span class="w">            </span><span class="p">}</span>
+<span class="w">        </span><span class="p">]</span>
+<span class="w">    </span><span class="p">}</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<h4 id="complete-example">Complete example</h4>
+<p>The create response shape is unconfirmed (see <a href="#what-is-not-pinned-down-yet">below</a>), so this program <strong>prints the raw body</strong> before trying to find an order number in it, and reads the order back when it finds one. Run it against a play tenant first — it writes a real order.</p>
+<div class="code-tabs">
+  <div class="tab-buttons">
+    <button class="tab-btn active" data-lang="python">Python</button>
+    <button class="tab-btn" data-lang="csharp">C#</button>
+  </div>
+  <div class="tab-panel active" data-lang="python">
+<div class="highlight"><pre><span></span><code><span class="sd">&quot;&quot;&quot;Create a sales order through the REST API, then read it back.&quot;&quot;&quot;</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">re</span>
+
+<span class="kn">import</span><span class="w"> </span><span class="nn">httpx</span>
+
+<span class="c1"># ---- EDIT THESE -----------------------------------------------------------</span>
+<span class="n">BASE_URL</span> <span class="o">=</span> <span class="s2">&quot;https://play.p21server.com&quot;</span>   <span class="c1"># your P21 server</span>
+<span class="n">USERNAME</span> <span class="o">=</span> <span class="s2">&quot;apiuser&quot;</span>
+<span class="n">PASSWORD</span> <span class="o">=</span> <span class="s2">&quot;your-password&quot;</span>
+<span class="n">VERIFY_SSL</span> <span class="o">=</span> <span class="kc">False</span>                        <span class="c1"># True once you trust the cert chain</span>
+<span class="n">CUSTOMER_ID</span> <span class="o">=</span> <span class="s2">&quot;100198&quot;</span>
+<span class="n">COMPANY_ID</span> <span class="o">=</span> <span class="s2">&quot;ACME&quot;</span>
+<span class="n">LOCATION_ID</span> <span class="o">=</span> <span class="s2">&quot;10&quot;</span>
+<span class="n">TAKER</span> <span class="o">=</span> <span class="s2">&quot;JSMITH&quot;</span>
+<span class="n">PROMISE_DATE</span> <span class="o">=</span> <span class="s2">&quot;2030-01-06&quot;</span>
+<span class="n">TERMS_ID</span> <span class="o">=</span> <span class="s2">&quot;NET30&quot;</span>
+<span class="n">SHIP_TO_ID</span> <span class="o">=</span> <span class="s2">&quot;200&quot;</span>
+<span class="n">ITEM_ID</span> <span class="o">=</span> <span class="s2">&quot;WIDGET-001&quot;</span>
+<span class="n">QUANTITY</span> <span class="o">=</span> <span class="mi">1</span>
+<span class="n">UNIT_PRICE</span> <span class="o">=</span> <span class="mf">0.99</span>
+<span class="c1"># ---------------------------------------------------------------------------</span>
+
+<span class="n">ORDER</span> <span class="o">=</span> <span class="p">{</span>
+    <span class="s2">&quot;CustomerId&quot;</span><span class="p">:</span> <span class="n">CUSTOMER_ID</span><span class="p">,</span>
+    <span class="s2">&quot;CompanyId&quot;</span><span class="p">:</span> <span class="n">COMPANY_ID</span><span class="p">,</span>
+    <span class="s2">&quot;LocationId&quot;</span><span class="p">:</span> <span class="n">LOCATION_ID</span><span class="p">,</span>
+    <span class="s2">&quot;Taker&quot;</span><span class="p">:</span> <span class="n">TAKER</span><span class="p">,</span>
+    <span class="s2">&quot;PromiseDate&quot;</span><span class="p">:</span> <span class="n">PROMISE_DATE</span><span class="p">,</span>
+    <span class="s2">&quot;TermsId&quot;</span><span class="p">:</span> <span class="n">TERMS_ID</span><span class="p">,</span>
+    <span class="s2">&quot;ShipToId&quot;</span><span class="p">:</span> <span class="n">SHIP_TO_ID</span><span class="p">,</span>
+    <span class="s2">&quot;SourceLocId&quot;</span><span class="p">:</span> <span class="n">LOCATION_ID</span><span class="p">,</span>
+    <span class="s2">&quot;PoNo&quot;</span><span class="p">:</span> <span class="s2">&quot;PO-TEST-001&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;Quote&quot;</span><span class="p">:</span> <span class="s2">&quot;N&quot;</span><span class="p">,</span>                          <span class="c1"># &quot;Y&quot; makes it a quote, not an order</span>
+    <span class="s2">&quot;DeletedFlag&quot;</span><span class="p">:</span> <span class="s2">&quot;N&quot;</span><span class="p">,</span>
+    <span class="c1"># Lines is an OBJECT wrapping a list -- a top-level array fails.</span>
+    <span class="s2">&quot;Lines&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;list&quot;</span><span class="p">:</span> <span class="p">[</span>
+            <span class="p">{</span>
+                <span class="s2">&quot;ItemId&quot;</span><span class="p">:</span> <span class="n">ITEM_ID</span><span class="p">,</span>
+                <span class="s2">&quot;UnitQuantity&quot;</span><span class="p">:</span> <span class="n">QUANTITY</span><span class="p">,</span>
+                <span class="s2">&quot;UnitOfMeasure&quot;</span><span class="p">:</span> <span class="s2">&quot;EA&quot;</span><span class="p">,</span>
+                <span class="s2">&quot;UnitPrice&quot;</span><span class="p">:</span> <span class="n">UNIT_PRICE</span><span class="p">,</span>
+                <span class="s2">&quot;TaxItem&quot;</span><span class="p">:</span> <span class="s2">&quot;N&quot;</span><span class="p">,</span>
+                <span class="s2">&quot;Delete&quot;</span><span class="p">:</span> <span class="s2">&quot;N&quot;</span><span class="p">,</span>
+            <span class="p">}</span>
+        <span class="p">]</span>
+    <span class="p">},</span>
+<span class="p">}</span>
+
+
+<span class="k">def</span><span class="w"> </span><span class="nf">get_token</span><span class="p">(</span><span class="n">client</span><span class="p">:</span> <span class="n">httpx</span><span class="o">.</span><span class="n">Client</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+<span class="w">    </span><span class="sd">&quot;&quot;&quot;v2 token endpoint — credentials go in the body, never in headers.&quot;&quot;&quot;</span>
+    <span class="n">r</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">post</span><span class="p">(</span>
+        <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">BASE_URL</span><span class="si">}</span><span class="s2">/api/security/token/v2&quot;</span><span class="p">,</span>
+        <span class="n">json</span><span class="o">=</span><span class="p">{</span><span class="s2">&quot;username&quot;</span><span class="p">:</span> <span class="n">USERNAME</span><span class="p">,</span> <span class="s2">&quot;password&quot;</span><span class="p">:</span> <span class="n">PASSWORD</span><span class="p">},</span>
+        <span class="n">headers</span><span class="o">=</span><span class="p">{</span><span class="s2">&quot;Accept&quot;</span><span class="p">:</span> <span class="s2">&quot;application/json&quot;</span><span class="p">},</span>
+    <span class="p">)</span>
+    <span class="n">r</span><span class="o">.</span><span class="n">raise_for_status</span><span class="p">()</span>
+    <span class="k">try</span><span class="p">:</span>
+        <span class="k">return</span> <span class="n">r</span><span class="o">.</span><span class="n">json</span><span class="p">()[</span><span class="s2">&quot;AccessToken&quot;</span><span class="p">]</span>
+    <span class="k">except</span> <span class="p">(</span><span class="ne">ValueError</span><span class="p">,</span> <span class="ne">KeyError</span><span class="p">):</span>  <span class="c1"># some middleware answers in XML</span>
+        <span class="n">match</span> <span class="o">=</span> <span class="n">re</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;&lt;AccessToken&gt;([^&lt;]+)&lt;/AccessToken&gt;&quot;</span><span class="p">,</span> <span class="n">r</span><span class="o">.</span><span class="n">text</span><span class="p">)</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="n">match</span><span class="p">:</span>
+            <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;No AccessToken in response: </span><span class="si">{</span><span class="n">r</span><span class="o">.</span><span class="n">text</span><span class="p">[:</span><span class="mi">200</span><span class="p">]</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span> <span class="kn">from</span><span class="w"> </span><span class="kc">None</span>
+        <span class="k">return</span> <span class="n">match</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">1</span><span class="p">)</span>
+
+
+<span class="k">with</span> <span class="n">httpx</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span><span class="n">verify</span><span class="o">=</span><span class="n">VERIFY_SSL</span><span class="p">,</span> <span class="n">timeout</span><span class="o">=</span><span class="mi">120</span><span class="p">,</span> <span class="n">follow_redirects</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span> <span class="k">as</span> <span class="n">client</span><span class="p">:</span>
+    <span class="n">token</span> <span class="o">=</span> <span class="n">get_token</span><span class="p">(</span><span class="n">client</span><span class="p">)</span>
+    <span class="n">headers</span> <span class="o">=</span> <span class="p">{</span>
+        <span class="s2">&quot;Authorization&quot;</span><span class="p">:</span> <span class="sa">f</span><span class="s2">&quot;Bearer </span><span class="si">{</span><span class="n">token</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">,</span>
+        <span class="s2">&quot;Accept&quot;</span><span class="p">:</span> <span class="s2">&quot;application/json&quot;</span><span class="p">,</span>       <span class="c1"># 2026.1 returns an empty 500 without this</span>
+        <span class="s2">&quot;Content-Type&quot;</span><span class="p">:</span> <span class="s2">&quot;application/json&quot;</span><span class="p">,</span>
+    <span class="p">}</span>
+
+    <span class="c1"># The trailing slash is required -- without it the request isn&#39;t routed here.</span>
+    <span class="n">resp</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">post</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">BASE_URL</span><span class="si">}</span><span class="s2">/api/sales/orders/&quot;</span><span class="p">,</span> <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span> <span class="n">json</span><span class="o">=</span><span class="n">ORDER</span><span class="p">)</span>
+    <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;HTTP </span><span class="si">{</span><span class="n">resp</span><span class="o">.</span><span class="n">status_code</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+    <span class="nb">print</span><span class="p">(</span><span class="n">resp</span><span class="o">.</span><span class="n">text</span><span class="p">[:</span><span class="mi">1000</span><span class="p">]</span> <span class="ow">or</span> <span class="s2">&quot;(empty body)&quot;</span><span class="p">)</span>   <span class="c1"># success shape is unconfirmed -- read it raw</span>
+    <span class="n">resp</span><span class="o">.</span><span class="n">raise_for_status</span><span class="p">()</span>
+
+    <span class="c1"># Find the new order number. The response key is not confirmed, so try the</span>
+    <span class="c1"># plausible spellings rather than assuming one.</span>
+    <span class="n">body</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">json</span><span class="p">()</span> <span class="k">if</span> <span class="n">resp</span><span class="o">.</span><span class="n">text</span><span class="o">.</span><span class="n">strip</span><span class="p">()</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;{&quot;</span><span class="p">)</span> <span class="k">else</span> <span class="p">{}</span>
+    <span class="n">order_no</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span>
+        <span class="p">(</span><span class="nb">str</span><span class="p">(</span><span class="n">body</span><span class="p">[</span><span class="n">key</span><span class="p">])</span> <span class="k">for</span> <span class="n">key</span> <span class="ow">in</span> <span class="p">(</span><span class="s2">&quot;OrderNo&quot;</span><span class="p">,</span> <span class="s2">&quot;OrderNumber&quot;</span><span class="p">,</span> <span class="s2">&quot;Id&quot;</span><span class="p">,</span> <span class="s2">&quot;OrderId&quot;</span><span class="p">)</span> <span class="k">if</span> <span class="n">body</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">key</span><span class="p">)),</span>
+        <span class="kc">None</span><span class="p">,</span>
+    <span class="p">)</span>
+    <span class="k">if</span> <span class="ow">not</span> <span class="n">order_no</span><span class="p">:</span>
+        <span class="k">raise</span> <span class="ne">SystemExit</span><span class="p">(</span><span class="s2">&quot;No order number in the create response -- see the body printed above&quot;</span><span class="p">)</span>
+
+    <span class="c1"># Read back -- HTTP 200 on the POST doesn&#39;t confirm what actually landed.</span>
+    <span class="n">resp</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">BASE_URL</span><span class="si">}</span><span class="s2">/api/sales/orders/</span><span class="si">{</span><span class="n">order_no</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">,</span> <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">)</span>
+    <span class="n">resp</span><span class="o">.</span><span class="n">raise_for_status</span><span class="p">()</span>
+    <span class="n">order</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">json</span><span class="p">()</span>
+    <span class="n">lines</span> <span class="o">=</span> <span class="p">(</span><span class="n">order</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s2">&quot;Lines&quot;</span><span class="p">)</span> <span class="ow">or</span> <span class="p">{})</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s2">&quot;list&quot;</span><span class="p">)</span> <span class="ow">or</span> <span class="p">[]</span>
+    <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Order </span><span class="si">{</span><span class="n">order_no</span><span class="si">}</span><span class="s2">: customer </span><span class="si">{</span><span class="n">order</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;CustomerId&#39;</span><span class="p">)</span><span class="si">}</span><span class="s2">, </span><span class="si">{</span><span class="nb">len</span><span class="p">(</span><span class="n">lines</span><span class="p">)</span><span class="si">}</span><span class="s2"> line(s)&quot;</span><span class="p">)</span>
+</code></pre></div>
+</div>
+  <div class="tab-panel" data-lang="csharp">
+<div class="highlight"><pre><span></span><code><span class="k">using</span><span class="w"> </span><span class="nn">System.Net.Http.Headers</span><span class="p">;</span>
+<span class="k">using</span><span class="w"> </span><span class="nn">System.Text</span><span class="p">;</span>
+<span class="k">using</span><span class="w"> </span><span class="nn">System.Text.Json</span><span class="p">;</span>
+
+<span class="c1">// ---- EDIT THESE -----------------------------------------------------------</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">BaseUrl</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;https://play.p21server.com&quot;</span><span class="p">;</span><span class="w">   </span><span class="c1">// your P21 server</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">Username</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;apiuser&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">Password</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;your-password&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">CustomerId</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;100198&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">CompanyId</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;ACME&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">LocationId</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;10&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">Taker</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;JSMITH&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">PromiseDate</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;2030-01-06&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">TermsId</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;NET30&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">ShipToId</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;200&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">ItemId</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;WIDGET-001&quot;</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">decimal</span><span class="w"> </span><span class="n">Quantity</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="mf">1m</span><span class="p">;</span>
+<span class="k">const</span><span class="w"> </span><span class="kt">decimal</span><span class="w"> </span><span class="n">UnitPrice</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="mf">0.99m</span><span class="p">;</span>
+<span class="c1">// ---------------------------------------------------------------------------</span>
+
+<span class="kt">var</span><span class="w"> </span><span class="n">order</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">new</span><span class="w"> </span><span class="n">Dictionary</span><span class="o">&lt;</span><span class="kt">string</span><span class="p">,</span><span class="w"> </span><span class="kt">object?</span><span class="o">&gt;</span>
+<span class="p">{</span>
+<span class="w">    </span><span class="na">[&quot;CustomerId&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">CustomerId</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;CompanyId&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">CompanyId</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;LocationId&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">LocationId</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;Taker&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">Taker</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;PromiseDate&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">PromiseDate</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;TermsId&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">TermsId</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;ShipToId&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">ShipToId</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;SourceLocId&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">LocationId</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;PoNo&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;PO-TEST-001&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="na">[&quot;Quote&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;N&quot;</span><span class="p">,</span><span class="w">                                    </span><span class="c1">// &quot;Y&quot; makes it a quote, not an order</span>
+<span class="w">    </span><span class="na">[&quot;DeletedFlag&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;N&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="c1">// Lines is an OBJECT wrapping a list -- a top-level array fails.</span>
+<span class="w">    </span><span class="na">[&quot;Lines&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">new</span><span class="w"> </span><span class="n">Dictionary</span><span class="o">&lt;</span><span class="kt">string</span><span class="p">,</span><span class="w"> </span><span class="kt">object?</span><span class="o">&gt;</span>
+<span class="w">    </span><span class="p">{</span>
+<span class="w">        </span><span class="na">[&quot;list&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">new</span><span class="p">[]</span>
+<span class="w">        </span><span class="p">{</span>
+<span class="w">            </span><span class="k">new</span><span class="w"> </span><span class="n">Dictionary</span><span class="o">&lt;</span><span class="kt">string</span><span class="p">,</span><span class="w"> </span><span class="kt">object?</span><span class="o">&gt;</span>
+<span class="w">            </span><span class="p">{</span>
+<span class="w">                </span><span class="na">[&quot;ItemId&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">ItemId</span><span class="p">,</span>
+<span class="w">                </span><span class="na">[&quot;UnitQuantity&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">Quantity</span><span class="p">,</span>
+<span class="w">                </span><span class="na">[&quot;UnitOfMeasure&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;EA&quot;</span><span class="p">,</span>
+<span class="w">                </span><span class="na">[&quot;UnitPrice&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">UnitPrice</span><span class="p">,</span>
+<span class="w">                </span><span class="na">[&quot;TaxItem&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;N&quot;</span><span class="p">,</span>
+<span class="w">                </span><span class="na">[&quot;Delete&quot;]</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">&quot;N&quot;</span><span class="p">,</span>
+<span class="w">            </span><span class="p">},</span>
+<span class="w">        </span><span class="p">},</span>
+<span class="w">    </span><span class="p">},</span>
+<span class="p">};</span>
+
+<span class="kt">var</span><span class="w"> </span><span class="n">handler</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">new</span><span class="w"> </span><span class="n">HttpClientHandler</span>
+<span class="p">{</span>
+<span class="w">    </span><span class="c1">// Test tenants often present a self-signed cert. Delete this line in production.</span>
+<span class="w">    </span><span class="n">ServerCertificateCustomValidationCallback</span><span class="w"> </span><span class="o">=</span>
+<span class="w">        </span><span class="n">HttpClientHandler</span><span class="p">.</span><span class="n">DangerousAcceptAnyServerCertificateValidator</span><span class="p">,</span>
+<span class="w">    </span><span class="n">AllowAutoRedirect</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">true</span><span class="p">,</span>
+<span class="p">};</span>
+<span class="k">using</span><span class="w"> </span><span class="nn">var</span><span class="w"> </span><span class="n">client</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">new</span><span class="w"> </span><span class="n">HttpClient</span><span class="p">(</span><span class="n">handler</span><span class="p">)</span><span class="w"> </span><span class="p">{</span><span class="w"> </span><span class="n">Timeout</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">TimeSpan</span><span class="p">.</span><span class="n">FromMinutes</span><span class="p">(</span><span class="mi">2</span><span class="p">)</span><span class="w"> </span><span class="p">};</span>
+<span class="n">client</span><span class="p">.</span><span class="n">DefaultRequestHeaders</span><span class="p">.</span><span class="n">Accept</span><span class="p">.</span><span class="n">Add</span><span class="p">(</span><span class="k">new</span><span class="w"> </span><span class="n">MediaTypeWithQualityHeaderValue</span><span class="p">(</span><span class="s">&quot;application/json&quot;</span><span class="p">));</span>
+
+<span class="kt">var</span><span class="w"> </span><span class="n">token</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">await</span><span class="w"> </span><span class="n">GetTokenAsync</span><span class="p">(</span><span class="n">client</span><span class="p">);</span>
+<span class="n">client</span><span class="p">.</span><span class="n">DefaultRequestHeaders</span><span class="p">.</span><span class="n">Authorization</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">new</span><span class="w"> </span><span class="n">AuthenticationHeaderValue</span><span class="p">(</span><span class="s">&quot;Bearer&quot;</span><span class="p">,</span><span class="w"> </span><span class="n">token</span><span class="p">);</span>
+
+<span class="c1">// The trailing slash is required -- without it the request isn&#39;t routed here.</span>
+<span class="kt">var</span><span class="w"> </span><span class="n">resp</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">await</span><span class="w"> </span><span class="n">client</span><span class="p">.</span><span class="n">PostAsync</span><span class="p">(</span>
+<span class="w">    </span><span class="s">$&quot;{BaseUrl}/api/sales/orders/&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="k">new</span><span class="w"> </span><span class="nf">StringContent</span><span class="p">(</span><span class="n">JsonSerializer</span><span class="p">.</span><span class="n">Serialize</span><span class="p">(</span><span class="n">order</span><span class="p">),</span><span class="w"> </span><span class="n">Encoding</span><span class="p">.</span><span class="n">UTF8</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;application/json&quot;</span><span class="p">));</span>
+<span class="kt">var</span><span class="w"> </span><span class="n">responseBody</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">await</span><span class="w"> </span><span class="n">resp</span><span class="p">.</span><span class="n">Content</span><span class="p">.</span><span class="n">ReadAsStringAsync</span><span class="p">();</span>
+<span class="n">Console</span><span class="p">.</span><span class="n">WriteLine</span><span class="p">(</span><span class="s">$&quot;HTTP {(int)resp.StatusCode}&quot;</span><span class="p">);</span>
+<span class="n">Console</span><span class="p">.</span><span class="n">WriteLine</span><span class="p">(</span><span class="n">responseBody</span><span class="p">.</span><span class="n">Length</span><span class="w"> </span><span class="o">&gt;</span><span class="w"> </span><span class="mi">0</span>
+<span class="w">    </span><span class="o">?</span><span class="w"> </span><span class="n">responseBody</span><span class="p">[..</span><span class="n">Math</span><span class="p">.</span><span class="n">Min</span><span class="p">(</span><span class="mi">1000</span><span class="p">,</span><span class="w"> </span><span class="n">responseBody</span><span class="p">.</span><span class="n">Length</span><span class="p">)]</span><span class="w">   </span><span class="c1">// success shape is unconfirmed</span>
+<span class="w">    </span><span class="p">:</span><span class="w"> </span><span class="s">&quot;(empty body)&quot;</span><span class="p">);</span>
+<span class="n">resp</span><span class="p">.</span><span class="n">EnsureSuccessStatusCode</span><span class="p">();</span>
+
+<span class="c1">// Find the new order number. The response key is not confirmed, so try the</span>
+<span class="c1">// plausible spellings rather than assuming one.</span>
+<span class="kt">string?</span><span class="w"> </span><span class="n">orderNo</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">null</span><span class="p">;</span>
+<span class="k">if</span><span class="w"> </span><span class="p">(</span><span class="n">responseBody</span><span class="p">.</span><span class="n">TrimStart</span><span class="p">().</span><span class="n">StartsWith</span><span class="p">(</span><span class="s">&quot;{&quot;</span><span class="p">))</span>
+<span class="p">{</span>
+<span class="w">    </span><span class="k">using</span><span class="w"> </span><span class="nn">var</span><span class="w"> </span><span class="n">created</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">JsonDocument</span><span class="p">.</span><span class="n">Parse</span><span class="p">(</span><span class="n">responseBody</span><span class="p">);</span>
+<span class="w">    </span><span class="k">foreach</span><span class="w"> </span><span class="p">(</span><span class="kt">var</span><span class="w"> </span><span class="n">key</span><span class="w"> </span><span class="k">in</span><span class="w"> </span><span class="k">new</span><span class="p">[]</span><span class="w"> </span><span class="p">{</span><span class="w"> </span><span class="s">&quot;OrderNo&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;OrderNumber&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;Id&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;OrderId&quot;</span><span class="w"> </span><span class="p">})</span>
+<span class="w">    </span><span class="p">{</span>
+<span class="w">        </span><span class="k">if</span><span class="w"> </span><span class="p">(</span><span class="n">created</span><span class="p">.</span><span class="n">RootElement</span><span class="p">.</span><span class="n">TryGetProperty</span><span class="p">(</span><span class="n">key</span><span class="p">,</span><span class="w"> </span><span class="k">out</span><span class="w"> </span><span class="kt">var</span><span class="w"> </span><span class="k">value</span><span class="p">)</span><span class="w"> </span><span class="o">&amp;&amp;</span>
+<span class="w">            </span><span class="k">value</span><span class="p">.</span><span class="n">ValueKind</span><span class="w"> </span><span class="k">is</span><span class="w"> </span><span class="k">not</span><span class="w"> </span><span class="p">(</span><span class="n">JsonValueKind</span><span class="p">.</span><span class="n">Null</span><span class="w"> </span><span class="k">or</span><span class="w"> </span><span class="n">JsonValueKind</span><span class="p">.</span><span class="n">Undefined</span><span class="p">))</span>
+<span class="w">        </span><span class="p">{</span>
+<span class="w">            </span><span class="n">orderNo</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">value</span><span class="p">.</span><span class="n">ToString</span><span class="p">();</span>
+<span class="w">            </span><span class="k">if</span><span class="w"> </span><span class="p">(</span><span class="o">!</span><span class="kt">string</span><span class="p">.</span><span class="n">IsNullOrWhiteSpace</span><span class="p">(</span><span class="n">orderNo</span><span class="p">))</span><span class="w"> </span><span class="k">break</span><span class="p">;</span>
+<span class="w">        </span><span class="p">}</span>
+<span class="w">    </span><span class="p">}</span>
+<span class="p">}</span>
+
+<span class="k">if</span><span class="w"> </span><span class="p">(</span><span class="kt">string</span><span class="p">.</span><span class="n">IsNullOrWhiteSpace</span><span class="p">(</span><span class="n">orderNo</span><span class="p">))</span>
+<span class="p">{</span>
+<span class="w">    </span><span class="n">Console</span><span class="p">.</span><span class="n">WriteLine</span><span class="p">(</span><span class="s">&quot;No order number in the create response -- see the body printed above&quot;</span><span class="p">);</span>
+<span class="w">    </span><span class="k">return</span><span class="p">;</span>
+<span class="p">}</span>
+
+<span class="c1">// Read back -- HTTP 200 on the POST doesn&#39;t confirm what actually landed.</span>
+<span class="n">resp</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">await</span><span class="w"> </span><span class="n">client</span><span class="p">.</span><span class="n">GetAsync</span><span class="p">(</span><span class="s">$&quot;{BaseUrl}/api/sales/orders/{orderNo}&quot;</span><span class="p">);</span>
+<span class="n">resp</span><span class="p">.</span><span class="n">EnsureSuccessStatusCode</span><span class="p">();</span>
+<span class="k">using</span><span class="w"> </span><span class="nn">var</span><span class="w"> </span><span class="n">readBack</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">JsonDocument</span><span class="p">.</span><span class="n">Parse</span><span class="p">(</span><span class="k">await</span><span class="w"> </span><span class="n">resp</span><span class="p">.</span><span class="n">Content</span><span class="p">.</span><span class="n">ReadAsStringAsync</span><span class="p">());</span>
+<span class="kt">var</span><span class="w"> </span><span class="n">lineCount</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">readBack</span><span class="p">.</span><span class="n">RootElement</span><span class="p">.</span><span class="n">TryGetProperty</span><span class="p">(</span><span class="s">&quot;Lines&quot;</span><span class="p">,</span><span class="w"> </span><span class="k">out</span><span class="w"> </span><span class="kt">var</span><span class="w"> </span><span class="n">lines</span><span class="p">)</span><span class="w"> </span><span class="o">&amp;&amp;</span>
+<span class="w">                </span><span class="n">lines</span><span class="p">.</span><span class="n">TryGetProperty</span><span class="p">(</span><span class="s">&quot;list&quot;</span><span class="p">,</span><span class="w"> </span><span class="k">out</span><span class="w"> </span><span class="kt">var</span><span class="w"> </span><span class="n">list</span><span class="p">)</span><span class="w"> </span><span class="o">&amp;&amp;</span>
+<span class="w">                </span><span class="n">list</span><span class="p">.</span><span class="n">ValueKind</span><span class="w"> </span><span class="o">==</span><span class="w"> </span><span class="n">JsonValueKind</span><span class="p">.</span><span class="n">Array</span>
+<span class="w">    </span><span class="o">?</span><span class="w"> </span><span class="n">list</span><span class="p">.</span><span class="n">GetArrayLength</span><span class="p">()</span>
+<span class="w">    </span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">;</span>
+<span class="kt">var</span><span class="w"> </span><span class="n">customer</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">readBack</span><span class="p">.</span><span class="n">RootElement</span><span class="p">.</span><span class="n">TryGetProperty</span><span class="p">(</span><span class="s">&quot;CustomerId&quot;</span><span class="p">,</span><span class="w"> </span><span class="k">out</span><span class="w"> </span><span class="kt">var</span><span class="w"> </span><span class="n">c</span><span class="p">)</span><span class="w"> </span><span class="o">?</span><span class="w"> </span><span class="n">c</span><span class="p">.</span><span class="n">ToString</span><span class="p">()</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s">&quot;?&quot;</span><span class="p">;</span>
+<span class="n">Console</span><span class="p">.</span><span class="n">WriteLine</span><span class="p">(</span><span class="s">$&quot;Order {orderNo}: customer {customer}, {lineCount} line(s)&quot;</span><span class="p">);</span>
+
+<span class="c1">// --- helpers ---------------------------------------------------------------</span>
+
+<span class="c1">// v2 token endpoint — credentials go in the body, never in headers.</span>
+<span class="k">static</span><span class="w"> </span><span class="k">async</span><span class="w"> </span><span class="n">Task</span><span class="o">&lt;</span><span class="kt">string</span><span class="o">&gt;</span><span class="w"> </span><span class="n">GetTokenAsync</span><span class="p">(</span><span class="n">HttpClient</span><span class="w"> </span><span class="n">client</span><span class="p">)</span>
+<span class="p">{</span>
+<span class="w">    </span><span class="kt">var</span><span class="w"> </span><span class="n">payload</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">JsonSerializer</span><span class="p">.</span><span class="n">Serialize</span><span class="p">(</span><span class="k">new</span><span class="w"> </span><span class="p">{</span><span class="w"> </span><span class="n">username</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">Username</span><span class="p">,</span><span class="w"> </span><span class="n">password</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">Password</span><span class="w"> </span><span class="p">});</span>
+<span class="w">    </span><span class="kt">var</span><span class="w"> </span><span class="n">response</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">await</span><span class="w"> </span><span class="n">client</span><span class="p">.</span><span class="n">PostAsync</span><span class="p">(</span>
+<span class="w">        </span><span class="s">$&quot;{BaseUrl}/api/security/token/v2&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="k">new</span><span class="w"> </span><span class="nf">StringContent</span><span class="p">(</span><span class="n">payload</span><span class="p">,</span><span class="w"> </span><span class="n">Encoding</span><span class="p">.</span><span class="n">UTF8</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;application/json&quot;</span><span class="p">));</span>
+<span class="w">    </span><span class="n">response</span><span class="p">.</span><span class="n">EnsureSuccessStatusCode</span><span class="p">();</span>
+<span class="w">    </span><span class="k">return</span><span class="w"> </span><span class="nf">ReadField</span><span class="p">(</span><span class="k">await</span><span class="w"> </span><span class="n">response</span><span class="p">.</span><span class="n">Content</span><span class="p">.</span><span class="n">ReadAsStringAsync</span><span class="p">(),</span><span class="w"> </span><span class="s">&quot;AccessToken&quot;</span><span class="p">);</span>
+<span class="p">}</span>
+
+<span class="c1">// Some middleware answers this endpoint in XML even when asked for JSON.</span>
+<span class="k">static</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="nf">ReadField</span><span class="p">(</span><span class="kt">string</span><span class="w"> </span><span class="n">payload</span><span class="p">,</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">field</span><span class="p">)</span>
+<span class="p">{</span>
+<span class="w">    </span><span class="k">try</span>
+<span class="w">    </span><span class="p">{</span>
+<span class="w">        </span><span class="kt">var</span><span class="w"> </span><span class="k">value</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">JsonDocument</span><span class="p">.</span><span class="n">Parse</span><span class="p">(</span><span class="n">payload</span><span class="p">).</span><span class="n">RootElement</span><span class="p">.</span><span class="n">GetProperty</span><span class="p">(</span><span class="n">field</span><span class="p">).</span><span class="n">GetString</span><span class="p">();</span>
+<span class="w">        </span><span class="k">if</span><span class="w"> </span><span class="p">(</span><span class="o">!</span><span class="kt">string</span><span class="p">.</span><span class="n">IsNullOrEmpty</span><span class="p">(</span><span class="k">value</span><span class="p">))</span><span class="w"> </span><span class="k">return</span><span class="w"> </span><span class="k">value</span><span class="p">;</span>
+<span class="w">    </span><span class="p">}</span>
+<span class="w">    </span><span class="k">catch</span><span class="w"> </span><span class="p">(</span><span class="n">Exception</span><span class="w"> </span><span class="n">ex</span><span class="p">)</span><span class="w"> </span><span class="k">when</span><span class="w"> </span><span class="p">(</span><span class="n">ex</span><span class="w"> </span><span class="k">is</span><span class="w"> </span><span class="n">JsonException</span><span class="w"> </span><span class="k">or</span><span class="w"> </span><span class="n">KeyNotFoundException</span><span class="p">)</span><span class="w"> </span><span class="p">{</span><span class="w"> </span><span class="p">}</span>
+
+<span class="w">    </span><span class="kt">var</span><span class="w"> </span><span class="n">match</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">System</span><span class="p">.</span><span class="n">Text</span><span class="p">.</span><span class="n">RegularExpressions</span><span class="p">.</span><span class="n">Regex</span><span class="p">.</span><span class="n">Match</span><span class="p">(</span><span class="n">payload</span><span class="p">,</span><span class="w"> </span><span class="s">$&quot;&lt;{field}&gt;([^&lt;]+)&lt;/{field}&gt;&quot;</span><span class="p">);</span>
+<span class="w">    </span><span class="k">if</span><span class="w"> </span><span class="p">(</span><span class="o">!</span><span class="n">match</span><span class="p">.</span><span class="n">Success</span><span class="p">)</span>
+<span class="w">        </span><span class="k">throw</span><span class="w"> </span><span class="k">new</span><span class="w"> </span><span class="nf">InvalidOperationException</span><span class="p">(</span>
+<span class="w">            </span><span class="s">$&quot;No {field} in response: {payload[..Math.Min(200, payload.Length)]}&quot;</span><span class="p">);</span>
+<span class="w">    </span><span class="k">return</span><span class="w"> </span><span class="n">match</span><span class="p">.</span><span class="n">Groups</span><span class="p">[</span><span class="mi">1</span><span class="p">].</span><span class="n">Value</span><span class="p">;</span>
+<span class="p">}</span>
+</code></pre></div>
+</div>
+</div>
+<h4 id="what-is-not-pinned-down-yet">What is not pinned down yet</h4>
+<p>Stated as unknowns rather than guessed at — if you settle one against your tenant, <a href="https://github.com/mrwuss/p21-api-documentation/issues/new/choose">open an issue</a> and it gets documented:</p>
+<ul>
+<li><strong>The success response shape</strong>, including where the generated order number comes back. The example above prints the raw body and probes four plausible key spellings for exactly this reason.</li>
+<li><strong>Which fields are strictly required</strong> versus optional. The header above is one working example from one 25.2 tenant, not a minimum payload — configuration (taxes, terms, ship-to defaults) decides what your server insists on.</li>
+<li><strong>Whether the inline ship-to fields are required alongside <code>ShipToId</code></strong> or only act as a fallback when the ship-to record doesn't resolve a full address.</li>
+<li><strong>HTTP status codes and body for validation failures</strong> — the write-side error vocabulary of this family is undocumented.</li>
+<li><strong>The other collections in the <code>/new</code> template</strong> (<code>Notes</code>, <code>Salesreps</code>, <code>BuilderSelectionSheets</code>, <code>Samples</code>) — presumably the same <code>{"list": [...]}</code> nesting as <code>Lines</code>, but untested.</li>
+</ul>
+<h4 id="rest-vs-the-transaction-api-for-order-creation">REST vs the Transaction API for order creation</h4>
+<p>Both create orders. Pick by what you need:</p>
+<div class="table-wrap"><table>
+<thead>
+<tr>
+<th></th>
+<th><code>POST /api/sales/orders/</code></th>
+<th>Transaction API <code>Order</code> service</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Payload</td>
+<td>Plain domain JSON, lines under <code>Lines.list</code></td>
+<td><code>DataElements</code> / <code>Rows</code> / <code>Edits</code>, every value a string</td>
+</tr>
+<tr>
+<td>Verified by</td>
+<td>Contributor, 25.2 (<a href="https://github.com/mrwuss/p21-api-documentation/issues/108">issue #108</a>)</td>
+<td>This repo, against a live tenant</td>
+</tr>
+<tr>
+<td>Error reporting</td>
+<td>Undocumented (see above)</td>
+<td><code>Summary.Succeeded</code> / <code>Failed</code> envelope, <a href="06-Error-Handling.html">documented traps</a></td>
+</tr>
+<tr>
+<td>Bulk</td>
+<td>One order per call</td>
+<td>Many orders per call</td>
+</tr>
+<tr>
+<td>Assembly lines</td>
+<td>Untested</td>
+<td>Auto-answers the explode prompt <strong>No</strong> — use the <a href="recipes/order-with-assembly.html">order-with-assembly</a> recipe instead</td>
+</tr>
+</tbody>
+</table></div>
+<p>For a walk-through of the Transaction path, see the <a href="recipes/create-sales-order.html">create-sales-order recipe</a>.</p>
 <h3 id="families-that-404-on-the-tested-tenant">Families that 404 on the tested tenant</h3>
 <p><code>sales/customers</code>, <code>sales/quotes</code>, <code>sales/invoices</code>, <code>sales/shipments</code>, <code>sales/payments</code>, <code>purchasing/*</code>, <code>ar/*</code>, <code>inventory/items</code>, <code>inventory/lots</code> — all returned 404 on ping. Availability may vary by version; the SOA middleware admin site lists the endpoint families your server actually exposes.</p>
 <p><em>Credit: Felipe Maurer (<a href="https://forums.p21ww.org/UserInfo10045.aspx">P21WWUG profile</a>) — surfaced <code>/api/sales/orders</code> and the middleware endpoint listing in <a href="https://forums.p21ww.org/Topic245514-3.aspx">this forum topic</a>.</em></p>
+<p><em>Credit: <a href="https://github.com/roblandham">Rob Landham</a> — documented <code>POST /api/sales/orders/</code>, the required trailing slash and the <code>Lines.list</code> nesting, tested on 25.2 (<a href="https://github.com/mrwuss/p21-api-documentation/issues/108">issue #108</a>).</em></p>
 <hr />
 <h2 id="common-errors">Common Errors</h2>
 <div class="table-wrap"><table>

--- a/docs/html/10-Changelog.html
+++ b/docs/html/10-Changelog.html
@@ -516,6 +516,7 @@
                 <div class="toc">
 <ul>
 <li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-08-19-v151">2026-08-19 — v1.5.1</a></li>
 <li><a href="#2026-08-11-v150">2026-08-11 — v1.5.0</a><ul>
 <li><a href="#first-pass-claims-checked-while-resolving-the-issues">First pass — claims checked while resolving the issues</a></li>
 <li><a href="#second-verification-pass-every-remaining-unproven-claim-chased">Second verification pass — every remaining unproven claim chased</a></li>
@@ -577,6 +578,12 @@
 <li><strong>25.2</strong> — <code>DatawindowName</code> <strong>required</strong> in Interactive change requests (3-param form stops working). → <a href="14-Breaking-Changes.html#p21-252">details</a></li>
 </ul>
 </blockquote>
+<hr />
+<h2 id="2026-08-19-v151">2026-08-19 — v1.5.1</h2>
+<p>Community contribution: the <code>/api/sales/orders</code> family creates orders as well as reading them.</p>
+<ul>
+<li><strong>feat:</strong> <strong><code>POST /api/sales/orders/</code> creates a sales order</strong> — documented from a community contribution tested on <strong>25.2</strong>, with the two shape rules that decide whether the call works at all: the <strong>trailing slash is required</strong> (without it the request is not routed to the API — and on a POST you cannot lean on a redirect-following client the way the read-side 307 lets you), and <strong><code>Lines</code> is an object, not an array</strong> — the lines go in <code>Lines.list</code>, which the <code>/new</code> template shows without explaining. Adds the header and line field tables, an example body, a complete runnable Python/C# program, and a REST-vs-Transaction comparison for choosing between the two order-creation paths. The section states plainly what the contribution does <strong>not</strong> settle — the success response shape and where the order number comes back, which fields are strictly required versus optional, whether the inline ship-to fields are required alongside <code>ShipToId</code> or only a fallback, the validation-error status codes, and whether the <code>/new</code> template's other collections (<code>Notes</code>, <code>Salesreps</code>, …) use the same <code>list</code> nesting — so nobody mistakes one working payload for a specification. Doc 05's "writes are untested" note, the selection guide and the task index are updated accordingly. → <a href="05-Entity-API.html#creating-an-order-post-apisalesorders">05 § Creating an Order</a> — <em>Rob Landham (<a href="https://github.com/roblandham">@roblandham</a>), documented by @mrwuss</em> — Fixes #108</li>
+</ul>
 <hr />
 <h2 id="2026-08-11-v150">2026-08-11 — v1.5.0</h2>
 <p>Cleared issues #103 and #105–#107, converted every API-calling code example in the docs into a complete runnable program, and re-verified a batch of long-standing claims against a live tenant. Verification build: <strong>26.1.5910.3</strong>. The checks turned up several errors in our own documentation; those are listed first.</p>
@@ -881,6 +888,11 @@
 <td>NextTWis</td>
 <td><a href="https://github.com/NextTWis">@NextTWis</a></td>
 <td>Postman Collection for P21 API verification (<a href="https://github.com/mrwuss/p21-api-documentation/pull/24">PR #24</a>)</td>
+</tr>
+<tr>
+<td>Rob Landham</td>
+<td><a href="https://github.com/roblandham">@roblandham</a></td>
+<td><code>POST /api/sales/orders/</code> order creation — payload shape, required trailing slash, <code>Lines.list</code> nesting (<a href="https://github.com/mrwuss/p21-api-documentation/issues/108">issue #108</a>)</td>
 </tr>
 <tr>
 <td>Alex Westemeier</td>

--- a/docs/html/recipes/create-sales-order.html
+++ b/docs/html/recipes/create-sales-order.html
@@ -532,6 +532,9 @@
 <h1 id="create-a-sales-order">Create a Sales Order</h1>
 <p>Create a sales order — header plus line items — in one stateless Transaction API call.</p>
 <p><strong>API:</strong> Transaction · <strong>Service:</strong> <code>Order</code> · <strong>Deep dive:</strong> <a href="../03-Transaction-API.html#create-order">Create Order</a> · <a href="../03-Transaction-API.html#order-service-gotchas">Order Service Gotchas</a> · <strong>Full schema:</strong> <a href="https://github.com/mrwuss/p21-api-documentation/blob/master/definitions/Order.json">Order.json</a></p>
+<blockquote>
+<p><strong>There is a second path.</strong> <code>POST /api/sales/orders/</code> creates an order from plain domain JSON — no <code>DataElements</code>, no string-typed values — contributed and tested on 25.2 (<a href="../05-Entity-API.html#creating-an-order-post-apisalesorders">05 § Creating an Order</a>). It is the lighter payload; this Transaction recipe is the one verified here, reports errors in a documented envelope, and creates many orders per call. The <a href="../05-Entity-API.html#rest-vs-the-transaction-api-for-order-creation">side-by-side comparison</a> picks between them.</p>
+</blockquote>
 <h2 id="prerequisites">Prerequisites</h2>
 <ul>
 <li>P21 credentials — the complete example below authenticates itself; nothing to install but <code>httpx</code> (Python) or a bare <code>net9.0</code> console project (C#).</li>

--- a/docs/html/task-index.html
+++ b/docs/html/task-index.html
@@ -805,7 +805,7 @@
 <tr>
 <td>Read/create <strong>sales orders via REST</strong> (<code>/api/sales/orders</code>)</td>
 <td>—</td>
-<td><a href="05-Entity-API.html#other-rest-endpoint-families">05 § Other REST Endpoint Families</a></td>
+<td><a href="05-Entity-API.html#other-rest-endpoint-families">05 § Other REST Endpoint Families</a> · <a href="05-Entity-API.html#creating-an-order-post-apisalesorders">05 § Creating an Order</a> — <strong>trailing slash required; lines nest under <code>Lines.list</code></strong></td>
 </tr>
 <tr>
 <td>Inventory items: read / create / update locations</td>

--- a/docs/recipes/create-sales-order.md
+++ b/docs/recipes/create-sales-order.md
@@ -4,6 +4,8 @@ Create a sales order — header plus line items — in one stateless Transaction
 
 **API:** Transaction · **Service:** `Order` · **Deep dive:** [Create Order](../03-Transaction-API.md#create-order) · [Order Service Gotchas](../03-Transaction-API.md#order-service-gotchas) · **Full schema:** [Order.json](../../definitions/Order.json)
 
+> **There is a second path.** `POST /api/sales/orders/` creates an order from plain domain JSON — no `DataElements`, no string-typed values — contributed and tested on 25.2 ([05 § Creating an Order](../05-Entity-API.md#creating-an-order-post-apisalesorders)). It is the lighter payload; this Transaction recipe is the one verified here, reports errors in a documented envelope, and creates many orders per call. The [side-by-side comparison](../05-Entity-API.md#rest-vs-the-transaction-api-for-order-creation) picks between them.
+
 ## Prerequisites
 
 - P21 credentials — the complete example below authenticates itself; nothing to install but `httpx` (Python) or a bare `net9.0` console project (C#).


### PR DESCRIPTION
Documents the community contribution in #108 from **[Rob Landham (@roblandham)](https://github.com/roblandham)** — `/api/sales/orders` creates orders as well as reading them.

Doc 05 previously said writes on this family were untested. They aren't, for creates: the same URL takes a POST whose body is one order.

## The two rules that decide whether the call works

- **The trailing slash is required.** `POST /api/sales/orders/` routes; without it the request never reaches the API. This is the write-side face of the [307 on list endpoints](https://github.com/mrwuss/p21-api-documentation/blob/master/docs/05-Entity-API.md#trailing-slash-on-list-endpoints) — except that on a POST you can't paper over it with a redirect-following client, because whether the body and method survive the hop is up to the client.
- **`Lines` is an object, not an array.** Lines go in `Lines.list`; a top-level `Lines` array fails. This is the one thing `GET /api/sales/orders/new` shows without explaining.

## What's in the PR

- **`docs/05-Entity-API.md`** — new *Creating an Order* section under *Other REST Endpoint Families*: header + line field tables, example body in repo placeholder data (`ACME`, `100198`, `WIDGET-001`), a complete runnable Python/C# program, and a REST-vs-Transaction comparison for picking between the two order-creation paths. The `POST` row is added to the family's call table and the "writes are untested" note is narrowed to the approve action and everything else.
- **Attribution** — inline credit block at the top of the section, a `*Credit: ...*` line beside Felipe Maurer's at the end of the family section, a changelog entry, and a row in the Contributors table.
- **Routing layer** — `docs/INDEX.md` row updated with the new anchor and the two gotchas; selection guide now says the family reads *and* creates; the Transaction `create-sales-order` recipe points at the REST alternative.
- **`docs/10-Changelog.md`** — `2026-08-19 — v1.5.1` entry, Fixes #108.
- **`docs/html/`** — regenerated (only the 5 affected pages differ; Pygments pinned to the version that reproduces the committed baseline, so there's no escaping churn across the other 27).

## Honest about what isn't known

Per the repo's facts-only rule, the contribution is presented as one working payload from one 25.2 tenant, not a specification. A *What is not pinned down yet* subsection states the open questions the contributor themself raised: the success response shape and where the order number comes back, which fields are strictly required vs optional, whether the inline ship-to fields are required alongside `ShipToId` or only a fallback, the validation-error status codes, and whether the `/new` template's other collections (`Notes`, `Salesreps`, …) use the same `list` nesting.

The runnable example is built around that uncertainty: it prints the raw create response before probing four plausible order-number keys, and only reads the order back if it finds one.

## Verification

- Python block parses (`ast.parse`); the JSON payload parses.
- Tabbed rendering and all three new anchors confirmed present in the generated HTML; inbound links from INDEX, the selection guide and the recipe resolve.
- **The C# block was not compiled** — no .NET SDK in this environment and the installer host is blocked by the proxy. It mirrors the repo's build-verified *Create Customer* example (same auth preamble, handler, and XML-fallback helper) and was reviewed by hand, but a maintainer with `dotnet` should `dotnet new console` + paste before trusting it.
- The endpoint behaviour itself is the contributor's, tested on 25.2, and is labelled as such throughout — not re-verified against a tenant here.

Fixes #108

---
_Generated by [Claude Code](https://claude.ai/code/session_01986cuaAN3PLkTuhdpneveN)_