### PR TITLE
docs: Order refuses RMAs — use the RMA service (v1.8.3)

### DIFF
--- a/docs/03-Transaction-API.md
+++ b/docs/03-Transaction-API.md
@@ -1443,6 +1443,7 @@ All verified live (credit: [Alex Westemeier](https://github.com/AWestemeier)):
 - **`company_id` is a disabled column** on the Order window — don't send it.
 - **DynaChange prompts are auto-answered with the default** (usually "No"), which silently discards the affected line — e.g. *"order line does not have a PO Cost… proceed? [No]"*. On multi-item orders the remaining lines then cascade-fail. This is a P21 configuration matter (exempt the rule for the API user, or fix the data), not something a payload change can work around — see [DynaChange and Popup Handling](#dynachange-and-popup-handling).
 - **Assembly items cannot be entered via the Transaction API** when they should explode or spawn a production order — the *"add as assembly?"* prompt is auto-answered **No**, killing the explode. Use the Interactive API for those lines: see [Sales Order Entry with Assembly Lines](04-Interactive-API.md#sales-order-entry-with-assembly-lines).
+- **RMAs are not `Order` records.** An order with `rma_flag = 'Y'` is refused outright: `General Exception: You cannot retrieve an RMA from the Order Entry/Front Counter window.` Use the [`RMA` service](#rma-service-orders-the-order-service-refuses).
 - **The same item on two lines collapses to one** with `Keys: []` — `TP_ITEMS.items` folds rows on its declared key (`oe_order_item_id`), last value wins, `Succeeded: 1`, no warning. Add `Keys: ["unit_quantity"]` (or another differing column) when an order legitimately repeats an item — see [Keys — Row Identity and the Collapse Trap](#keys-row-identity-and-the-collapse-trap).
 - The created `order_no` comes back in the result rows; check `Summary.Succeeded`, not the HTTP status.
 
@@ -3485,6 +3486,29 @@ static string ReadField(string payload, string field)
 <!-- /tabs -->
 
 ---
+
+### RMA Service — Orders the `Order` Service Refuses
+
+Return Merchandise Authorizations live in `oe_hdr` alongside ordinary sales orders, but the **`Order` service will not touch them**. Loading one by `order_no` fails immediately:
+
+```text
+General Exception: You cannot retrieve an RMA from the Order Entry/Front Counter window.
+DataElement: order, Column: order_no
+```
+
+The **`RMA`** service is the same window for the return side. It publishes an **identical `TABPAGE_1.order` Form keyed on `order_no`**, carrying the same header fields (`taker`, `po_no`, dates, and so on), so a payload written for `Order` generally works against `RMA` unchanged — you swap the service name.
+
+Verified on a 26.1 tenant (August 2026) against the same RMA order: `Order` refused it with the message above; `RMA` loaded the record and proceeded to ordinary validation.
+
+**Detect before you dispatch.** There is no way to tell from the order number alone. Read `oe_hdr.rma_flag` over OData and route:
+
+```http
+GET {base}/odataservice/odata/view/p21_view_oe_hdr?$filter=rma_flag eq 'Y'&$select=order_no,rma_flag
+```
+
+This matters most for **bulk header maintenance** — reassigning `taker` when a salesperson leaves, retagging orders, any sweep over open orders. RMAs are a normal part of such a set, and the failure message doesn't obviously mean *"use a different service"*, so a batch job hits it as an unexplained per-record error.
+
+> **Credit:** [Alex Westemeier](https://github.com/AWestemeier) — found while reassigning takers at scale, where the RMA rows in an open-order set failed as a group.
 
 ### Salesrep Service — Editing a Rep's Name and Email
 

--- a/docs/10-Changelog.md
+++ b/docs/10-Changelog.md
@@ -17,6 +17,16 @@ All notable changes to this documentation project are listed below, grouped by d
 
 ---
 
+## 2026-08-20 — v1.8.3
+
+Cross-check against [Alex Westemeier](https://github.com/AWestemeier)'s verified process work — 17 new commits since the July pass. This entry ships the one finding that breaks something published earlier today; the rest are filed as [#130](https://github.com/mrwuss/p21-api-documentation/issues/130)–[#133](https://github.com/mrwuss/p21-api-documentation/issues/133).
+
+- **fix:** **The `Order` service refuses RMAs — use the `RMA` service.** An order with `oe_hdr.rma_flag = 'Y'` fails to load at all: `You cannot retrieve an RMA from the Order Entry/Front Counter window.` The **`RMA`** service is the same window for the return side, publishing an identical `TABPAGE_1.order` form keyed on `order_no` with the same fields — swap the service name and the payload works unchanged. **Verified on our own tenant:** the same RMA order refused by `Order`, loaded by `RMA`.
+
+  This shipped immediately rather than waiting because the [update-order-lines recipe](recipes/update-order-lines.md) went out earlier today telling readers to key `TABPAGE_1.order` and sweep open orders — exactly the bulk pattern that hits RMAs. Adds an [RMA Service](03-Transaction-API.md#rma-service-orders-the-order-service-refuses) reference entry, a gotcha in the recipe and in [Order Service Gotchas](03-Transaction-API.md#order-service-gotchas), and an INDEX row for the error text. Detect with `oe_hdr.rma_flag` and route per order rather than discovering it as a failure — *found by [Alex Westemeier](https://github.com/AWestemeier) while reassigning takers at scale; verified and documented by @mrwuss*
+
+---
+
 ## 2026-08-20 — v1.8.2
 
 Completes the 26.2 help sweep — every one of the 1,251 articles scored for API relevance, 17 candidates triaged, two findings worth keeping.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -63,6 +63,7 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 | Attribute API writes to a **real user**, not the service account | [00 § Attributing writes to a real user](00-Authentication.md#attributing-writes-to-a-real-user) |
 | Who can **read a consumer key's value** (DynaChange rules) | [00 § Method 2: Consumer Key](00-Authentication.md#method-2-consumer-key) — `RuleState.ConsumerKey` exposes it to any rule author |
 | Update a specific order line deterministically (**line handles**) | [03 § Design for updates: assign your own line handles](03-Transaction-API.md#design-for-updates-assign-your-own-line-handles) · [recipe: update-order-lines](recipes/update-order-lines.md) |
+| `You cannot retrieve an RMA from the Order Entry/Front Counter window` | [03 § RMA Service](03-Transaction-API.md#rma-service-orders-the-order-service-refuses) — use the `RMA` service; route on `oe_hdr.rma_flag` |
 | **Modify an existing sales order** (edit a line, add a line) | [recipe: update-order-lines](recipes/update-order-lines.md) |
 | A tool is missing from `GET /v2/tools` on a multi-tab window | [04 § Sales Order Notepad Writes](04-Interactive-API.md#sales-order-notepad-writes-header-vs-line) — tool lists are tab-scoped and accumulate; select the tab first |
 | Write an **item / customer / supplier note** (drag-and-drop area picker) | [04 § Standalone Notepad Windows](04-Interactive-API.md#standalone-notepad-windows-itemcustomersupplier) — the picker is `cb_selectall` via `/tools` |

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -728,6 +728,7 @@
 <li><a href="#binlocation-service-creating-bins">BinLocation Service -- Creating Bins</a></li>
 <li><a href="#putawayzone-pickzone-services-creating-bin-zones">PutawayZone / PickZone Services — Creating Bin Zones</a></li>
 <li><a href="#shipping-service-carrier-tracking-number">Shipping Service -- Carrier Tracking Number</a></li>
+<li><a href="#rma-service-orders-the-order-service-refuses">RMA Service — Orders the Order Service Refuses</a></li>
 <li><a href="#salesrep-service-editing-a-reps-name-and-email">Salesrep Service — Editing a Rep's Name and Email</a></li>
 <li><a href="#itemdefaults-service-per-location-item-defaults">ItemDefaults Service — Per-Location Item Defaults</a></li>
 </ul>
@@ -2627,6 +2628,7 @@ When creating items with lot tracking, interleave item and lot DataElements:
 <li><strong><code>company_id</code> is a disabled column</strong> on the Order window — don't send it.</li>
 <li><strong>DynaChange prompts are auto-answered with the default</strong> (usually "No"), which silently discards the affected line — e.g. <em>"order line does not have a PO Cost… proceed? [No]"</em>. On multi-item orders the remaining lines then cascade-fail. This is a P21 configuration matter (exempt the rule for the API user, or fix the data), not something a payload change can work around — see <a href="#dynachange-and-popup-handling">DynaChange and Popup Handling</a>.</li>
 <li><strong>Assembly items cannot be entered via the Transaction API</strong> when they should explode or spawn a production order — the <em>"add as assembly?"</em> prompt is auto-answered <strong>No</strong>, killing the explode. Use the Interactive API for those lines: see <a href="04-Interactive-API.html#sales-order-entry-with-assembly-lines">Sales Order Entry with Assembly Lines</a>.</li>
+<li><strong>RMAs are not <code>Order</code> records.</strong> An order with <code>rma_flag = 'Y'</code> is refused outright: <code>General Exception: You cannot retrieve an RMA from the Order Entry/Front Counter window.</code> Use the <a href="#rma-service-orders-the-order-service-refuses"><code>RMA</code> service</a>.</li>
 <li><strong>The same item on two lines collapses to one</strong> with <code>Keys: []</code> — <code>TP_ITEMS.items</code> folds rows on its declared key (<code>oe_order_item_id</code>), last value wins, <code>Succeeded: 1</code>, no warning. Add <code>Keys: ["unit_quantity"]</code> (or another differing column) when an order legitimately repeats an item — see <a href="#keys-row-identity-and-the-collapse-trap">Keys — Row Identity and the Collapse Trap</a>.</li>
 <li>The created <code>order_no</code> comes back in the result rows; check <code>Summary.Succeeded</code>, not the HTTP status.</li>
 </ul>
@@ -4994,6 +4996,22 @@ General Exception: This pick ticket has already been invoiced.
 </div>
 </div>
 <hr />
+<h3 id="rma-service-orders-the-order-service-refuses">RMA Service — Orders the <code>Order</code> Service Refuses</h3>
+<p>Return Merchandise Authorizations live in <code>oe_hdr</code> alongside ordinary sales orders, but the <strong><code>Order</code> service will not touch them</strong>. Loading one by <code>order_no</code> fails immediately:</p>
+<div class="highlight"><pre><span></span><code>General Exception: You cannot retrieve an RMA from the Order Entry/Front Counter window.
+DataElement: order, Column: order_no
+</code></pre></div>
+
+<p>The <strong><code>RMA</code></strong> service is the same window for the return side. It publishes an <strong>identical <code>TABPAGE_1.order</code> Form keyed on <code>order_no</code></strong>, carrying the same header fields (<code>taker</code>, <code>po_no</code>, dates, and so on), so a payload written for <code>Order</code> generally works against <code>RMA</code> unchanged — you swap the service name.</p>
+<p>Verified on a 26.1 tenant (August 2026) against the same RMA order: <code>Order</code> refused it with the message above; <code>RMA</code> loaded the record and proceeded to ordinary validation.</p>
+<p><strong>Detect before you dispatch.</strong> There is no way to tell from the order number alone. Read <code>oe_hdr.rma_flag</code> over OData and route:</p>
+<div class="highlight"><pre><span></span><code><span class="err">GET {base}/odataservice/odata/view/p21_view_oe_hdr?$filter=rma_flag eq &#39;Y&#39;&amp;$select=order_no,rma_flag</span>
+</code></pre></div>
+
+<p>This matters most for <strong>bulk header maintenance</strong> — reassigning <code>taker</code> when a salesperson leaves, retagging orders, any sweep over open orders. RMAs are a normal part of such a set, and the failure message doesn't obviously mean <em>"use a different service"</em>, so a batch job hits it as an unexplained per-record error.</p>
+<blockquote>
+<p><strong>Credit:</strong> <a href="https://github.com/AWestemeier">Alex Westemeier</a> — found while reassigning takers at scale, where the RMA rows in an open-order set failed as a group.</p>
+</blockquote>
 <h3 id="salesrep-service-editing-a-reps-name-and-email">Salesrep Service — Editing a Rep's Name and Email</h3>
 <p>The <code>Salesrep</code> service is the write surface for a salesrep's own contact record (the <code>contacts</code> row where <code>salesrep = 'Y'</code>). Verified against P21 26.1 in production (2026-08-11): a misspelled rep name and its email corrected in one transaction, <code>Status: "Passed"</code>, confirmed by read-after-write against <code>contacts</code>.</p>
 <div class="highlight"><pre><span></span><code><span class="p">{</span>
@@ -6310,6 +6328,7 @@ WHERE menu_name LIKE 'm[_]%';</code></p>
 <li><a href="#binlocation-service-creating-bins">BinLocation Service -- Creating Bins</a></li>
 <li><a href="#putawayzone-pickzone-services-creating-bin-zones">PutawayZone / PickZone Services — Creating Bin Zones</a></li>
 <li><a href="#shipping-service-carrier-tracking-number">Shipping Service -- Carrier Tracking Number</a></li>
+<li><a href="#rma-service-orders-the-order-service-refuses">RMA Service — Orders the Order Service Refuses</a></li>
 <li><a href="#salesrep-service-editing-a-reps-name-and-email">Salesrep Service — Editing a Rep's Name and Email</a></li>
 <li><a href="#itemdefaults-service-per-location-item-defaults">ItemDefaults Service — Per-Location Item Defaults</a></li>
 </ul>

--- a/docs/html/10-Changelog.html
+++ b/docs/html/10-Changelog.html
@@ -641,6 +641,7 @@
         <div class="toc">
 <ul>
 <li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-08-20-v183">2026-08-20 — v1.8.3</a></li>
 <li><a href="#2026-08-20-v182">2026-08-20 — v1.8.2</a></li>
 <li><a href="#2026-08-20-v181">2026-08-20 — v1.8.1</a></li>
 <li><a href="#2026-08-20-v180">2026-08-20 — v1.8.0</a></li>
@@ -705,6 +706,13 @@
 <li><strong>25.2</strong> — <code>DatawindowName</code> <strong>required</strong> in Interactive change requests (3-param form stops working). → <a href="14-Breaking-Changes.html#p21-252">details</a></li>
 </ul>
 </blockquote>
+<hr />
+<h2 id="2026-08-20-v183">2026-08-20 — v1.8.3</h2>
+<p>Cross-check against <a href="https://github.com/AWestemeier">Alex Westemeier</a>'s verified process work — 17 new commits since the July pass. This entry ships the one finding that breaks something published earlier today; the rest are filed as <a href="https://github.com/mrwuss/p21-api-documentation/issues/130">#130</a>–<a href="https://github.com/mrwuss/p21-api-documentation/issues/133">#133</a>.</p>
+<ul>
+<li><strong>fix:</strong> <strong>The <code>Order</code> service refuses RMAs — use the <code>RMA</code> service.</strong> An order with <code>oe_hdr.rma_flag = 'Y'</code> fails to load at all: <code>You cannot retrieve an RMA from the Order Entry/Front Counter window.</code> The <strong><code>RMA</code></strong> service is the same window for the return side, publishing an identical <code>TABPAGE_1.order</code> form keyed on <code>order_no</code> with the same fields — swap the service name and the payload works unchanged. <strong>Verified on our own tenant:</strong> the same RMA order refused by <code>Order</code>, loaded by <code>RMA</code>.</li>
+</ul>
+<p>This shipped immediately rather than waiting because the <a href="recipes/update-order-lines.html">update-order-lines recipe</a> went out earlier today telling readers to key <code>TABPAGE_1.order</code> and sweep open orders — exactly the bulk pattern that hits RMAs. Adds an <a href="03-Transaction-API.html#rma-service-orders-the-order-service-refuses">RMA Service</a> reference entry, a gotcha in the recipe and in <a href="03-Transaction-API.html#order-service-gotchas">Order Service Gotchas</a>, and an INDEX row for the error text. Detect with <code>oe_hdr.rma_flag</code> and route per order rather than discovering it as a failure — <em>found by <a href="https://github.com/AWestemeier">Alex Westemeier</a> while reassigning takers at scale; verified and documented by @mrwuss</em></p>
 <hr />
 <h2 id="2026-08-20-v182">2026-08-20 — v1.8.2</h2>
 <p>Completes the 26.2 help sweep — every one of the 1,251 articles scored for API relevance, 17 candidates triaged, two findings worth keeping.</p>
@@ -1169,6 +1177,7 @@
             <div class="toc">
 <ul>
 <li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-08-20-v183">2026-08-20 — v1.8.3</a></li>
 <li><a href="#2026-08-20-v182">2026-08-20 — v1.8.2</a></li>
 <li><a href="#2026-08-20-v181">2026-08-20 — v1.8.1</a></li>
 <li><a href="#2026-08-20-v180">2026-08-20 — v1.8.0</a></li>

--- a/docs/html/recipes/update-order-lines.html
+++ b/docs/html/recipes/update-order-lines.html
@@ -659,7 +659,7 @@
 <h2 id="prerequisites">Prerequisites</h2>
 <ul>
 <li>P21 credentials — the complete example below authenticates itself; nothing to install but <code>httpx</code> (Python) or a bare <code>net9.0</code> console project (C#).</li>
-<li>An existing, editable order (not fully invoiced/closed).</li>
+<li>An existing, editable order (not fully invoiced/closed) that is <strong>not an RMA</strong> — see the RMA gotcha below.</li>
 <li><strong>Know each target line's <code>user_line_no</code>.</strong> It is the stable update key. If your integration created the order, you ideally <a href="../03-Transaction-API.html#design-for-updates-assign-your-own-line-handles">assigned handles at create time</a>; otherwise read them back first (see <a href="#finding-the-handles">Finding the handles</a>).</li>
 </ul>
 <h2 id="how-it-works">How it works</h2>
@@ -1020,6 +1020,7 @@
 <li><strong><code>user_line_no</code> must be in each row's <code>Edits</code>.</strong> A key field that isn't sent fails the transaction with the opaque <code>General Exception: Sequence contains no matching element</code>.</li>
 <li><strong>A new handle inserts; that's the feature and the risk.</strong> A typo'd handle doesn't error — it quietly adds a line. The read-back below catches it.</li>
 <li><strong>DynaChange prompts are auto-answered with the default</strong> — same as order creation; a dropped change still reports <code>Succeeded</code>. See <a href="create-sales-order.html#gotchas">create-sales-order § Gotchas</a>.</li>
+<li><strong>RMAs need a different service.</strong> An order with <code>oe_hdr.rma_flag = 'Y'</code> cannot be loaded through <code>Order</code> at all — it fails with <code>You cannot retrieve an RMA from the Order Entry/Front Counter window.</code> Use the <strong><code>RMA</code></strong> service instead: identical <code>TABPAGE_1.order</code> form, keyed the same way, same fields. Bulk jobs over open orders hit this routinely, so route per order on <code>rma_flag</code> rather than discovering it as a failure. See <a href="../03-Transaction-API.html#rma-service-orders-the-order-service-refuses">03 § RMA Service</a>.</li>
 <li><strong>HTTP 200 ≠ success.</strong> Check <code>Summary</code> and <code>Results.Transactions[].Status == "Passed"</code>.</li>
 </ul>
 <h2 id="verify">Verify</h2>

--- a/docs/html/task-index.html
+++ b/docs/html/task-index.html
@@ -859,6 +859,10 @@
 <td><a href="03-Transaction-API.html#design-for-updates-assign-your-own-line-handles">03 § Design for updates: assign your own line handles</a> · <a href="recipes/update-order-lines.html">recipe: update-order-lines</a></td>
 </tr>
 <tr>
+<td><code>You cannot retrieve an RMA from the Order Entry/Front Counter window</code></td>
+<td><a href="03-Transaction-API.html#rma-service-orders-the-order-service-refuses">03 § RMA Service</a> — use the <code>RMA</code> service; route on <code>oe_hdr.rma_flag</code></td>
+</tr>
+<tr>
 <td><strong>Modify an existing sales order</strong> (edit a line, add a line)</td>
 <td><a href="recipes/update-order-lines.html">recipe: update-order-lines</a></td>
 </tr>

--- a/docs/recipes/update-order-lines.md
+++ b/docs/recipes/update-order-lines.md
@@ -9,7 +9,7 @@ Everything here was verified live on 26.1 (August 2026) with `/transaction/get` 
 ## Prerequisites
 
 - P21 credentials — the complete example below authenticates itself; nothing to install but `httpx` (Python) or a bare `net9.0` console project (C#).
-- An existing, editable order (not fully invoiced/closed).
+- An existing, editable order (not fully invoiced/closed) that is **not an RMA** — see the RMA gotcha below.
 - **Know each target line's `user_line_no`.** It is the stable update key. If your integration created the order, you ideally [assigned handles at create time](../03-Transaction-API.md#design-for-updates-assign-your-own-line-handles); otherwise read them back first (see [Finding the handles](#finding-the-handles)).
 
 ## How it works
@@ -382,6 +382,7 @@ All verified live on 26.1 — details in [Keys — Row Identity and the Collapse
 - **`user_line_no` must be in each row's `Edits`.** A key field that isn't sent fails the transaction with the opaque `General Exception: Sequence contains no matching element`.
 - **A new handle inserts; that's the feature and the risk.** A typo'd handle doesn't error — it quietly adds a line. The read-back below catches it.
 - **DynaChange prompts are auto-answered with the default** — same as order creation; a dropped change still reports `Succeeded`. See [create-sales-order § Gotchas](create-sales-order.md#gotchas).
+- **RMAs need a different service.** An order with `oe_hdr.rma_flag = 'Y'` cannot be loaded through `Order` at all — it fails with `You cannot retrieve an RMA from the Order Entry/Front Counter window.` Use the **`RMA`** service instead: identical `TABPAGE_1.order` form, keyed the same way, same fields. Bulk jobs over open orders hit this routinely, so route per order on `rma_flag` rather than discovering it as a failure. See [03 § RMA Service](../03-Transaction-API.md#rma-service-orders-the-order-service-refuses).
 - **HTTP 200 ≠ success.** Check `Summary` and `Results.Transactions[].Status == "Passed"`.
 
 ## Verify


### PR DESCRIPTION
First result of the cross-check against [Alex Westemeier](https://github.com/AWestemeier)'s repo (17 new commits since the July pass). Shipping this one ahead of the rest because **it breaks a recipe we published earlier today**.

## The trap

An order with `oe_hdr.rma_flag = 'Y'` cannot be loaded through the `Order` service at all:

```text
General Exception: You cannot retrieve an RMA from the Order Entry/Front Counter window.
```

The **`RMA`** service is the same window for the return side — identical `TABPAGE_1.order` form, keyed on `order_no`, same fields (67 vs `Order`'s 69). Swap the service name and the payload works unchanged.

**Verified on our own 26.1 tenant**, not taken on report: the same RMA order refused by `Order`, loaded by `RMA`.

## Why it couldn't wait

The [update-order-lines recipe](docs/recipes/update-order-lines.md) went out earlier today telling readers to key `TABPAGE_1.order` and sweep open orders — precisely the bulk-maintenance pattern that hits RMAs. The error text doesn't obviously mean *"use a different service"*, so a batch job meets it as an unexplained per-record failure.

Adds an [RMA Service](docs/03-Transaction-API.md) reference entry, gotchas in the recipe prerequisites and in Order Service Gotchas, and an INDEX row keyed on the error string so it's findable by paste.

## Rest of the cross-check

Filed rather than shipped, since they need re-verification on our tenant first:

- **#130** — a transaction can **commit while reporting `Failed`**. Two instances. This inverts the `Summary.Failed == 0` rule we state on every write page, and is the mirror of the `IgnoreDisabled` silent success.
- **#131** — the definition's **`Required` flag is not a contract**; several `Required: true` fields must be omitted. Confirmed the flag values against our own definitions. Notably, Alex's "these columns are disabled" claim **did not reproduce** here in isolation — recorded as tenant/context-dependent rather than copied through.
- **#132** — the undocumented **AP cycle**: `PurchaseOrder` → `PurchaseOrderReceipt` → `ConvertPOToVoucher`.
- **#133** — **an in-window wizard IS drivable** via the Interactive API (direct-ship PO generation), and it **commits at `cb_next`** before you finish it.

Credit follows the repo convention: name + GitHub profile.

Changelog v1.8.3, HTML regenerated, anchors validated (0 broken).

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)