### PR TITLE
ci: flag issues and PRs opened from outside the repo team

### DIFF
--- a/.github/workflows/flag-external-contributions.yml
+++ b/.github/workflows/flag-external-contributions.yml
@@ -1,0 +1,63 @@
+# Flags issues and pull requests opened by people outside the repo team, so
+# community contributions stand out from the maintainer's own activity.
+#
+# As the repo owner you already get a notification for *every* issue and PR by
+# watching the repo. What this adds is a way to tell external ones apart: each
+# gets the `external-contribution` label (filterable in the issue list) and is
+# assigned to the owner, which lands the notification in the "Participating"
+# bucket — the one GitHub emails by default.
+#
+# Security: `pull_request_target` runs with a write token in the *base* repo's
+# context, so this workflow deliberately never checks out or executes the PR's
+# code. Do not add `actions/checkout` here.
+
+name: Flag external contributions
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  flag:
+    # OWNER / MEMBER / COLLABORATOR are the repo's own team; everyone else is
+    # external, including a CONTRIBUTOR who has had a patch merged before.
+    # Bots (dependabot and friends) are not people and are skipped.
+    if: >-
+      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.issue.author_association || github.event.pull_request.author_association)
+      && (github.event.issue.user.type || github.event.pull_request.user.type) != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label and assign
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          KIND: ${{ github.event.issue.number && 'issue' || 'pull request' }}
+          AUTHOR: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
+          ASSOCIATION: ${{ github.event.issue.author_association || github.event.pull_request.author_association }}
+          ASSIGNEE: ${{ github.repository_owner }}
+          LABEL: external-contribution
+        run: |
+          set -euo pipefail
+
+          # Create the label on first use so a fresh clone of this workflow works.
+          gh api "repos/$REPO/labels/$LABEL" --silent 2>/dev/null \
+            || gh api "repos/$REPO/labels" --silent \
+                 -f name="$LABEL" \
+                 -f color=0E8A16 \
+                 -f description="Opened by someone outside the repo team" 2>/dev/null \
+            || true
+
+          # Both endpoints are the issues API -- pull requests are issues here.
+          gh api "repos/$REPO/issues/$NUMBER/labels" --silent -f "labels[]=$LABEL"
+          gh api "repos/$REPO/issues/$NUMBER/assignees" --silent -f "assignees[]=$ASSIGNEE"
+
+          echo "Flagged $KIND #$NUMBER by @$AUTHOR ($ASSOCIATION):" >> "$GITHUB_STEP_SUMMARY"
+          echo "labeled \`$LABEL\`, assigned to @$ASSIGNEE." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds `.github/workflows/flag-external-contributions.yml` — the repo's first workflow.

## What it does

On an issue or PR opened by anyone outside the repo team, it:

1. applies the `external-contribution` label (created on first use, so there's no setup step), and
2. assigns the item to the repo owner.

"Outside the team" means `author_association` is not `OWNER`, `MEMBER` or `COLLABORATOR` — so a `CONTRIBUTOR` who has had a patch merged before still counts as external. Bots are skipped, so Dependabot and friends don't trip it.

## Why assignment, not just a label

Watching this repo already notifies you about *every* issue and PR, so nothing was being missed — what was missing was a way to tell community contributions apart from your own activity. The label makes them filterable in the issue list (`label:external-contribution`); the assignment is what produces the notification, landing it in the **Participating** bucket, which is the one GitHub emails by default. A label on its own notifies nobody.

## Security note

`pull_request_target` is required to label a PR from a fork — the `pull_request` token is read-only in that case. It runs with a write token in the base repo's context, so the job **never checks out or executes the PR's code**: there is no `actions/checkout` step, deliberately, and a comment in the file says so.

## Verification

- YAML parses; trigger, permissions, condition and steps confirmed, and the absence of `actions/checkout` asserted.
- Both API calls go through the issues endpoints, which serve pull requests too, so one code path covers both.
- **Not exercised end to end** — that needs an external account to open an issue here, which I can't stage. The first real external contribution is the live test; if it doesn't fire, the run log under Actions → *Flag external contributions* will say why.

Assignees must have push access or GitHub silently ignores them; `github.repository_owner` does, so that's fine here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01986cuaAN3PLkTuhdpneveN)_