### PR TITLE
docs: drive the direct-ship wizard end-to-end (v1.8.7)

### DIFF
--- a/docs/04-Interactive-API.md
+++ b/docs/04-Interactive-API.md
@@ -2781,7 +2781,7 @@ static string ReadField(string payload, string field)
 
 The Transaction API [cannot drive wizards](03-Transaction-API.md#limitations) — that limitation is real, and this is the worked example of the escape hatch. The Order window's **PO/RFQ generation wizard** creates a purchase order linked to a sales order (a *direct ship*), and it is reachable through the Interactive API.
 
-> **Prerequisite: the API user needs a Buyer ID.** Without one, setting the trigger returns `Status: 2` with `To create a PO, you must have a valid Buyer ID.` — verified on 26.1 (August 2026). It is set in User Maintenance and is a **P21 configuration change**, not something the API can do for you. Check it before writing any of the rest.
+> **Prerequisite: the API user needs a Buyer ID.** Without one, setting the trigger returns `Status: 2` with `To create a PO, you must have a valid Buyer ID.`; with one it returns `Status: 1`. Both verified on 26.1 (August 2026). The Buyer ID is set per user in **User Maintenance** — a P21 configuration change, not something the API can do for you. Check it before writing any of the rest, because every other step works right up until the save.
 
 ### Why this cannot start in the Transaction API
 
@@ -2792,7 +2792,8 @@ The line's `disposition` field is the trigger for a direct-ship line, and it is 
 1. Create and save the sales order with its `D` line **first**. Requesting the PO in the same save does not work — a new order's save stacks other prompts ahead of the wizard and the sequence derails.
 2. Re-open the saved order and set the header checkbox **`c_create_po = 'ON'`** (`TABPAGE_1.order`, valid values `ON`/`OFF`).
 3. `save()` → **`Status: 3`** with a `windowopened` event carrying the wizard's window id. Buttons: `cb_back`, `cb_next`, `cb_finish`, `cb_cancel`.
-   - **Identify the wizard by its buttons before pressing anything** (`GET /v2/tools?windowId={popupId}`; `cb_finish` present). Never blind-answer a response window here — the first one may not be the wizard.
+   - **Identify the wizard by its buttons before pressing anything** (`GET /v2/tools?windowId={popupId}`; `cb_finish` present). Never blind-answer a response window here — the first one may not be the wizard. Saving a *new* order first raises a different `cb_1`/`cb_2`/`cb_3` rule dialog, which is exactly why the two-phase order matters.
+   - ⚠️ **The tool list for a popup also contains the parent window's ribbon** (`Quick.Save`, `inquiry.*`, `help.*`, and any tab-scoped tools). Search it for the specific button names — don't read the first few entries and conclude you have the wrong window.
    - Page 1 is an `items` grid, one row per `D` line: `purchase_item='Y'`, `qty_to_purchase`, `supplier_id`/`supplier_name`.
    - `cb_next` → page 2 shows the assigned `po_no`.
    - `cb_finish` to close cleanly.
@@ -2808,7 +2809,31 @@ The line's `disposition` field is the trigger for a direct-ship line, and it is 
 - **`PurchaseOrder` TAPI cannot build a `D`-type PO** — `po_hdr_po_type` is system-disabled, and the Backorders link tab is invisible to TAPI.
 - **Direct-ship POs are not received** via [PurchaseOrderReceipt](03-Transaction-API.md#purchaseorderreceipt-service-receiving-a-po) — the window refuses because the linked sales-order lines are `'T'` status. Their receipt is created by the sales-side confirmation instead (`DirectShipConfirmation`, keyed on `po_no`), which in one save writes the receipt, completes the PO line, invoices the sales-order line and creates the customer AR invoice.
 
-*(Flow, wizard mechanics and dead ends verified by [Alex Westemeier](https://github.com/AWestemeier) across two full cycles with SQL confirmation. Verified independently here: the `c_create_po` Buyer-ID prerequisite and its exact message, the `disposition` disabled-column behavior, and the field/valid-value definitions. The wizard itself was not re-driven — our API user has no Buyer ID, and granting one is an operator decision.)*
+### Setting `disposition` — only at line entry
+
+`disposition` behaves as a **disabled column everywhere except a line being entered**. Verified three ways on 26.1:
+
+| Attempt | Result |
+|---|---|
+| `POST /transaction` with `disposition` on `TP_ITEMS.items` | `Column is disabled: disposition` |
+| Interactive change on an **existing** saved line | `Column is disabled: disposition` |
+| Interactive change on the line **as it is entered** | **`Status: 1`** — accepted |
+
+So there is no way to convert an existing order line to direct ship through either API, and no stateless path at all. The line must be created in the window with `disposition = 'D'` set during entry.
+
+### Verified run
+
+Driven end-to-end on a 26.1 play tenant (August 2026):
+
+1. Order **1519097** created interactively — one line, `disposition = 'D'`, saved.
+   - Setting `requested_date` fired the **date-cascade popup** (`Status: 3`) even on a brand-new order, exactly as documented below; the sequence stalls with `400`s on every later call until it is answered.
+2. Re-opened, `c_create_po = 'ON'` → `Status: 1`, then `save()` → `Status: 3` with the wizard (`cb_finish` present in its tool list).
+3. `cb_next` → page 2 carried PO **998303**.
+4. `cb_finish` → closed.
+
+Confirmed in the database: `po_hdr` 998303 with **`po_type = 'D'`, `approved = 'Y'`**, and an `oe_line_po` row linking order 1519097 line 1 ↔ PO 998303 line 1 with **`connection_type = 'P'`** — matching the reported shape field for field.
+
+*(Flow and dead ends originally verified by [Alex Westemeier](https://github.com/AWestemeier) across two cycles; re-driven and confirmed independently here.)*
 
 ## Sales Order Notepad Writes (Header vs Line)
 

--- a/docs/10-Changelog.md
+++ b/docs/10-Changelog.md
@@ -17,6 +17,17 @@ All notable changes to this documentation project are listed below, grouped by d
 
 ---
 
+## 2026-08-20 — v1.8.7
+
+The direct-ship wizard, driven end-to-end here rather than taken on report.
+
+- **feat:** **[Driving an In-Window Wizard](04-Interactive-API.md#driving-an-in-window-wizard-direct-ship-po-generation) upgraded from "reported" to verified.** Order **1519097** created with a `D` line, re-opened with `c_create_po = 'ON'`, save → the wizard, `cb_next` → PO **998303** on page 2, `cb_finish`. Confirmed in the database: `po_hdr` `po_type='D'`, `approved='Y'`, plus an `oe_line_po` row linking order line ↔ PO line with `connection_type='P'`. Matches the reported shape field for field — *@mrwuss, flow originally verified by [Alex Westemeier](https://github.com/AWestemeier)*
+- **feat:** **`disposition` is settable only at line entry** — new table showing all three attempts: `/transaction` → `Column is disabled`; interactive change on an **existing** line → `Column is disabled`; interactive change on the line **as it is entered** → `Status: 1`. So an existing order line **cannot be converted** to direct ship through either API, and there is no stateless path at all — *@mrwuss*
+- **docs:** **The popup tool list also contains the parent window's ribbon.** `GET /v2/tools?windowId={popupId}` returns `Quick.Save`, `inquiry.*`, `help.*` and tab-scoped tools alongside the popup's own buttons — search it for the specific names rather than reading the first few entries and concluding you have the wrong window. Also records that saving a *new* order raises a different `cb_1`/`cb_2`/`cb_3` rule dialog, which is precisely why the two-phase sequence matters — *@mrwuss*
+- **docs:** Buyer-ID prerequisite now shows **both** sides — `Status: 2` with the error when the user has none, `Status: 1` when they do. Every other step works right up until the save, so it's worth checking first — *@mrwuss*
+
+---
+
 ## 2026-08-20 — v1.8.6
 
 Closes the cross-check. The wizard limitation now has a worked escape hatch.

--- a/docs/html/04-Interactive-API.html
+++ b/docs/html/04-Interactive-API.html
@@ -710,6 +710,8 @@
 <li><a href="#why-this-cannot-start-in-the-transaction-api">Why this cannot start in the Transaction API</a></li>
 <li><a href="#the-flow">The flow</a></li>
 <li><a href="#related-dead-ends">Related dead ends</a></li>
+<li><a href="#setting-disposition-only-at-line-entry">Setting disposition — only at line entry</a></li>
+<li><a href="#verified-run">Verified run</a></li>
 </ul>
 </li>
 <li><a href="#sales-order-notepad-writes-header-vs-line">Sales Order Notepad Writes (Header vs Line)</a></li>
@@ -3893,7 +3895,7 @@ The API returns Status as an integer. String values (<code>"Success"</code>, <co
 <h2 id="driving-an-in-window-wizard-direct-ship-po-generation">Driving an In-Window Wizard (Direct-Ship PO Generation)</h2>
 <p>The Transaction API <a href="03-Transaction-API.html#limitations">cannot drive wizards</a> — that limitation is real, and this is the worked example of the escape hatch. The Order window's <strong>PO/RFQ generation wizard</strong> creates a purchase order linked to a sales order (a <em>direct ship</em>), and it is reachable through the Interactive API.</p>
 <blockquote>
-<p><strong>Prerequisite: the API user needs a Buyer ID.</strong> Without one, setting the trigger returns <code>Status: 2</code> with <code>To create a PO, you must have a valid Buyer ID.</code> — verified on 26.1 (August 2026). It is set in User Maintenance and is a <strong>P21 configuration change</strong>, not something the API can do for you. Check it before writing any of the rest.</p>
+<p><strong>Prerequisite: the API user needs a Buyer ID.</strong> Without one, setting the trigger returns <code>Status: 2</code> with <code>To create a PO, you must have a valid Buyer ID.</code>; with one it returns <code>Status: 1</code>. Both verified on 26.1 (August 2026). The Buyer ID is set per user in <strong>User Maintenance</strong> — a P21 configuration change, not something the API can do for you. Check it before writing any of the rest, because every other step works right up until the save.</p>
 </blockquote>
 <h3 id="why-this-cannot-start-in-the-transaction-api">Why this cannot start in the Transaction API</h3>
 <p>The line's <code>disposition</code> field is the trigger for a direct-ship line, and it is a <strong>disabled column</strong> — <code>Column is disabled: disposition</code>, verified both through <code>/transaction</code> and through an interactive change on an existing line. Its valid values are <code>B</code>, <code>C</code>, <code>D</code>, <code>H</code>, <code>M</code>, <code>P</code>, <code>S</code>; <code>D</code> is direct ship. Set it <strong>as the line is entered</strong>, in the Interactive window — there is no stateless path.</p>
@@ -3902,7 +3904,8 @@ The API returns Status as an integer. String values (<code>"Success"</code>, <co
 <li>Create and save the sales order with its <code>D</code> line <strong>first</strong>. Requesting the PO in the same save does not work — a new order's save stacks other prompts ahead of the wizard and the sequence derails.</li>
 <li>Re-open the saved order and set the header checkbox <strong><code>c_create_po = 'ON'</code></strong> (<code>TABPAGE_1.order</code>, valid values <code>ON</code>/<code>OFF</code>).</li>
 <li><code>save()</code> → <strong><code>Status: 3</code></strong> with a <code>windowopened</code> event carrying the wizard's window id. Buttons: <code>cb_back</code>, <code>cb_next</code>, <code>cb_finish</code>, <code>cb_cancel</code>.</li>
-<li><strong>Identify the wizard by its buttons before pressing anything</strong> (<code>GET /v2/tools?windowId={popupId}</code>; <code>cb_finish</code> present). Never blind-answer a response window here — the first one may not be the wizard.</li>
+<li><strong>Identify the wizard by its buttons before pressing anything</strong> (<code>GET /v2/tools?windowId={popupId}</code>; <code>cb_finish</code> present). Never blind-answer a response window here — the first one may not be the wizard. Saving a <em>new</em> order first raises a different <code>cb_1</code>/<code>cb_2</code>/<code>cb_3</code> rule dialog, which is exactly why the two-phase order matters.</li>
+<li>⚠️ <strong>The tool list for a popup also contains the parent window's ribbon</strong> (<code>Quick.Save</code>, <code>inquiry.*</code>, <code>help.*</code>, and any tab-scoped tools). Search it for the specific button names — don't read the first few entries and conclude you have the wrong window.</li>
 <li>Page 1 is an <code>items</code> grid, one row per <code>D</code> line: <code>purchase_item='Y'</code>, <code>qty_to_purchase</code>, <code>supplier_id</code>/<code>supplier_name</code>.</li>
 <li><code>cb_next</code> → page 2 shows the assigned <code>po_no</code>.</li>
 <li><code>cb_finish</code> to close cleanly.</li>
@@ -3918,7 +3921,42 @@ The API returns Status as an integer. String values (<code>"Success"</code>, <co
 <li><strong><code>PurchaseOrder</code> TAPI cannot build a <code>D</code>-type PO</strong> — <code>po_hdr_po_type</code> is system-disabled, and the Backorders link tab is invisible to TAPI.</li>
 <li><strong>Direct-ship POs are not received</strong> via <a href="03-Transaction-API.html#purchaseorderreceipt-service-receiving-a-po">PurchaseOrderReceipt</a> — the window refuses because the linked sales-order lines are <code>'T'</code> status. Their receipt is created by the sales-side confirmation instead (<code>DirectShipConfirmation</code>, keyed on <code>po_no</code>), which in one save writes the receipt, completes the PO line, invoices the sales-order line and creates the customer AR invoice.</li>
 </ul>
-<p><em>(Flow, wizard mechanics and dead ends verified by <a href="https://github.com/AWestemeier">Alex Westemeier</a> across two full cycles with SQL confirmation. Verified independently here: the <code>c_create_po</code> Buyer-ID prerequisite and its exact message, the <code>disposition</code> disabled-column behavior, and the field/valid-value definitions. The wizard itself was not re-driven — our API user has no Buyer ID, and granting one is an operator decision.)</em></p>
+<h3 id="setting-disposition-only-at-line-entry">Setting <code>disposition</code> — only at line entry</h3>
+<p><code>disposition</code> behaves as a <strong>disabled column everywhere except a line being entered</strong>. Verified three ways on 26.1:</p>
+<div class="table-wrap"><table>
+<thead>
+<tr>
+<th>Attempt</th>
+<th>Result</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>POST /transaction</code> with <code>disposition</code> on <code>TP_ITEMS.items</code></td>
+<td><code>Column is disabled: disposition</code></td>
+</tr>
+<tr>
+<td>Interactive change on an <strong>existing</strong> saved line</td>
+<td><code>Column is disabled: disposition</code></td>
+</tr>
+<tr>
+<td>Interactive change on the line <strong>as it is entered</strong></td>
+<td><strong><code>Status: 1</code></strong> — accepted</td>
+</tr>
+</tbody>
+</table></div>
+<p>So there is no way to convert an existing order line to direct ship through either API, and no stateless path at all. The line must be created in the window with <code>disposition = 'D'</code> set during entry.</p>
+<h3 id="verified-run">Verified run</h3>
+<p>Driven end-to-end on a 26.1 play tenant (August 2026):</p>
+<ol>
+<li>Order <strong>1519097</strong> created interactively — one line, <code>disposition = 'D'</code>, saved.</li>
+<li>Setting <code>requested_date</code> fired the <strong>date-cascade popup</strong> (<code>Status: 3</code>) even on a brand-new order, exactly as documented below; the sequence stalls with <code>400</code>s on every later call until it is answered.</li>
+<li>Re-opened, <code>c_create_po = 'ON'</code> → <code>Status: 1</code>, then <code>save()</code> → <code>Status: 3</code> with the wizard (<code>cb_finish</code> present in its tool list).</li>
+<li><code>cb_next</code> → page 2 carried PO <strong>998303</strong>.</li>
+<li><code>cb_finish</code> → closed.</li>
+</ol>
+<p>Confirmed in the database: <code>po_hdr</code> 998303 with <strong><code>po_type = 'D'</code>, <code>approved = 'Y'</code></strong>, and an <code>oe_line_po</code> row linking order 1519097 line 1 ↔ PO 998303 line 1 with <strong><code>connection_type = 'P'</code></strong> — matching the reported shape field for field.</p>
+<p><em>(Flow and dead ends originally verified by <a href="https://github.com/AWestemeier">Alex Westemeier</a> across two cycles; re-driven and confirmed independently here.)</em></p>
 <h2 id="sales-order-notepad-writes-header-vs-line">Sales Order Notepad Writes (Header vs Line)</h2>
 <p>The <strong>Order window has the same two notepad surfaces</strong> as PurchaseOrder, drivable with the same Notepad Entry popup mechanics (<a href="#the-notepad-entry-popup">above</a>) — verified end-to-end on 26.1 (August 2026), both notes confirmed in the database. This matters doubly because the Transaction API's note surface on <code>Order</code> is <strong>entirely closed</strong> (<a href="03-Transaction-API.html#limitations">03 § Limitations</a>): this is the working path.</p>
 <div class="table-wrap"><table>
@@ -5186,6 +5224,8 @@ Row 5 selected → Detail shows row 4 (1 behind)
 <li><a href="#why-this-cannot-start-in-the-transaction-api">Why this cannot start in the Transaction API</a></li>
 <li><a href="#the-flow">The flow</a></li>
 <li><a href="#related-dead-ends">Related dead ends</a></li>
+<li><a href="#setting-disposition-only-at-line-entry">Setting disposition — only at line entry</a></li>
+<li><a href="#verified-run">Verified run</a></li>
 </ul>
 </li>
 <li><a href="#sales-order-notepad-writes-header-vs-line">Sales Order Notepad Writes (Header vs Line)</a></li>

--- a/docs/html/10-Changelog.html
+++ b/docs/html/10-Changelog.html
@@ -641,6 +641,7 @@
         <div class="toc">
 <ul>
 <li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-08-20-v187">2026-08-20 — v1.8.7</a></li>
 <li><a href="#2026-08-20-v186">2026-08-20 — v1.8.6</a></li>
 <li><a href="#2026-08-20-v185">2026-08-20 — v1.8.5</a></li>
 <li><a href="#2026-08-20-v184">2026-08-20 — v1.8.4</a></li>
@@ -709,6 +710,15 @@
 <li><strong>25.2</strong> — <code>DatawindowName</code> <strong>required</strong> in Interactive change requests (3-param form stops working). → <a href="14-Breaking-Changes.html#p21-252">details</a></li>
 </ul>
 </blockquote>
+<hr />
+<h2 id="2026-08-20-v187">2026-08-20 — v1.8.7</h2>
+<p>The direct-ship wizard, driven end-to-end here rather than taken on report.</p>
+<ul>
+<li><strong>feat:</strong> <strong><a href="04-Interactive-API.html#driving-an-in-window-wizard-direct-ship-po-generation">Driving an In-Window Wizard</a> upgraded from "reported" to verified.</strong> Order <strong>1519097</strong> created with a <code>D</code> line, re-opened with <code>c_create_po = 'ON'</code>, save → the wizard, <code>cb_next</code> → PO <strong>998303</strong> on page 2, <code>cb_finish</code>. Confirmed in the database: <code>po_hdr</code> <code>po_type='D'</code>, <code>approved='Y'</code>, plus an <code>oe_line_po</code> row linking order line ↔ PO line with <code>connection_type='P'</code>. Matches the reported shape field for field — <em>@mrwuss, flow originally verified by <a href="https://github.com/AWestemeier">Alex Westemeier</a></em></li>
+<li><strong>feat:</strong> <strong><code>disposition</code> is settable only at line entry</strong> — new table showing all three attempts: <code>/transaction</code> → <code>Column is disabled</code>; interactive change on an <strong>existing</strong> line → <code>Column is disabled</code>; interactive change on the line <strong>as it is entered</strong> → <code>Status: 1</code>. So an existing order line <strong>cannot be converted</strong> to direct ship through either API, and there is no stateless path at all — <em>@mrwuss</em></li>
+<li><strong>docs:</strong> <strong>The popup tool list also contains the parent window's ribbon.</strong> <code>GET /v2/tools?windowId={popupId}</code> returns <code>Quick.Save</code>, <code>inquiry.*</code>, <code>help.*</code> and tab-scoped tools alongside the popup's own buttons — search it for the specific names rather than reading the first few entries and concluding you have the wrong window. Also records that saving a <em>new</em> order raises a different <code>cb_1</code>/<code>cb_2</code>/<code>cb_3</code> rule dialog, which is precisely why the two-phase sequence matters — <em>@mrwuss</em></li>
+<li><strong>docs:</strong> Buyer-ID prerequisite now shows <strong>both</strong> sides — <code>Status: 2</code> with the error when the user has none, <code>Status: 1</code> when they do. Every other step works right up until the save, so it's worth checking first — <em>@mrwuss</em></li>
+</ul>
 <hr />
 <h2 id="2026-08-20-v186">2026-08-20 — v1.8.6</h2>
 <p>Closes the cross-check. The wizard limitation now has a worked escape hatch.</p>
@@ -1218,6 +1228,7 @@
             <div class="toc">
 <ul>
 <li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-08-20-v187">2026-08-20 — v1.8.7</a></li>
 <li><a href="#2026-08-20-v186">2026-08-20 — v1.8.6</a></li>
 <li><a href="#2026-08-20-v185">2026-08-20 — v1.8.5</a></li>
 <li><a href="#2026-08-20-v184">2026-08-20 — v1.8.4</a></li>


### PR DESCRIPTION
Upgrades the wizard section from "reported" to **verified here**.

## The run

Order **1519097** created interactively with a `D` line → re-opened with `c_create_po = 'ON'` → save → the wizard → `cb_next` → PO **998303** on page 2 → `cb_finish`.

Confirmed in the database: `po_hdr` 998303 with **`po_type='D'`, `approved='Y'`**, plus an `oe_line_po` row linking order 1519097 line 1 ↔ PO 998303 line 1 with **`connection_type='P'`**. Matches the reported shape field for field — including the important part: **the PO already existed on page 2, before `cb_finish`.**

## New finding: `disposition` is settable only at line entry

| Attempt | Result |
|---|---|
| `POST /transaction` | `Column is disabled: disposition` |
| Interactive change on an **existing** line | `Column is disabled: disposition` |
| Interactive change on the line **as it is entered** | **`Status: 1`** |

So an existing order line **cannot be converted** to direct ship through either API, and there's no stateless path at all. I tried to shortcut phase 1 through TAPI first; that's why this is now a table rather than a sentence.

## Two things that cost me a run

- **A popup's tool list includes the parent window's ribbon** — `Quick.Save`, `inquiry.*`, `help.*` and tab-scoped tools come back alongside the popup's own buttons. Search for the specific names; reading the first few entries makes it look like the wrong window.
- **Saving a *new* order raises a different `cb_1`/`cb_2`/`cb_3` rule dialog**, not the wizard — which is exactly why the two-phase sequence exists. I blind-pressed `cb_1` on that one before identifying it, which is the mistake the doc now warns against in its own voice.

Buyer-ID prerequisite now shows both sides: `Status: 2` with the error when absent, `Status: 1` when present. Every other step works right up until the save, so check it first.

## Note on how this was authenticated

Run against **play only**, authenticated via consumer key impersonating `cstickley` at the operator's direction, because our own API user has no Buyer ID. The impersonation is visible in the data — `po_hdr.created_by` and `oe_line_po.last_maintained_by` both read `CSTICKLEY`. Worth seeing concretely, given the consumer-key warning added earlier today.

Separately: `P21_CONSUMER_KEY_PLAY` in `.env` is **not registered on either tenant**; `P21_CONSUMER_KEY_PROD` works on both. Flagged for the operator, not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)