### PR TITLE
docs: batch pricing, enterprise search views, serverinfo version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ reference/
 
 # Misc local files (repo root only)
 /*.png
+
+# Local Prettier config (kept out of the repo so it can't silently reformat
+# docs/*.md on someone's format-on-save -- Prettier can't match this repo's
+# markdown table/emphasis style, see .prettierignore)
+.prettierrc.json
+.prettierignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,4 +168,4 @@ All documentation is derived from:
 
 ---
 
-*Last updated: 2026-08-26*
+*Last updated: 2026-08-27*

--- a/docs/00-Authentication.md
+++ b/docs/00-Authentication.md
@@ -538,8 +538,6 @@ If per-operator attribution matters to your integration, this is the setting to 
 
 > **`Accept: application/json` is not optional on 2026.1.** Every example in this documentation sends it; on P21 **2026.1** the Interactive API returns an **empty HTTP 500** for any request whose `Accept` header doesn't include `application/json` — including the `Accept: */*` default of httpx and .NET HttpClient — and the failed session create leaves a ghost session behind. Set it in one shared header builder rather than per call site. See [Breaking Changes § 2026.1](14-Breaking-Changes.md#p21-20261).
 
-
-
 Include the token in the `Authorization` header for all API requests:
 
 ```http
@@ -1094,6 +1092,176 @@ static async Task<JsonElement> GetTokenV2Async(
 ```
 
 <!-- /tabs -->
+
+---
+
+## Server Info Endpoint (Version & Environment Detection)
+
+`/uiserver0/ui/common/v1/serverinfo` is an **undocumented** UI-server endpoint — not part of the published OData/REST/SDK surface — that reports the P21 server's version and whether it considers itself a production instance. Reverse-engineered from the P21 web client's own network traffic; same bearer-token auth as every other `uiserver0/*` call, so it needs the [UI server URL](#ui-server-url) resolved first.
+
+```http
+GET /uiserver0/ui/common/v1/serverinfo HTTP/1.1
+Host: play.p21server.com
+Authorization: Bearer {token}
+Accept: application/json
+```
+
+Like the token and router endpoints, it serves **DataContract XML by default** but honors `Accept: application/json` — unlike those two, the JSON body is a flat `{"Result": {"Section/Key": value, ...}}` map (about a dozen keys; `Session/State`, `Monitoring/*`, `Version/*`) rather than a typed object:
+
+**Response** (trimmed to the keys that matter):
+
+```json
+{
+  "Result": {
+    "Monitoring/fullversion": "0.0.0.0",
+    "Monitoring/shortversion": "0.0",
+    "Monitoring/isproduction": null,
+    "Version/Application Version": "26.1.5930.1",
+    "Version/Build Framework": ".NET Core"
+  }
+}
+```
+
+> **Gotcha — `Monitoring/shortversion`/`fullversion` are not always populated:** these are the keys their own names suggest for version detection, and real values (e.g. `"26.1"`) have been observed there when captured from the P21 web app's own session traffic. But a direct API call authenticated the same way as every other example on this page — fresh token, no browser session — got back `"0.0"` / `"0.0.0.0"` on a live 26.1.5930.1 tenant instead. Whatever the difference in call context, don't rely on these two fields alone. `Version/Application Version` returned the real build number (`"26.1.5930.1"`) in the same call and is the safer field to read — note the literal space in the key, and that it's the **full** build number, not a bare major.minor, so parse the first two dot-segments if you only need `"26.1"`-style gating.
+
+Two keys are useful in practice:
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `Version/Application Version` | string | e.g. `"26.1.5930.1"` — full build number; take the first two segments for major.minor gating (e.g. ES views require 26.1+, see [Breaking Changes](14-Breaking-Changes.md)). Prefer this over `Monitoring/shortversion`/`fullversion`, which were `"0.0"`/`"0.0.0.0"` on a direct API call even though the same fields carry real values in the web app's own traffic |
+| `Monitoring/isproduction` | boolean, null, or absent | observed `null` (not `false`) on a non-production tenant — treat anything other than literal `true` as "not confirmed production," never assume `false` |
+
+> **Use case:** call this once at login, alongside resolving the UI server URL, and cache the result for the session. It's cheaper than probing a version-gated view and catching the 404, and it lets the UI cross-check a play/live banner against what the server itself reports instead of trusting only a build-time config value.
+
+<!-- tabs -->
+
+**Python:**
+
+```python
+"""Detect P21 server version/environment via the undocumented serverinfo endpoint."""
+import httpx
+
+# ---- EDIT THESE -----------------------------------------------------------
+BASE_URL = "https://play.p21server.com"   # your P21 server
+USERNAME = "apiuser"
+PASSWORD = "your-password"
+VERIFY_SSL = False                        # True once you trust the cert chain
+# ---------------------------------------------------------------------------
+
+
+def get_token_v2(base_url: str, username: str, password: str) -> dict:
+    """Get token using V2 endpoint (recommended)."""
+    response = httpx.post(
+        f"{base_url}/api/security/token/v2",
+        json={"username": username, "password": password},
+        headers={"Accept": "application/json"},
+        verify=VERIFY_SSL,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_server_info(base_url: str, token: str) -> dict:
+    """GET /uiserver0/ui/common/v1/serverinfo - version + production flag.
+
+    Monitoring/shortversion and Monitoring/fullversion are not always
+    populated -- came back "0.0" / "0.0.0.0" on a direct API call even
+    though the same fields carry real values in the P21 web app's own
+    session traffic. Version/Application Version is the safer field to
+    read.
+    """
+    response = httpx.get(
+        f"{base_url}/uiserver0/ui/common/v1/serverinfo",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        verify=VERIFY_SSL,
+    )
+    response.raise_for_status()
+    result = response.json().get("Result", {})
+    full_version = result.get("Version/Application Version")  # e.g. "26.1.5930.1"
+    return {
+        "version": full_version,
+        "short_version": ".".join(full_version.split(".")[:2]) if full_version else None,
+        "is_production": result.get("Monitoring/isproduction"),  # None/null if not confirmed
+    }
+
+
+if __name__ == "__main__":
+    token_data = get_token_v2(BASE_URL, USERNAME, PASSWORD)
+    info = get_server_info(BASE_URL, token_data["AccessToken"])
+    print("Server info:", info)
+```
+
+**C#:**
+
+```csharp
+using System.Text;
+using System.Text.Json;
+
+// ---- EDIT THESE -----------------------------------------------------------
+const string BaseUrl = "https://play.p21server.com";   // your P21 server
+const string Username = "apiuser";
+const string Password = "your-password";
+// ---------------------------------------------------------------------------
+
+using var authClient = new HttpClient();
+var tokenData = await GetTokenV2Async(authClient, BaseUrl, Username, Password);
+var token = tokenData.GetProperty("AccessToken").GetString() ?? "";
+
+var info = await GetServerInfoAsync(BaseUrl, token);
+Console.WriteLine($"Version: {info.Version}, IsProduction: {info.IsProduction?.ToString() ?? "unknown"}");
+
+// --- helpers ---------------------------------------------------------------
+
+// Monitoring/shortversion and Monitoring/fullversion are not always
+// populated -- came back "0.0" / "0.0.0.0" on a direct API call even
+// though the same fields carry real values in the P21 web app's own
+// session traffic. Version/Application Version is the safer field to read.
+static async Task<ServerInfo> GetServerInfoAsync(string baseUrl, string token)
+{
+    using var client = new HttpClient();
+    client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+
+    var response = await client.GetAsync($"{baseUrl}/uiserver0/ui/common/v1/serverinfo");
+    response.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    var result = doc.RootElement.GetProperty("Result");
+
+    string? version = result.TryGetProperty("Version/Application Version", out var v)
+        ? v.GetString() : null;
+    bool? isProduction = result.TryGetProperty("Monitoring/isproduction", out var p)
+        && p.ValueKind is JsonValueKind.True or JsonValueKind.False
+        ? p.GetBoolean() : null;
+
+    return new ServerInfo(version, isProduction);
+}
+
+/// <summary>Get token using V2 endpoint (recommended).</summary>
+static async Task<JsonElement> GetTokenV2Async(
+    HttpClient client, string baseUrl, string username, string password)
+{
+    var body = new { username, password };
+    var content = new StringContent(
+        JsonSerializer.Serialize(body),
+        Encoding.UTF8, "application/json");
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+
+    var response = await client.PostAsync(
+        $"{baseUrl}/api/security/token/v2", content);
+    response.EnsureSuccessStatusCode();
+
+    var json = await response.Content.ReadAsStringAsync();
+    using var doc = JsonDocument.Parse(json);
+    return doc.RootElement.Clone();
+}
+
+record ServerInfo(string? Version, bool? IsProduction);
+```
+
+<!-- /tabs -->
+
+Verified live on 26.1.5930.1 (August 2026); the `Result` flattening and JSON content-negotiation behavior matches the token and router endpoints on the same host. The `Monitoring/shortversion` gotcha above was caught by that same live run — the endpoint's shape matched expectations, but the field originally documented for version detection came back `"0.0"` on this direct API call despite being populated in the source web-app traffic the endpoint was reverse-engineered from.
 
 ---
 

--- a/docs/02-OData-API.md
+++ b/docs/02-OData-API.md
@@ -639,6 +639,158 @@ static string ReadField(string payload, string field)
 
 ---
 
+## Enterprise/Global Search Views (`p21_view_es_*`)
+
+> **Added August 2026** — discovered and verified live against a 26.1.5930.1 tenant.
+
+25 views share a `p21_view_es_*` prefix and back P21's in-app global search feature (the `es` reads as "enterprise search"; not an officially documented expansion, inferred from the schema below). They are **not** part of the curated 118-view [`/data/erp/views/v1`](#the-other-odata-surface-dataerpviewsv1) surface — query them the normal way, at `/odataservice/odata/view/{viewname}`, and the same [`$top` is mandatory](#skip-pagination) guidance applies.
+
+They split cleanly into two groups by what their columns look like.
+
+### Search-source views (18)
+
+Denormalized, heavily-joined views of a single business entity — one row per record, with lookups (class codes, descriptions, salesrep names, etc.) already resolved. All 18 share two trailing fields useful for incremental sync: `unique_id` (a per-view natural key, often composite — e.g. `p21_view_es_item`'s is `{item_id}--{supplier_id}`, since the view fans an item out to one row per supplier) and `max_date_last_modified` (the latest modification timestamp across every joined table, so `$filter=max_date_last_modified gt {timestamp}` catches changes anywhere in the join, not just on the primary table).
+
+| View | Source entity | Fields |
+|---|---|---|
+| `p21_view_es_customer` | Customer | 58 |
+| `p21_view_es_contacts` | Contact | 87 |
+| `p21_view_es_vendor` | Vendor | 75 |
+| `p21_view_es_item` | Item | 15 |
+| `p21_view_es_item_supplier` | Item × Supplier | 57 |
+| `p21_view_es_sales_order` | Sales order header | 115 |
+| `p21_view_es_sales_order_line` | Sales order line | 157 |
+| `p21_view_es_quote` | Quote | 89 |
+| `p21_view_es_invoice_hdr` | Invoice header | 137 |
+| `p21_view_es_invoice_line` | Invoice line | 139 |
+| `p21_view_es_vendor_invoice` | Vendor invoice | 49 |
+| `p21_view_es_ship_to` | Ship-to | 63 |
+| `p21_view_es_pick_ticket_hdr` | Pick ticket header | 21 |
+| `p21_view_es_pick_ticket_line` | Pick ticket line | 16 |
+| `p21_view_es_production_order` | Production order | 85 |
+| `p21_view_es_production_order_component` | Production order component | 61 |
+| `p21_view_es_service_order` | Service order | 93 |
+| `p21_view_es_work_in_process` | WIP stage | 45 |
+
+### Index configuration views (7)
+
+These carry no business data — they configure the search feature itself. Every one of them returned `"value": []` on the tenant this was verified against (no custom indexes had been configured), but the schema is always present and the relationships below are legible from the foreign-key-shaped column names:
+
+| View | Purpose |
+|---|---|
+| `p21_view_es_index_hdr` | One row per named search index — `index_name` plus the source view it indexes (`view_name`), display panel layout (`line1_panel`…`line3_extended`), and refresh schedule (`refresh_rate_seconds`, `last_sync_date`) |
+| `p21_view_es_index_field` | One row per indexed column (FK `es_index_hdr_uid`) — `searchable_flag` / `display_in_search_flag` / `filter_in_search_flag` per field, plus `data_type` |
+| `p21_view_es_index_priority_hdr` | A named priority/ranking profile |
+| `p21_view_es_index_priority_field` | Per-profile override of an index field's searchable/display/filter flags (FKs to both the profile and the field) |
+| `p21_view_es_index_priority_ranking` | Result ordering — assigns a `rank` to an (profile, index) pair |
+| `p21_view_es_index_priority_role` | Links a priority profile to a role (`role_uid`) |
+| `p21_view_es_index_priority_user` | Links a priority profile to a user (`users_uid`) |
+
+> **Inferred, not confirmed:** the hdr→field and priority-hdr→field/ranking/role/user relationships above are read off the column names and `$metadata` types (`Edm.Int32` FK-shaped columns), not off live data — every `*_priority_*` view was empty on the verification tenant, so the actual row shape and what "priority" changes about search ranking were not directly observed.
+
+### Example: querying `p21_view_es_item`
+
+Verified live, 26.1.5930.1:
+
+```http
+GET /odataservice/odata/view/p21_view_es_item?$top=1
+Authorization: Bearer {token}
+Accept: application/json
+```
+
+```json
+{
+  "@odata.context": "{base}/odataservice/odata/view/$metadata#p21_view_es_item",
+  "value": [
+    {
+      "item_id": "WIDGET-001",
+      "item_desc": "Standard Widget Assembly",
+      "extended_desc": "Standard Widget Assembly - full description text",
+      "supplier_part_no": "",
+      "upc_code": null,
+      "catalog_name": null,
+      "contract_number": null,
+      "ean_code": null,
+      "purchase_discount_group": "Default",
+      "discount_group_description": "Default",
+      "alternate_code": null,
+      "alternate_code_desc": null,
+      "supplier_id": 10143,
+      "unique_id": "WIDGET-001--10143",
+      "max_date_last_modified": "2026-07-24T11:22:14.747-04:00"
+    }
+  ]
+}
+```
+
+> Some rows on the verification tenant had a stray leading space on `item_id` (e.g. `" EX21-NI"`). It isn't consistent padding — row lengths on the same column varied freely (7 to 19 characters) with no fixed width, so this reads as pre-existing data-entry noise in that specific database rather than a behavior of the view or column type. Not included as a documented gotcha; if you see it on your tenant, treat it as a data-quality issue, not an API contract.
+
+### Example: querying `p21_view_es_ship_to` — the case for these views
+
+`p21_view_es_item` above is deliberately the simplest of the 18 (15 fields). `p21_view_es_ship_to` (63 fields) is a better demonstration of what these views are *for*: one row already joins ship-to, customer, tax group, freight/carrier, payment terms, branch, salesrep, and both customer- and ship-to-level class codes — a query that would otherwise mean separately reading `ship_to`, `customer`, `tax_group`, `freight_code`, `terms`, `company`, and the class-code tables and joining them client-side (OData has [no server-side joins](#no-joins-chain-queries-by-uid)).
+
+Verified live, 26.1.5930.1:
+
+```http
+GET /odataservice/odata/view/p21_view_es_ship_to?$top=1
+Authorization: Bearer {token}
+Accept: application/json
+```
+
+```json
+{
+  "@odata.context": "{base}/odataservice/odata/view/$metadata#p21_view_es_ship_to",
+  "value": [
+    {
+      "ship_to_id": 1,
+      "ship_to_name": "Address 1",
+      "customer_id": 10397,
+      "customer_name": "ACME Plumbing Supply",
+      "phys_address1": null,
+      "phys_address2": null,
+      "phys_city": null,
+      "phys_state": null,
+      "phys_postal_code": "08701",
+      "company_id": "ACME",
+      "company_name": "ACME Distribution Inc.",
+      "default_branch": "01",
+      "tax_group_id": "NJ UEZ TAX",
+      "terms_id": "10",
+      "default_carrier_id": null,
+      "delivery_instructions": null,
+      "freight_code_uid": 2,
+      "tax_group_description": "NJ UEZ Sales Tax",
+      "freight_cd": "IN/OUT",
+      "freight_desc": "Customer Pays Incoming and Outgoing Freight",
+      "branch_description": "Main Branch",
+      "carrier_name": null,
+      "terms_desc": "COD",
+      "cust_class_1id": null,
+      "cust_class_1desc": null,
+      "cust_class_2id": "NOT INSU",
+      "cust_class_2desc": "Not Insured",
+      "ship_to_class1_id": null,
+      "ship_to_class1_desc": null,
+      "date_created": "2019-03-27T15:12:13.623-04:00",
+      "date_last_modified": "2021-04-26T13:09:15.507-04:00",
+      "created_by": "apiuser",
+      "last_maintained_by": "apiuser",
+      "corp_address_id": 10397,
+      "corp_address_name": "ACME Plumbing Supply",
+      "salesrep_id": "1002",
+      "salesrep_name": "Jane Smith",
+      "freight_charge_id": null,
+      "unique_id": "ACME-1-1002",
+      "max_date_last_modified": "2026-08-19T15:00:00-04:00"
+    }
+  ]
+}
+```
+
+> Trimmed to the fields that make the point; the live response carries all 63 (mailing address, all five customer- and ship-to-level class code pairs, `route_description`, `shipping_route_uid`, etc.). Note `unique_id`'s shape here is `{company_id}-{ship_to_id}-{salesrep_id}` — a different composite pattern than `p21_view_es_item`'s `{item_id}--{supplier_id}` (double dash). **`unique_id` composition is per-view; don't assume one view's key shape for another.**
+
+---
+
 ## Undeployed / Unlicensed Windows: Readable Tables, No API Surface
 
 OData exposes the **schema**, not the deployment state. A table can be fully readable over OData while the feature that populates it is **undeployed or unlicensed** — its maintenance window is classic-desktop-only and it has no Transaction/Interactive API surface. The rows you read are then **dead storage**: nothing writes them and no business logic consults them.

--- a/docs/10-Changelog.md
+++ b/docs/10-Changelog.md
@@ -18,6 +18,18 @@ All notable changes to this documentation project are listed below, grouped by d
 
 ---
 
+## 2026-08-27 — v1.10.0
+
+Two new endpoint families documented against a live 26.1.5930.1 tenant, plus a correction to the Server Info Endpoint added last version.
+
+- **feat:** **[Batch Pricing](11-Inventory-REST-API.md#batch-pricing)** — `POST /api/inventory/parts/prices` (and the identical `/api/inventory/v2/parts/prices`) is commonly mistaken for XML-only. It isn't: both JSON and XML bodies work, verified live. The actual cause of the "XML only" impression is a WCF quirk — the service picks its (de)serializer from `Content-Type`, not by inspecting the body, so a JSON body sent with `Content-Type: application/xml` fails with a generic, unhelpful WCF "Request Error" page that gives no hint the fix is a header. Also documented: three query parameters (`companyId`, `customerId`, `salesLocId`) are required and validated one at a time, so an incomplete request appears to fail progressively as each gets added.
+
+- **feat:** **[Enterprise/Global Search Views](02-OData-API.md#enterpriseglobal-search-views-p21_view_es_)** — 25 views under a `p21_view_es_*` prefix, discovered via the tenant's full OData `$metadata` and not listed anywhere else in this documentation. 18 are denormalized search-source views (`es_customer`, `es_item`, `es_sales_order`, etc.) ending in a consistent `unique_id`/`max_date_last_modified` pair useful for incremental sync; 7 are index-configuration views (`es_index_hdr`, `es_index_field`, `es_index_priority_*`) describing the search feature itself rather than carrying business data. Confirmed not part of the curated 118-view `/data/erp/views/v1` surface. Includes a live `p21_view_es_ship_to` example demonstrating the case for these views — one row already joins customer, tax group, freight/carrier, terms, branch, salesrep, and class codes that would otherwise take 6+ separate reads and client-side joins.
+
+- **fix:** **[Server Info Endpoint — `Monitoring/shortversion` is not the field to read](00-Authentication.md#server-info-endpoint-version-environment-detection).** Added last version as the recommended way to detect P21's version, it turned out to return `"0.0"` on a direct API call on a live 26.1.5930.1 tenant, despite carrying a real value when captured from the P21 web app's own session traffic — not consistently populated, and not safe to rely on alone. `Version/Application Version` returned the real build number (`"26.1.5930.1"`) in the same call and is now the documented field; both the Python and C# examples updated to read it, and a C# compile error in the original example (a `record` declared before a local function, invalid in a top-level-statements file) fixed along the way.
+
+---
+
 ## 2026-08-26 — v1.9.0
 
 The 2026.1 registry re-run end to end against a newer middleware build. Two entries retire, one gets a sharper mechanism, one is new — and the empty 500 everyone learned to recognize now means something else.

--- a/docs/11-Inventory-REST-API.md
+++ b/docs/11-Inventory-REST-API.md
@@ -54,7 +54,8 @@ Example: `https://play.p21server.com/api/inventory/parts`
 | `GET` | `/api/inventory/parts/{ItemId}/v2/price` | Single item pricing (V2) | Yes |
 | `GET` | `/api/inventory/v2/parts/v2/price/{ItemId}` | Single item pricing (alternative path) | Yes |
 | `POST` | `/api/inventory/parts/itemsAvailability` | Batch availability | Not tested |
-| `POST` | `/api/inventory/parts/prices` | Batch pricing | Not tested |
+| `POST` | `/api/inventory/parts/prices` | Batch pricing (JSON or XML, see [Batch Pricing](#batch-pricing)) | Yes |
+| `POST` | `/api/inventory/v2/parts/prices` | Batch pricing (alternative path, identical behavior) | Yes |
 
 ---
 
@@ -1971,6 +1972,302 @@ When item IDs contain special characters, URL encoding is required:
 | `+` | `%2B` | Use standard URL encoding |
 
 > **Known Issue**: Forward slash (`/`) in item IDs cannot be URL-encoded for the pricing endpoints. The API (or IIS) interprets `%2F` as a literal path separator, returning 404. There is no known workaround for items containing `/` in their ID. (Credit: John Kennedy, confirmed by Felipe Maurer)
+
+---
+
+### Batch Pricing
+
+> **Added August 2026** — Live-verified against Prophet21Play (26.1).
+
+`POST /api/inventory/parts/prices` (and the identical `POST /api/inventory/v2/parts/prices`) price and check availability for **multiple items in one call**. Unlike single-item pricing, `ItemId` is in the request body, not the URL — so the [forward-slash URL-encoding limitation](#url-encoding-for-special-characters) above does not apply here.
+
+```http
+POST /api/inventory/parts/prices?companyId=ACME&customerId=10&salesLocId=100
+Authorization: Bearer {token}
+Content-Type: application/json
+Accept: application/json
+
+[
+    { "ItemId": "WIDGET-001", "SourceLocId": 100 },
+    { "ItemId": "WIDGET-002", "SourceLocId": 100 }
+]
+```
+
+**Required query parameters** (verified — omitting any one produces a distinct error naming exactly that parameter, checked in this order):
+
+1. `companyId`
+2. `customerId`
+3. `salesLocId`
+
+P21 validates these one at a time and fails on the first missing one, so an incomplete request appears to fail "progressively" as you add parameters — each retry reveals the next missing one rather than listing all of them up front:
+
+```json
+{"ErrorMessage": "Please provide a value for required parameter companyId.", "ErrorType": "System.ArgumentException", ...}
+```
+
+The WCF method signature (visible in the stack trace) also accepts `optionalShipToId`, `optionalOrderDate`, and `optionalJobNo` as query parameters — not verified.
+
+**Request body** — a JSON array or an XML `ArrayOfItemPriceInfo` of per-item objects. Verified minimum: `ItemId` + `SourceLocId`. Also accepted per item: `CustomerPartNo`, `UnitQuantity`, `UnitSize`, `UOM`, `PriceUom` (all optional — P21 defaults `UOM`/`PriceUom` to the item's base unit when omitted).
+
+**Response** — a JSON array or an XML `ArrayOfItemPrice`, one entry per requested item, in the same shape as [single-item pricing](#verified-pricing-response) (pricing **and** availability fields together).
+
+#### Content-Type must match the body — this is not "XML only" (verified)
+
+This endpoint is often mistaken for XML-only. **It is not** — both JSON and XML request/response bodies work. It's a WCF REST endpoint that selects its (de)serializer from the `Content-Type` header, not by inspecting the body, so sending a body that doesn't match `Content-Type` produces a confusing failure that looks like a format rejection:
+
+| `Content-Type` sent | Actual body | Result |
+|---|---|---|
+| `application/json` | JSON | **200** — works |
+| `application/xml` | XML | **200** — works |
+| *(omitted, `Accept: application/json`)* | JSON | **200** — works (defaults to JSON) |
+| `application/xml` | JSON | **400** — generic WCF "Request Error" HTML page pointing at `/help`; no P21 error, no mention of a header mismatch |
+| `application/json` | XML | **500** — at least a real P21 error: `BadRequestException: Invalid JSON or request body for parameter 'itemInfo'. Unexpected character encountered while parsing value: <...` |
+
+The `application/xml` + JSON-body case is what creates the "XML only" impression: the response gives no hint that the body was even parsed, let alone that the fix is the `Content-Type` header rather than the body format. If a batch pricing POST comes back as that generic WCF "Request Error" page, check that `Content-Type` matches what you actually sent before concluding the endpoint rejects JSON.
+
+<!-- tabs -->
+
+**Python**
+
+```python
+"""Batch price + availability lookup via the Inventory REST API (JSON body)."""
+import re
+
+import httpx
+
+# ---- EDIT THESE -----------------------------------------------------------
+BASE_URL = "https://play.p21server.com"   # your P21 server
+USERNAME = "apiuser"
+PASSWORD = "your-password"
+VERIFY_SSL = False                        # True once you trust the cert chain
+COMPANY_ID = "ACME"                       # required query param
+CUSTOMER_ID = "10"                        # required query param
+SALES_LOC_ID = "100"                      # required query param
+ITEMS = [
+    {"ItemId": "WIDGET-001", "SourceLocId": 100},
+    {"ItemId": "WIDGET-002", "SourceLocId": 100},
+]
+# ---------------------------------------------------------------------------
+
+
+def get_token(client: httpx.Client) -> str:
+    """v2 token endpoint — credentials go in the body, never in headers."""
+    r = client.post(
+        f"{BASE_URL}/api/security/token/v2",
+        json={"username": USERNAME, "password": PASSWORD},
+        headers={"Accept": "application/json"},
+    )
+    r.raise_for_status()
+    try:
+        return r.json()["AccessToken"]
+    except (ValueError, KeyError):  # some middleware answers in XML
+        match = re.search(r"<AccessToken>([^<]+)</AccessToken>", r.text)
+        if not match:
+            raise ValueError(f"No AccessToken in response: {r.text[:200]}") from None
+        return match.group(1)
+
+
+with httpx.Client(verify=VERIFY_SSL, timeout=120, follow_redirects=True) as client:
+    token = get_token(client)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        # Content-Type must match the body -- application/json here because ITEMS
+        # is sent as JSON. Sending application/xml with a JSON body 400s (see above).
+        "Content-Type": "application/json",
+    }
+
+    resp = client.post(
+        f"{BASE_URL}/api/inventory/parts/prices",
+        headers=headers,
+        params={"companyId": COMPANY_ID, "customerId": CUSTOMER_ID, "salesLocId": SALES_LOC_ID},
+        json=ITEMS,
+    )
+    resp.raise_for_status()
+    for price in resp.json():
+        print(
+            f"{price['ItemId']}: UnitPrice={price['UnitPrice']} "
+            f"QtyAvailable={price['QuantityAvailable']}"
+        )
+```
+
+**C#**
+
+```csharp
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+// ---- EDIT THESE -----------------------------------------------------------
+const string BaseUrl = "https://play.p21server.com";   // your P21 server
+const string Username = "apiuser";
+const string Password = "your-password";
+const string CompanyId = "ACME";                        // required query param
+const string CustomerId = "10";                         // required query param
+const string SalesLocId = "100";                        // required query param
+// ---------------------------------------------------------------------------
+
+var handler = new HttpClientHandler
+{
+    // Test tenants often present a self-signed cert. Delete this line in production.
+    ServerCertificateCustomValidationCallback =
+        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+};
+using var client = new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(2) };
+client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+var token = await GetTokenAsync(client);
+client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+var items = new JsonArray
+{
+    new JsonObject { ["ItemId"] = "WIDGET-001", ["SourceLocId"] = 100 },
+    new JsonObject { ["ItemId"] = "WIDGET-002", ["SourceLocId"] = 100 },
+};
+
+// Content-Type must match the body -- application/json here because items is
+// sent as JSON. Sending application/xml with a JSON body 400s (see above).
+var url = $"{BaseUrl}/api/inventory/parts/prices" +
+          $"?companyId={CompanyId}&customerId={CustomerId}&salesLocId={SalesLocId}";
+var content = new StringContent(items.ToJsonString(), Encoding.UTF8, "application/json");
+var resp = await client.PostAsync(url, content);
+resp.EnsureSuccessStatusCode();
+
+var prices = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!.AsArray();
+foreach (var price in prices)
+{
+    Console.WriteLine(
+        $"{price!["ItemId"]}: UnitPrice={price["UnitPrice"]} " +
+        $"QtyAvailable={price["QuantityAvailable"]}");
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// v2 token endpoint — credentials go in the body, never in headers.
+static async Task<string> GetTokenAsync(HttpClient client)
+{
+    var payload = JsonSerializer.Serialize(new { username = Username, password = Password });
+    var response = await client.PostAsync(
+        $"{BaseUrl}/api/security/token/v2",
+        new StringContent(payload, Encoding.UTF8, "application/json"));
+    response.EnsureSuccessStatusCode();
+    return ReadField(await response.Content.ReadAsStringAsync(), "AccessToken");
+}
+
+// Some middleware answers this endpoint in XML even when asked for JSON.
+static string ReadField(string payload, string field)
+{
+    try
+    {
+        var value = JsonDocument.Parse(payload).RootElement.GetProperty(field).GetString();
+        if (!string.IsNullOrEmpty(value)) return value;
+    }
+    catch (Exception ex) when (ex is JsonException or KeyNotFoundException) { }
+
+    var match = System.Text.RegularExpressions.Regex.Match(payload, $"<{field}>([^<]+)</{field}>");
+    if (!match.Success)
+        throw new InvalidOperationException(
+            $"No {field} in response: {payload[..Math.Min(200, payload.Length)]}");
+    return match.Groups[1].Value;
+}
+```
+
+<!-- /tabs -->
+
+**Sample response** (one entry per requested item, same fields as [single-item pricing](#verified-pricing-response)):
+
+```json
+[
+    {
+        "UnitPrice": 10.780000000,
+        "BaseUnitPrice": 10.780000000,
+        "UOM": "EA",
+        "UOMUnitSize": 1.000000000,
+        "PricePageUid": 0,
+        "PriceUOM": "EA",
+        "PriceUnitSize": 1.000000000,
+        "ExtendedPrice": 10.780000000,
+        "CalcValue": 1.000000000,
+        "UnitCommissionCost": 5.308224600,
+        "UnitOtherCost": 5.390000000,
+        "UnitSalesCost": 5.308224600,
+        "LotCosted": "N",
+        "ItemId": "WIDGET-001",
+        "CompanyId": null,
+        "LocationId": 100,
+        "QuantityAvailable": 41.000000000,
+        "QuantityOnHand": 41.000000000,
+        "QuantityAllocated": 0.000000000,
+        "QuantityNonPickable": 0.0,
+        "QuantityQuarantined": 0.0,
+        "QuantityFrozen": 0.0,
+        "LocationType": "Standard"
+    },
+    {
+        "ItemId": "WIDGET-002",
+        "PricePageUid": 813,
+        "...": "one object per requested item, same shape"
+    }
+]
+```
+
+> **Note:** As with single-item pricing, `CompanyId` in the response can be `null` even though it was required in the request.
+
+#### Equivalent XML request/response
+
+The same call, sent as XML instead — only the `Content-Type`/`Accept` headers and body format change; the query parameters and URL are identical:
+
+```http
+POST /api/inventory/parts/prices?companyId=ACME&customerId=10&salesLocId=100
+Authorization: Bearer {token}
+Content-Type: application/xml
+Accept: application/xml
+
+<ArrayOfItemPriceInfo>
+    <ItemPriceInfo>
+        <ItemId>WIDGET-001</ItemId>
+        <SourceLocId>100</SourceLocId>
+    </ItemPriceInfo>
+    <ItemPriceInfo>
+        <ItemId>WIDGET-002</ItemId>
+        <SourceLocId>100</SourceLocId>
+    </ItemPriceInfo>
+</ArrayOfItemPriceInfo>
+```
+
+```xml
+<?xml version="1.0"?>
+<ArrayOfItemPrice xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ItemPrice>
+    <ItemId>WIDGET-001</ItemId>
+    <LocationId>100</LocationId>
+    <QuantityAvailable>41.000000000</QuantityAvailable>
+    <QuantityOnHand>41.000000000</QuantityOnHand>
+    <QuantityAllocated>0.000000000</QuantityAllocated>
+    <QuantityNonPickable>0</QuantityNonPickable>
+    <QuantityQuarantined>0</QuantityQuarantined>
+    <QuantityFrozen>0</QuantityFrozen>
+    <LocationType>Standard</LocationType>
+    <UnitPrice>10.780000000</UnitPrice>
+    <BaseUnitPrice>10.780000000</BaseUnitPrice>
+    <UOM>EA</UOM>
+    <UOMUnitSize>1.000000000</UOMUnitSize>
+    <PricePageUid>0</PricePageUid>
+    <PriceUOM>EA</PriceUOM>
+    <PriceUnitSize>1.000000000</PriceUnitSize>
+    <ExtendedPrice>10.780000000</ExtendedPrice>
+    <CalcValue>1.000000000</CalcValue>
+    <UnitCommissionCost>5.308224600</UnitCommissionCost>
+    <UnitOtherCost>5.390000000</UnitOtherCost>
+    <UnitSalesCost>5.308224600</UnitSalesCost>
+    <LotCosted>N</LotCosted>
+  </ItemPrice>
+  <!-- one <ItemPrice> per requested item -->
+</ArrayOfItemPrice>
+```
+
+> Full runnable version: adapt the [Python/C# example above](#batch-pricing) — swap the JSON body/headers for the XML shown here, no other change needed.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 | Authenticate with a consumer key | [00 § Method 2: Consumer Key](00-Authentication.md#method-2-consumer-key) |
 | Get the UI server URL (Transaction/Interactive base) — 307 redirect gotcha | [00 § UI Server URL](00-Authentication.md#ui-server-url) |
 | Token TTL / reuse across APIs | [00 § Token Lifetime and Reuse](00-Authentication.md#token-lifetime-and-reuse) |
+| Detect P21 server version / production flag (undocumented endpoint) | [00 § Server Info Endpoint](00-Authentication.md#server-info-endpoint-version-environment-detection) |
 | Fix "not authorized" (P21 user permissions) | [00 § P21 Permissions](00-Authentication.md#p21-permissions-user-credential-auth) |
 | Pick which API to use for a task | [01 API Selection Guide](01-API-Selection-Guide.md) (short — read whole) |
 | A write failed — will the *other* API get through? (usually no) | [01 § Interactive Is Not an Escape Hatch](01-API-Selection-Guide.md#before-you-choose-interactive-is-not-an-escape-hatch) |
@@ -34,6 +35,7 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 | Date filters (`now()` is unsupported) | [02 § now() Not Supported](02-OData-API.md#now-function-not-supported) |
 | New table/column missing from OData | [02 § OData Schema Refresh](02-OData-API.md#odata-schema-refresh) |
 | Table reads fine but is empty/inert (undeployed feature, e.g. zip→rep) | [02 § Undeployed / Unlicensed Windows](02-OData-API.md#undeployed-unlicensed-windows-readable-tables-no-api-surface) |
+| Denormalized, search-friendly views (`p21_view_es_*`: customer, item, order, invoice, etc.) | [02 § Enterprise/Global Search Views](02-OData-API.md#enterpriseglobal-search-views-p21_view_es_) |
 
 ## Create / update records (Transaction API)
 
@@ -117,6 +119,7 @@ Every task assumes you already have a token and (for Transaction/Interactive) th
 | Inventory items: read / create / update locations | — | [11 § Reading Items](11-Inventory-REST-API.md#reading-items) · [11 § Minimum Create Payload](11-Inventory-REST-API.md#minimum-create-payload) · [11 § Updating Existing Location Fields](11-Inventory-REST-API.md#updating-existing-location-fields) |
 | Append locations **at scale** (supplier-x-loc primary, GL requireds, kit Buy, OP/OQ, retries, PrimaryBin) | — | [11 § Location-Append & Update Gotchas](11-Inventory-REST-API.md#location-append-update-gotchas-verified-at-scale) |
 | Customer-specific **price + availability** lookup | — | [11 § Pricing Endpoints](11-Inventory-REST-API.md#pricing-endpoints) |
+| **Batch** price + availability lookup (multiple items in one call, JSON *or* XML) | — | [11 § Batch Pricing](11-Inventory-REST-API.md#batch-pricing) |
 | User-defined tables (UDT) rows | — | [13 § Insert](13-UDT-Service-API.md#insert) · [13 § Update](13-UDT-Service-API.md#update) · [13 § Delete](13-UDT-Service-API.md#delete) — **update/delete need a `row_uid` column; 2026.1-created UDTs don't have one** |
 | UDT delete "succeeds" but nothing is deleted | — | [06 § `[0] rows deleted`](06-Error-Handling.md#0-rows-deleted-successfully-a-delete-that-deletes-nothing-20261) · [14 § entry 7](14-Breaking-Changes.md#7-udt-service-updatedelete-cannot-target-rows-in-a-udt-created-on-20261) |
 | Bulk-load a UDT from CSV (2026.1+) | — | [13 § Bulk Data API](13-UDT-Service-API.md#bulk-data-api-20261) — CSV upload; **headerless file silently inserts nothing** |


### PR DESCRIPTION
## Summary
- Document `POST /api/inventory/parts/prices` (Batch Pricing) — live-verified that it accepts both JSON and XML; the "XML only" impression traces to a WCF Content-Type/body mismatch producing an unhelpful generic error, not an actual JSON rejection. Also documents the three required, sequentially-validated query params.
- Document 25 `p21_view_es_*` Enterprise/Global Search views (18 search-source + 7 index-config), discovered via live `$metadata` and not previously covered anywhere in this repo.
- Fix the Server Info Endpoint section added in v1.9.0: `Monitoring/shortversion` returned `"0.0"` on a live direct API call despite carrying a real value in the P21 web app's own traffic — `Version/Application Version` is the reliable field, now reflected in both the Python and C# examples. Also fixes a C# compile error (`record` declared before a local function) and a broken anchor link in INDEX.md.
- Bumped changelog to v1.10.0.

## Test plan
- [x] All Python code examples parse (`ast.parse`)
- [x] C# examples build clean on `net8.0` in a scratch console project
- [x] Batch Pricing and Server Info Python/C# examples run successfully end-to-end against a live 26.1.5930.1 tenant
- [x] `scripts/check_anchors.py` passes (1118 ids across 33 pages, zero broken links)
- [x] `scripts/generate_html.py` output not committed (avoids unrelated markdown-library formatting diff)
