### PR TITLE
fix(examples): C# examples 401 on every run — router trailing slash (v1.8.10)

### DIFF
--- a/docs/00-Authentication.md
+++ b/docs/00-Authentication.md
@@ -915,7 +915,7 @@ class TokenManager
 The Interactive and Transaction APIs require the UI server URL, which is obtained after authentication:
 
 ```http
-GET /api/ui/router/v1?urlType=external HTTP/1.1
+GET /api/ui/router/v1/?urlType=external HTTP/1.1
 Host: play.p21server.com
 Authorization: Bearer {token}
 Accept: application/json
@@ -928,7 +928,24 @@ Accept: application/json
 }
 ```
 
-> **307 redirect gotcha:** On some installations, `GET /api/ui/router/v1?urlType=external` (no trailing slash after `v1`) responds with a **307 redirect** to the trailing-slash form. HTTP clients that do not follow redirects by default — including `httpx` — receive the 307 and an HTML body instead of the JSON response. Either request `/api/ui/router/v1/?urlType=external` (trailing slash) directly, or enable redirect following (`httpx.get(..., follow_redirects=True)`). C# `HttpClient` follows GET redirects by default and is unaffected. Verified live on a 25.2 system (July 2026).
+> ⚠️ **Send the trailing slash. It is not cosmetic, and following the redirect is not an equivalent fix.**
+>
+> `GET /api/ui/router/v1?urlType=external` (no trailing slash after `v1`) answers **307** to the trailing-slash form. What happens next depends on your client, and neither outcome is what you want:
+>
+> | Client | Behavior on the slashless URL |
+> |---|---|
+> | `httpx` without `follow_redirects` | Returns the **307** and an HTML body — no JSON to parse |
+> | `httpx` with `follow_redirects=True` | Works — httpx keeps `Authorization` on a same-origin redirect |
+> | .NET `HttpClient` | Follows the redirect but **strips the `Authorization` header**, so the second request arrives unauthenticated → **401** |
+>
+> The .NET case is the one that misleads, because the redirect *is* followed and the failure surfaces one step later as an authentication error rather than a routing one:
+>
+> ```text
+> 401 {"Description":"Authorization header was not present or 'Bearer' was missing.",
+>      "Error":"invalid_request","Uri":""}
+> ```
+>
+> The token is fine — it never left the client. .NET drops `Authorization` on **any** auto-redirect, same-origin included, and whether the header was set on `DefaultRequestHeaders` or on the individual request; `AllowAutoRedirect` only changes whether you see the 307 or the 401. Requesting `/api/ui/router/v1/?urlType=external` avoids the redirect entirely and is the portable answer for every client. Verified live on 25.2 (July 2026) and re-verified on 26.1 with the .NET behavior isolated (August 2026).
 
 > **XML responses:** As with the token endpoint, some middleware returns **XML** for the router response even with `Accept: application/json`. Parse JSON first and fall back to XML (see [XML Token Responses](#xml-token-responses)).
 
@@ -1029,8 +1046,10 @@ static HttpClient CreateAuthorizedClient(string token)
 static async Task<string> GetUiServerUrlAsync(string baseUrl, string token)
 {
     using var client = CreateAuthorizedClient(token);
+    // Trailing slash required: without it the server 307s, and HttpClient
+    // drops the Authorization header when it follows a redirect -> 401.
     var response = await client.GetAsync(
-        $"{baseUrl}/api/ui/router/v1?urlType=external");
+        $"{baseUrl}/api/ui/router/v1/?urlType=external");
     response.EnsureSuccessStatusCode();
 
     // Some middleware returns XML here even when asked for JSON, so try JSON

--- a/docs/03-Transaction-API.md
+++ b/docs/03-Transaction-API.md
@@ -30,7 +30,7 @@ The Transaction API is a **stateless RESTful** web service for bulk data manipul
 All Transaction API endpoints use the UI Server URL. First, obtain the UI Server URL:
 
 ```http
-GET https://{hostname}/api/ui/router/v1?urlType=external
+GET https://{hostname}/api/ui/router/v1/?urlType=external
 ```
 
 Note that the no-trailing-slash form can return a 307 redirect and the response may be XML on some middleware — use the trailing-slash form (`/api/ui/router/v1/`) and follow redirects; see [00-Authentication § UI Server URL](00-Authentication.md#ui-server-url).

--- a/docs/04-Interactive-API.md
+++ b/docs/04-Interactive-API.md
@@ -30,7 +30,7 @@ The Interactive API (IAPI) is a **stateful** RESTful API that simulates user int
 All Interactive API endpoints use the UI Server URL. First, obtain it:
 
 ```http
-GET https://{hostname}/api/ui/router/v1?urlType=external
+GET https://{hostname}/api/ui/router/v1/?urlType=external
 ```
 
 Then use the returned URL as base:
@@ -3024,7 +3024,7 @@ The C# SDK (`P21.UI.Service.Client`) calls these V1 REST endpoints internally. T
 | POST | `/uiserver0/ui/interactive/v1/row` | Add row |
 | PUT | `/uiserver0/ui/interactive/v1/row` | Change row |
 
-> **Note:** The `uiserver0` prefix is the UI server instance name assigned during routing. Your environment may use a different instance name — check `GET /api/ui/router/v1?urlType=external` to obtain the correct base URL.
+> **Note:** The `uiserver0` prefix is the UI server instance name assigned during routing. Your environment may use a different instance name — check `GET /api/ui/router/v1/?urlType=external` to obtain the correct base URL.
 
 ---
 

--- a/docs/10-Changelog.md
+++ b/docs/10-Changelog.md
@@ -17,6 +17,22 @@ All notable changes to this documentation project are listed below, grouped by d
 
 ---
 
+## 2026-08-25 — v1.8.10
+
+Every C# example in the repo failed to authenticate, and the doc note that would have explained it said the opposite.
+
+- **fix:** **The C# examples could not authenticate — 401 on every program.** `P21Auth.GetUiServerUrlAsync` requested the router as `/api/ui/router/v1?urlType=external`, **without the trailing slash**. The server answers that with a **307** to the trailing-slash form, and .NET's `HttpClient` **strips the `Authorization` header when it follows a redirect** — so the second request arrived unauthenticated and came back `401 {"Description":"Authorization header was not present or 'Bearer' was missing."}`. The token was never the problem; it was obtained successfully one call earlier. Fixed by requesting the trailing-slash URL, which avoids the redirect outright — *@mrwuss*
+
+- **fix:** **`P21Config.LoadDotEnv()` never found the repo `.env`.** It walked up from `AppContext.BaseDirectory` for a fixed **6** iterations, but an example runs from `<project>/bin/<config>/<tfm>/` — already three levels below its own project folder — putting the repository root **7** levels up. Every C# example therefore died with *"P21_BASE_URL environment variable is required"* unless you exported the variables by hand. It now walks to the filesystem root — *@mrwuss*
+
+- **fix:** **[00 § UI Server URL](00-Authentication.md#ui-server-url) said C# was unaffected by this.** The old note read *"C# `HttpClient` follows GET redirects by default and is unaffected"* — half right and wholly misleading: it follows the redirect, and that is exactly when it drops the header. Replaced with a per-client table of what actually happens on the slashless URL, the 401 body it produces, and why *following the redirect* is not an equivalent fix to *not causing one*. .NET drops `Authorization` on **any** auto-redirect — same-origin included, and whether the header sits on `DefaultRequestHeaders` or on the individual request — *@mrwuss*
+
+- **chore:** **Trailing slash everywhere, so nothing re-learns this.** The five Python call sites, the remaining `docs/00`/`03`/`04` snippets, and the Postman collection's *Get UI Server URL* request now all send `/api/ui/router/v1/?urlType=external`. The Python paths worked before — httpx keeps the header on a same-origin redirect — but they were paying for a pointless round trip and modelling the form that breaks in another language — *@mrwuss*
+
+  *Verified on 26.1: token → router → OData → Transaction all green through `P21Client.CreateAsync()`, and `dotnet run --project Recipes` now reaches a recipe's payload with no environment variables exported.*
+
+---
+
 ## 2026-08-25 — v1.8.9
 
 A grid everyone had written off as undeletable, and the field that deletes it.

--- a/docs/html/00-Authentication.html
+++ b/docs/html/00-Authentication.html
@@ -1731,7 +1731,7 @@
 <hr />
 <h2 id="ui-server-url">UI Server URL</h2>
 <p>The Interactive and Transaction APIs require the UI server URL, which is obtained after authentication:</p>
-<div class="highlight"><pre><span></span><code><span class="nf">GET</span> <span class="nn">/api/ui/router/v1?urlType=external</span> <span class="kr">HTTP</span><span class="o">/</span><span class="m">1.1</span>
+<div class="highlight"><pre><span></span><code><span class="nf">GET</span> <span class="nn">/api/ui/router/v1/?urlType=external</span> <span class="kr">HTTP</span><span class="o">/</span><span class="m">1.1</span>
 <span class="na">Host</span><span class="o">:</span> <span class="l">play.p21server.com</span>
 <span class="na">Authorization</span><span class="o">:</span> <span class="l">Bearer {token}</span>
 <span class="na">Accept</span><span class="o">:</span> <span class="l">application/json</span>
@@ -1744,7 +1744,35 @@
 </code></pre></div>
 
 <blockquote>
-<p><strong>307 redirect gotcha:</strong> On some installations, <code>GET /api/ui/router/v1?urlType=external</code> (no trailing slash after <code>v1</code>) responds with a <strong>307 redirect</strong> to the trailing-slash form. HTTP clients that do not follow redirects by default — including <code>httpx</code> — receive the 307 and an HTML body instead of the JSON response. Either request <code>/api/ui/router/v1/?urlType=external</code> (trailing slash) directly, or enable redirect following (<code>httpx.get(..., follow_redirects=True)</code>). C# <code>HttpClient</code> follows GET redirects by default and is unaffected. Verified live on a 25.2 system (July 2026).</p>
+<p>⚠️ <strong>Send the trailing slash. It is not cosmetic, and following the redirect is not an equivalent fix.</strong></p>
+<p><code>GET /api/ui/router/v1?urlType=external</code> (no trailing slash after <code>v1</code>) answers <strong>307</strong> to the trailing-slash form. What happens next depends on your client, and neither outcome is what you want:</p>
+<div class="table-wrap"><table>
+<thead>
+<tr>
+<th>Client</th>
+<th>Behavior on the slashless URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>httpx</code> without <code>follow_redirects</code></td>
+<td>Returns the <strong>307</strong> and an HTML body — no JSON to parse</td>
+</tr>
+<tr>
+<td><code>httpx</code> with <code>follow_redirects=True</code></td>
+<td>Works — httpx keeps <code>Authorization</code> on a same-origin redirect</td>
+</tr>
+<tr>
+<td>.NET <code>HttpClient</code></td>
+<td>Follows the redirect but <strong>strips the <code>Authorization</code> header</strong>, so the second request arrives unauthenticated → <strong>401</strong></td>
+</tr>
+</tbody>
+</table></div>
+<p>The .NET case is the one that misleads, because the redirect <em>is</em> followed and the failure surfaces one step later as an authentication error rather than a routing one:</p>
+<p><code>text
+401 {"Description":"Authorization header was not present or 'Bearer' was missing.",
+     "Error":"invalid_request","Uri":""}</code></p>
+<p>The token is fine — it never left the client. .NET drops <code>Authorization</code> on <strong>any</strong> auto-redirect, same-origin included, and whether the header was set on <code>DefaultRequestHeaders</code> or on the individual request; <code>AllowAutoRedirect</code> only changes whether you see the 307 or the 401. Requesting <code>/api/ui/router/v1/?urlType=external</code> avoids the redirect entirely and is the portable answer for every client. Verified live on 25.2 (July 2026) and re-verified on 26.1 with the .NET behavior isolated (August 2026).</p>
 <p><strong>XML responses:</strong> As with the token endpoint, some middleware returns <strong>XML</strong> for the router response even with <code>Accept: application/json</code>. Parse JSON first and fall back to XML (see <a href="#xml-token-responses">XML Token Responses</a>).</p>
 </blockquote>
 <div class="code-tabs">
@@ -1843,8 +1871,10 @@
 <span class="k">static</span><span class="w"> </span><span class="k">async</span><span class="w"> </span><span class="n">Task</span><span class="o">&lt;</span><span class="kt">string</span><span class="o">&gt;</span><span class="w"> </span><span class="n">GetUiServerUrlAsync</span><span class="p">(</span><span class="kt">string</span><span class="w"> </span><span class="n">baseUrl</span><span class="p">,</span><span class="w"> </span><span class="kt">string</span><span class="w"> </span><span class="n">token</span><span class="p">)</span>
 <span class="p">{</span>
 <span class="w">    </span><span class="k">using</span><span class="w"> </span><span class="nn">var</span><span class="w"> </span><span class="n">client</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">CreateAuthorizedClient</span><span class="p">(</span><span class="n">token</span><span class="p">);</span>
+<span class="w">    </span><span class="c1">// Trailing slash required: without it the server 307s, and HttpClient</span>
+<span class="w">    </span><span class="c1">// drops the Authorization header when it follows a redirect -&gt; 401.</span>
 <span class="w">    </span><span class="kt">var</span><span class="w"> </span><span class="n">response</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">await</span><span class="w"> </span><span class="n">client</span><span class="p">.</span><span class="n">GetAsync</span><span class="p">(</span>
-<span class="w">        </span><span class="s">$&quot;{baseUrl}/api/ui/router/v1?urlType=external&quot;</span><span class="p">);</span>
+<span class="w">        </span><span class="s">$&quot;{baseUrl}/api/ui/router/v1/?urlType=external&quot;</span><span class="p">);</span>
 <span class="w">    </span><span class="n">response</span><span class="p">.</span><span class="n">EnsureSuccessStatusCode</span><span class="p">();</span>
 
 <span class="w">    </span><span class="c1">// Some middleware returns XML here even when asked for JSON, so try JSON</span>

--- a/docs/html/03-Transaction-API.html
+++ b/docs/html/03-Transaction-API.html
@@ -802,7 +802,7 @@
 <hr />
 <h2 id="endpoints">Endpoints</h2>
 <p>All Transaction API endpoints use the UI Server URL. First, obtain the UI Server URL:</p>
-<div class="highlight"><pre><span></span><code><span class="err">GET https://{hostname}/api/ui/router/v1?urlType=external</span>
+<div class="highlight"><pre><span></span><code><span class="err">GET https://{hostname}/api/ui/router/v1/?urlType=external</span>
 </code></pre></div>
 
 <p>Note that the no-trailing-slash form can return a 307 redirect and the response may be XML on some middleware — use the trailing-slash form (<code>/api/ui/router/v1/</code>) and follow redirects; see <a href="00-Authentication.html#ui-server-url">00-Authentication § UI Server URL</a>.</p>

--- a/docs/html/04-Interactive-API.html
+++ b/docs/html/04-Interactive-API.html
@@ -787,7 +787,7 @@
 <hr />
 <h2 id="endpoints">Endpoints</h2>
 <p>All Interactive API endpoints use the UI Server URL. First, obtain it:</p>
-<div class="highlight"><pre><span></span><code><span class="err">GET https://{hostname}/api/ui/router/v1?urlType=external</span>
+<div class="highlight"><pre><span></span><code><span class="err">GET https://{hostname}/api/ui/router/v1/?urlType=external</span>
 </code></pre></div>
 
 <p>Then use the returned URL as base:</p>
@@ -4367,7 +4367,7 @@ GET /odataservice/odata/table/oe_line_notepad?$filter=order_no eq '1519092'</cod
 </tbody>
 </table></div>
 <blockquote>
-<p><strong>Note:</strong> The <code>uiserver0</code> prefix is the UI server instance name assigned during routing. Your environment may use a different instance name — check <code>GET /api/ui/router/v1?urlType=external</code> to obtain the correct base URL.</p>
+<p><strong>Note:</strong> The <code>uiserver0</code> prefix is the UI server instance name assigned during routing. Your environment may use a different instance name — check <code>GET /api/ui/router/v1/?urlType=external</code> to obtain the correct base URL.</p>
 </blockquote>
 <hr />
 <h2 id="verifying-writes-dont-trust-save-status-alone">Verifying Writes (Don't Trust Save Status Alone)</h2>

--- a/docs/html/10-Changelog.html
+++ b/docs/html/10-Changelog.html
@@ -641,6 +641,7 @@
         <div class="toc">
 <ul>
 <li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-08-25-v1810">2026-08-25 — v1.8.10</a></li>
 <li><a href="#2026-08-25-v189">2026-08-25 — v1.8.9</a></li>
 <li><a href="#2026-08-20-v188">2026-08-20 — v1.8.8</a></li>
 <li><a href="#2026-08-20-v187">2026-08-20 — v1.8.7</a></li>
@@ -712,6 +713,24 @@
 <li><strong>25.2</strong> — <code>DatawindowName</code> <strong>required</strong> in Interactive change requests (3-param form stops working). → <a href="14-Breaking-Changes.html#p21-252">details</a></li>
 </ul>
 </blockquote>
+<hr />
+<h2 id="2026-08-25-v1810">2026-08-25 — v1.8.10</h2>
+<p>Every C# example in the repo failed to authenticate, and the doc note that would have explained it said the opposite.</p>
+<ul>
+<li>
+<p><strong>fix:</strong> <strong>The C# examples could not authenticate — 401 on every program.</strong> <code>P21Auth.GetUiServerUrlAsync</code> requested the router as <code>/api/ui/router/v1?urlType=external</code>, <strong>without the trailing slash</strong>. The server answers that with a <strong>307</strong> to the trailing-slash form, and .NET's <code>HttpClient</code> <strong>strips the <code>Authorization</code> header when it follows a redirect</strong> — so the second request arrived unauthenticated and came back <code>401 {"Description":"Authorization header was not present or 'Bearer' was missing."}</code>. The token was never the problem; it was obtained successfully one call earlier. Fixed by requesting the trailing-slash URL, which avoids the redirect outright — <em>@mrwuss</em></p>
+</li>
+<li>
+<p><strong>fix:</strong> <strong><code>P21Config.LoadDotEnv()</code> never found the repo <code>.env</code>.</strong> It walked up from <code>AppContext.BaseDirectory</code> for a fixed <strong>6</strong> iterations, but an example runs from <code>&lt;project&gt;/bin/&lt;config&gt;/&lt;tfm&gt;/</code> — already three levels below its own project folder — putting the repository root <strong>7</strong> levels up. Every C# example therefore died with <em>"P21_BASE_URL environment variable is required"</em> unless you exported the variables by hand. It now walks to the filesystem root — <em>@mrwuss</em></p>
+</li>
+<li>
+<p><strong>fix:</strong> <strong><a href="00-Authentication.html#ui-server-url">00 § UI Server URL</a> said C# was unaffected by this.</strong> The old note read <em>"C# <code>HttpClient</code> follows GET redirects by default and is unaffected"</em> — half right and wholly misleading: it follows the redirect, and that is exactly when it drops the header. Replaced with a per-client table of what actually happens on the slashless URL, the 401 body it produces, and why <em>following the redirect</em> is not an equivalent fix to <em>not causing one</em>. .NET drops <code>Authorization</code> on <strong>any</strong> auto-redirect — same-origin included, and whether the header sits on <code>DefaultRequestHeaders</code> or on the individual request — <em>@mrwuss</em></p>
+</li>
+<li>
+<p><strong>chore:</strong> <strong>Trailing slash everywhere, so nothing re-learns this.</strong> The five Python call sites, the remaining <code>docs/00</code>/<code>03</code>/<code>04</code> snippets, and the Postman collection's <em>Get UI Server URL</em> request now all send <code>/api/ui/router/v1/?urlType=external</code>. The Python paths worked before — httpx keeps the header on a same-origin redirect — but they were paying for a pointless round trip and modelling the form that breaks in another language — <em>@mrwuss</em></p>
+</li>
+</ul>
+<p><em>Verified on 26.1: token → router → OData → Transaction all green through <code>P21Client.CreateAsync()</code>, and <code>dotnet run --project Recipes</code> now reaches a recipe's payload with no environment variables exported.</em></p>
 <hr />
 <h2 id="2026-08-25-v189">2026-08-25 — v1.8.9</h2>
 <p>A grid everyone had written off as undeletable, and the field that deletes it.</p>
@@ -1275,6 +1294,7 @@
             <div class="toc">
 <ul>
 <li><a href="#p21-breaking-change-alerts">⚠ P21 Breaking-Change Alerts</a></li>
+<li><a href="#2026-08-25-v1810">2026-08-25 — v1.8.10</a></li>
 <li><a href="#2026-08-25-v189">2026-08-25 — v1.8.9</a></li>
 <li><a href="#2026-08-20-v188">2026-08-20 — v1.8.8</a></li>
 <li><a href="#2026-08-20-v187">2026-08-20 — v1.8.7</a></li>

--- a/examples/csharp/Common/P21Auth.cs
+++ b/examples/csharp/Common/P21Auth.cs
@@ -109,12 +109,18 @@ namespace P21Examples.Common
 
         /// <summary>
         /// Get the UI Server URL for Interactive/Transaction API calls.
+        ///
+        /// The trailing slash after v1 is required, not cosmetic. Without it
+        /// the server answers 307 to the trailing-slash form, and HttpClient
+        /// strips the Authorization header when it follows a redirect — so the
+        /// second request arrives unauthenticated and the call fails with 401
+        /// "Authorization header was not present or 'Bearer' was missing."
         /// </summary>
         public static async Task<string> GetUiServerUrlAsync(
             HttpClient client, string baseUrl)
         {
             var response = await client.GetAsync(
-                $"{baseUrl}/api/ui/router/v1?urlType=external");
+                $"{baseUrl}/api/ui/router/v1/?urlType=external");
             response.EnsureSuccessStatusCode();
             var body = await response.Content.ReadAsStringAsync();
 

--- a/examples/csharp/Common/P21Config.cs
+++ b/examples/csharp/Common/P21Config.cs
@@ -67,9 +67,13 @@ namespace P21Examples.Common
 
         private static void LoadDotEnv()
         {
-            // Walk up from current directory to find .env
+            // Walk up from the build output directory to find .env. Keep going
+            // until the filesystem root: an example runs from
+            // <project>/bin/<config>/<tfm>/, which is already three levels below
+            // its own project folder, so a fixed small depth misses a .env at
+            // the repository root.
             var dir = AppContext.BaseDirectory;
-            for (var i = 0; i < 6; i++)
+            while (true)
             {
                 var envFile = System.IO.Path.Combine(dir, ".env");
                 if (System.IO.File.Exists(envFile))

--- a/examples/python/common/auth.py
+++ b/examples/python/common/auth.py
@@ -208,7 +208,7 @@ def get_ui_server_url(base_url: str, token: str, verify_ssl: bool = False) -> st
     """
     with httpx.Client(verify=verify_ssl, follow_redirects=True) as client:
         response = client.get(
-            f"{base_url}/api/ui/router/v1?urlType=external",
+            f"{base_url}/api/ui/router/v1/?urlType=external",  # trailing slash avoids a 307
             headers=get_auth_headers(token)
         )
         response.raise_for_status()

--- a/examples/python/common/client.py
+++ b/examples/python/common/client.py
@@ -995,7 +995,7 @@ class P21Client:
             return self._ui_server
         self._ensure_token()
         client = self._get_client()
-        resp = client.get(f"{self.config.base_url}/api/ui/router/v1?urlType=external")
+        resp = client.get(f"{self.config.base_url}/api/ui/router/v1/?urlType=external")  # trailing slash avoids a 307
         resp.raise_for_status()
         # Router may respond with JSON or XML — handle both
         self._ui_server = _parse_router_response(resp).rstrip("/")
@@ -1115,7 +1115,7 @@ class AsyncP21Client:
             return self._ui_server
         await self._ensure_token()
         client = self._get_client()
-        resp = await client.get(f"{self.config.base_url}/api/ui/router/v1?urlType=external")
+        resp = await client.get(f"{self.config.base_url}/api/ui/router/v1/?urlType=external")  # trailing slash avoids a 307
         resp.raise_for_status()
         # Router may respond with JSON or XML — handle both
         self._ui_server = _parse_router_response(resp).rstrip("/")

--- a/examples/python/interactive/06_complex_workflow.py
+++ b/examples/python/interactive/06_complex_workflow.py
@@ -106,7 +106,7 @@ class InteractiveClient:
 
     def _get_ui_server(self):
         response = self.client.get(
-            f"{self.base_url}/api/ui/router/v1?urlType=external",
+            f"{self.base_url}/api/ui/router/v1/?urlType=external",  # trailing slash avoids a 307
             headers={"Authorization": f"Bearer {self.token}", "Accept": "application/json"}
         )
         response.raise_for_status()

--- a/examples/python/transaction/test_session_pool.py
+++ b/examples/python/transaction/test_session_pool.py
@@ -71,7 +71,7 @@ class SessionPoolTester:
 
         # Get UI server URL
         resp = await client.get(
-            f"{self.base_url}/api/ui/router/v1?urlType=external",
+            f"{self.base_url}/api/ui/router/v1/?urlType=external",  # trailing slash avoids a 307
             headers={"Authorization": f"Bearer {self.token}", "Accept": "application/json"},
             follow_redirects=True
         )

--- a/postman/p21-api-documentation.postman_collection.json
+++ b/postman/p21-api-documentation.postman_collection.json
@@ -85,7 +85,7 @@
       "method": "GET",
       "header": [],
       "url": {
-       "raw": "{{P21_BASE_URL}}/api/ui/router/v1?urlType=external",
+       "raw": "{{P21_BASE_URL}}/api/ui/router/v1/?urlType=external",
        "host": [
         "{{P21_BASE_URL}}"
        ],
@@ -93,7 +93,8 @@
         "api",
         "ui",
         "router",
-        "v1"
+        "v1",
+        ""
        ],
        "query": [
         {


### PR DESCRIPTION
Fixes #142. Every C# example in the repo failed to authenticate; the note in the docs that would have explained it asserted the opposite.

## Root cause

Not the credentials, and not the token call — that one succeeds. `P21Auth.GetUiServerUrlAsync` requested the router **without the trailing slash**, and .NET's `HttpClient` **strips the `Authorization` header when it follows a redirect**, so the redirected request arrived unauthenticated.

Isolated on a 26.1 tenant:

| Request | Result |
|---|---|
| no slash, `AllowAutoRedirect = false` | `307` → `Location: .../api/ui/router/v1/?urlType=external` |
| no slash, `AllowAutoRedirect = true` | **401** — header dropped following the redirect |
| no slash, auth header per-request instead of on `DefaultRequestHeaders` | **401** — same |
| **with trailing slash** | **200** `{"Url":"https://.../uiserver0/"}` |

```text
401 {"Description":"Authorization header was not present or 'Bearer' was missing.",
     "Error":"invalid_request","Uri":""}
```

.NET drops `Authorization` on **any** auto-redirect, same-origin included. `AllowAutoRedirect` only decides whether you see the 307 or the 401.

## Second defect, hit first

`P21Config.LoadDotEnv()` walked up from `AppContext.BaseDirectory` a fixed **6** iterations. An example runs from `<project>/bin/<config>/<tfm>/` — three levels below its own project folder — so the repository root is **7** up and `.env` was never found. Every example died with *"P21_BASE_URL environment variable is required"* unless you exported the variables by hand. Now walks to the filesystem root.

## The doc note said C# was fine

[00 § UI Server URL](docs/00-Authentication.md#ui-server-url) read: *"C# `HttpClient` follows GET redirects by default and is unaffected."* Half right and wholly misleading — it follows the redirect, and that is exactly when it drops the header, making C# the only one of the three documented clients that fails on the slashless URL. Replaced with a per-client table, the 401 body it produces, and why *following the redirect* is not an equivalent fix to *not causing one*.

## Changes

- `examples/csharp/Common/P21Auth.cs` — trailing-slash router URL, with the reason in the doc comment.
- `examples/csharp/Common/P21Config.cs` — `LoadDotEnv()` walks to the filesystem root.
- `docs/00-Authentication.md` — corrected note, corrected `http` and C# snippets.
- Trailing slash aligned everywhere else so nothing re-learns this: five Python call sites, the `docs/03` and `docs/04` snippets, and the Postman collection's *Get UI Server URL* request. The Python paths already worked — httpx keeps the header on a same-origin redirect — but they were paying for a pointless round trip and modelling the form that breaks in another language.
- Changelog v1.8.10.

## Verification

- `P21Client.CreateAsync()` → token, router, OData (`customer_salesrep`), and Transaction (`ListServicesAsync`, 300 services) all green on 26.1.
- `dotnet run --project Recipes` with **no** environment variables exported now reaches a recipe's payload and honors the dry-run gate. `CreateCustomer` — which failed identically before — passes too, confirming the fix is in the shared path rather than one recipe.
- `dotnet build` clean, 0 warnings. `check_anchors.py` clean, 1070 ids across 33 pages. `ruff` shows no new findings (the 6 pre-existing `E402`s from the `sys.path` idiom are unchanged). HTML regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
