### PR TITLE
docs(transaction): a 204 from /commands empties the whole batch response

### DIFF
--- a/docs/03-Transaction-API.md
+++ b/docs/03-Transaction-API.md
@@ -842,7 +842,9 @@ Verified against a 26.1 tenant (August 2026) by running each value and reading t
 | `6` | Save | — |
 | `9` | Run a tool (button) | `ToolName`, `Row` |
 
-`3` returns HTTP **204** and `4` returns `Status: 2` — both are real actions whose arguments we haven't mapped. `7`, `8`, and `10`+ return an **empty HTTP 500**, the same not-implemented signature seen elsewhere on 26.1. `DetailLevel` was `0` throughout except where noted; its effect is undocumented.
+`3` and `4` are real but unmapped: `4` with a `DatawindowName` returns `Status: 2` (Failure), while `3` with any argument shape — and `4` with none — returns **HTTP 204**. `7`, `8`, and `10`+ return an **empty HTTP 500**, the not-implemented signature seen elsewhere on 26.1.
+
+> **A `204` empties the entire response, not just that step.** One unrecognised action mid-batch and you get a zero-length body — no `Results` array, no per-step statuses, nothing to inspect about the steps that *did* run. Parse defensively: check for a body before calling `.json()`, and treat a 204 as "the batch told you nothing", not as success. `DetailLevel` was `0`/`1`/`2` across these probes with no observable difference; its effect is undocumented.
 
 > **This is the sanctioned path for notepads.** Verified end-to-end on 26.1 (August 2026): the payload above wrote an item note — including satisfying the mandatory **drag-and-drop area selector** via `Action 5` (select a row in `tp_17_dw_dragdrop`) then `Action 9` (`cb_select`) — returned `savesucceeded`, and the row was confirmed in the `note` table. See [Limitations](#limitations) for how this relates to the `/transaction` endpoint's refusal of the same services.
 

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -2015,8 +2015,9 @@
 </tr>
 </tbody>
 </table></div>
-<p><code>3</code> returns HTTP <strong>204</strong> and <code>4</code> returns <code>Status: 2</code> — both are real actions whose arguments we haven't mapped. <code>7</code>, <code>8</code>, and <code>10</code>+ return an <strong>empty HTTP 500</strong>, the same not-implemented signature seen elsewhere on 26.1. <code>DetailLevel</code> was <code>0</code> throughout except where noted; its effect is undocumented.</p>
+<p><code>3</code> and <code>4</code> are real but unmapped: <code>4</code> with a <code>DatawindowName</code> returns <code>Status: 2</code> (Failure), while <code>3</code> with any argument shape — and <code>4</code> with none — returns <strong>HTTP 204</strong>. <code>7</code>, <code>8</code>, and <code>10</code>+ return an <strong>empty HTTP 500</strong>, the not-implemented signature seen elsewhere on 26.1.</p>
 <blockquote>
+<p><strong>A <code>204</code> empties the entire response, not just that step.</strong> One unrecognised action mid-batch and you get a zero-length body — no <code>Results</code> array, no per-step statuses, nothing to inspect about the steps that <em>did</em> run. Parse defensively: check for a body before calling <code>.json()</code>, and treat a 204 as "the batch told you nothing", not as success. <code>DetailLevel</code> was <code>0</code>/<code>1</code>/<code>2</code> across these probes with no observable difference; its effect is undocumented.</p>
 <p><strong>This is the sanctioned path for notepads.</strong> Verified end-to-end on 26.1 (August 2026): the payload above wrote an item note — including satisfying the mandatory <strong>drag-and-drop area selector</strong> via <code>Action 5</code> (select a row in <code>tp_17_dw_dragdrop</code>) then <code>Action 9</code> (<code>cb_select</code>) — returned <code>savesucceeded</code>, and the row was confirmed in the <code>note</code> table. See <a href="#limitations">Limitations</a> for how this relates to the <code>/transaction</code> endpoint's refusal of the same services.</p>
 </blockquote>
 <hr />


### PR DESCRIPTION
Follow-up while trying to close the last documented gap — the unmapped `Action` codes `3` and `4` on `/api/v2/commands`.

Probing both with varied argument shapes and `DetailLevel` 0/1/2 didn't pin their meaning, so they stay marked unmapped. But it surfaced something a client author does need:

**An unrecognised action mid-batch returns HTTP 204 with a zero-length body** — no `Results` array, no per-step statuses, nothing about the steps that *did* run. Parse defensively: check for a body before `.json()`, and treat a 204 as "the batch told you nothing" rather than as success.

Also narrows the enum note: `Action 4` **with** a `DatawindowName` returns `Status: 2`, while `Action 3` with any argument shape (and `4` with none) returns 204. `DetailLevel` made no observable difference across 0/1/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)